### PR TITLE
feat: implement Allow for Session permission handling

### DIFF
--- a/ail-core/src/session/state.rs
+++ b/ail-core/src/session/state.rs
@@ -11,7 +11,6 @@ pub struct Session {
     pub pipeline: Pipeline,
     pub invocation_prompt: String,
     pub turn_log: TurnLog,
-    pub tool_allowlist: Vec<String>,
     /// CLI-supplied provider/model overrides. Highest priority in the resolution chain:
     /// pipeline defaults → per-step model → cli_provider.
     pub cli_provider: ProviderConfig,
@@ -45,7 +44,6 @@ impl Session {
             pipeline,
             invocation_prompt,
             turn_log,
-            tool_allowlist: Vec::new(),
             cli_provider: ProviderConfig::default(),
         }
     }

--- a/ail/src/chat.rs
+++ b/ail/src/chat.rs
@@ -39,6 +39,11 @@ use std::sync::Arc;
 use std::time::Instant;
 use uuid::Uuid;
 
+/// Shared slot carrying `(tool_name, response_sender)` for a pending permission request.
+/// The permission responder callback parks the sender here; the stdin reader picks it up.
+type PendingPermissionSlot =
+    Arc<std::sync::Mutex<Option<(String, mpsc::SyncSender<PermissionResponse>)>>>;
+
 /// Emit a single NDJSON line to stdout (locked).
 fn emit(value: &serde_json::Value) {
     let stdout = std::io::stdout();
@@ -62,9 +67,8 @@ fn run_turn_stream(
     turn_id: &str,
     pause_requested: Arc<AtomicBool>,
     kill_requested: Arc<AtomicBool>,
-    pending_permission: Arc<
-        std::sync::Mutex<Option<mpsc::SyncSender<ail_core::runner::PermissionResponse>>>,
-    >,
+    pending_permission: PendingPermissionSlot,
+    tool_allowlist: Arc<std::sync::Mutex<HashSet<String>>>,
     hitl_rx: mpsc::Receiver<String>,
 ) -> Result<(Option<String>, f64), String> {
     let mut session = Session::new(pipeline, prompt.to_string());
@@ -85,13 +89,20 @@ fn run_turn_stream(
         .map(|s| s.id.as_str() == "invocation")
         .unwrap_or(false);
 
-    // Build per-turn permission responder.
+    // Build per-turn permission responder — checks allowlist first; otherwise blocks.
     let pending_perm = Arc::clone(&pending_permission);
+    let allowlist_responder = Arc::clone(&tool_allowlist);
     let responder: ail_core::runner::PermissionResponder =
-        Arc::new(move |_req: ail_core::runner::PermissionRequest| {
+        Arc::new(move |req: ail_core::runner::PermissionRequest| {
+            // Fast path: tool is in the session allowlist — approve silently.
+            if let Ok(guard) = allowlist_responder.lock() {
+                if guard.contains(&req.display_name) {
+                    return PermissionResponse::Allow;
+                }
+            }
             let (tx, rx) = mpsc::sync_channel(1);
             if let Ok(mut guard) = pending_perm.lock() {
-                *guard = Some(tx);
+                *guard = Some((req.display_name, tx));
             }
             rx.recv_timeout(std::time::Duration::from_secs(300))
                 .unwrap_or(PermissionResponse::Deny("timeout".to_string()))
@@ -243,9 +254,12 @@ pub fn run_chat_stream(
     // Shared control flags reused across turns.
     let pause_requested = Arc::new(AtomicBool::new(false));
     let kill_requested = Arc::new(AtomicBool::new(false));
-    let pending_permission: Arc<
-        std::sync::Mutex<Option<mpsc::SyncSender<ail_core::runner::PermissionResponse>>>,
-    > = Arc::new(std::sync::Mutex::new(None));
+
+    // In-memory allowlist for "Allow for session" — persists across turns within the chat session.
+    let tool_allowlist: Arc<std::sync::Mutex<HashSet<String>>> =
+        Arc::new(std::sync::Mutex::new(HashSet::new()));
+
+    let pending_permission: PendingPermissionSlot = Arc::new(std::sync::Mutex::new(None));
 
     // Channel for user prompts (None = shutdown sentinel).
     let (prompt_tx, prompt_rx) = mpsc::sync_channel::<Option<String>>(32);
@@ -254,8 +268,8 @@ pub fn run_chat_stream(
     // We use a slot (Mutex<Option<Sender>>) so the stdin reader can target the current turn.
     let hitl_slot: Arc<std::sync::Mutex<Option<mpsc::SyncSender<String>>>> =
         Arc::new(std::sync::Mutex::new(None));
-    let perm_slot: Arc<std::sync::Mutex<Option<mpsc::SyncSender<PermissionResponse>>>> =
-        Arc::new(std::sync::Mutex::new(None));
+    // Carries (tool_name, response_sender) so allow_for_session can insert into the allowlist.
+    let perm_slot: PendingPermissionSlot = Arc::new(std::sync::Mutex::new(None));
 
     // Enqueue the initial message if provided (one-shot mode).
     if let Some(msg) = initial_message {
@@ -271,6 +285,7 @@ pub fn run_chat_stream(
         let kill_stdin = Arc::clone(&kill_requested);
         let hitl_slot_stdin = Arc::clone(&hitl_slot);
         let perm_slot_stdin = Arc::clone(&perm_slot);
+        let allowlist_stdin = Arc::clone(&tool_allowlist);
 
         std::thread::spawn(move || {
             use std::io::BufRead;
@@ -323,6 +338,11 @@ pub fn run_chat_stream(
                             .and_then(|v| v.get("allowed"))
                             .and_then(|v| v.as_bool())
                             .unwrap_or(false);
+                        let allow_for_session = parsed
+                            .as_ref()
+                            .and_then(|v| v.get("allow_for_session"))
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
                         let response = if allowed {
                             PermissionResponse::Allow
                         } else {
@@ -334,8 +354,15 @@ pub fn run_chat_stream(
                                 .to_string();
                             PermissionResponse::Deny(reason)
                         };
-                        let guard = perm_slot_stdin.lock().unwrap_or_else(|e| e.into_inner());
-                        if let Some(ref tx) = *guard {
+                        let mut guard = perm_slot_stdin.lock().unwrap_or_else(|e| e.into_inner());
+                        if let Some((tool_name, tx)) = guard.take() {
+                            // If "allow for session" was requested, add tool to the allowlist
+                            // before sending Allow so future identical calls skip the prompt.
+                            if allowed && allow_for_session {
+                                if let Ok(mut al) = allowlist_stdin.lock() {
+                                    al.insert(tool_name);
+                                }
+                            }
                             let _ = tx.send(response);
                         }
                     }
@@ -405,16 +432,17 @@ pub fn run_chat_stream(
             std::thread::spawn(move || {
                 loop {
                     // Poll until a pending sender appears (set by the permission responder callback).
-                    let tx_opt = {
+                    let entry_opt = {
                         let guard = pending_perm.lock().unwrap_or_else(|e| e.into_inner());
                         guard.clone()
                     };
-                    if let Some(tx) = tx_opt {
-                        // Install the sender into perm_slot so the stdin reader can deliver.
+                    if let Some(entry) = entry_opt {
+                        // Install the (tool_name, sender) into perm_slot so the stdin reader
+                        // can deliver a decision (and optionally add tool to allowlist).
                         {
                             let mut guard =
                                 perm_slot_loop.lock().unwrap_or_else(|e| e.into_inner());
-                            *guard = Some(tx);
+                            *guard = Some(entry);
                         }
                         break;
                     }
@@ -434,6 +462,7 @@ pub fn run_chat_stream(
             Arc::clone(&pause_requested),
             Arc::clone(&kill_requested),
             Arc::clone(&pending_permission),
+            Arc::clone(&tool_allowlist),
             hitl_rx,
         );
 
@@ -444,7 +473,7 @@ pub fn run_chat_stream(
         }
         {
             let mut guard = perm_slot.lock().unwrap_or_else(|e| e.into_inner());
-            *guard = None;
+            drop(guard.take());
         }
 
         let duration_ms = start.elapsed().as_millis();

--- a/ail/src/main.rs
+++ b/ail/src/main.rs
@@ -13,6 +13,17 @@ use ail_core::runner::{InvokeOptions, Runner};
 use clap::Parser;
 use cli::{Cli, Commands, OutputFormat};
 
+/// Shared slot carrying `(tool_name, response_sender)` for a pending permission request.
+/// The permission responder callback parks the sender here; the stdin reader picks it up.
+type PendingPermissionSlot = std::sync::Arc<
+    std::sync::Mutex<
+        Option<(
+            String,
+            std::sync::mpsc::SyncSender<ail_core::runner::PermissionResponse>,
+        )>,
+    >,
+>;
+
 /// Initialise tracing. Always writes structured JSON logs to stderr.
 fn init_tracing() {
     tracing_subscriber::fmt()
@@ -345,19 +356,30 @@ fn run_once_json(session: &mut ail_core::session::Session, runner: &dyn Runner, 
     let pause_requested = Arc::new(AtomicBool::new(false));
     let kill_requested = Arc::new(AtomicBool::new(false));
 
-    // One-shot channel for permission responses. When the PermissionResponder
-    // callback fires, it parks a SyncSender here; the stdin reader picks it up.
-    let pending_permission: Arc<
-        std::sync::Mutex<Option<mpsc::SyncSender<ail_core::runner::PermissionResponse>>>,
-    > = Arc::new(std::sync::Mutex::new(None));
+    // In-memory allowlist for "Allow for session" — tool names added here are auto-approved
+    // for the remainder of this run without prompting.
+    let tool_allowlist: Arc<std::sync::Mutex<HashSet<String>>> =
+        Arc::new(std::sync::Mutex::new(HashSet::new()));
 
-    // Build the permission responder — blocks until the stdin reader delivers a decision.
+    // One-shot channel for permission responses. When the PermissionResponder
+    // callback fires, it parks `(tool_name, SyncSender)` here; the stdin reader picks it up.
+    let pending_permission: PendingPermissionSlot = Arc::new(std::sync::Mutex::new(None));
+
+    // Build the permission responder — checks allowlist first; otherwise blocks until the
+    // stdin reader delivers a decision.
     let pending_perm_responder = Arc::clone(&pending_permission);
+    let allowlist_responder = Arc::clone(&tool_allowlist);
     let responder: ail_core::runner::PermissionResponder =
-        Arc::new(move |_req: ail_core::runner::PermissionRequest| {
+        Arc::new(move |req: ail_core::runner::PermissionRequest| {
+            // Fast path: tool is in the session allowlist — approve silently.
+            if let Ok(guard) = allowlist_responder.lock() {
+                if guard.contains(&req.display_name) {
+                    return ail_core::runner::PermissionResponse::Allow;
+                }
+            }
             let (tx, rx) = mpsc::sync_channel(1);
             if let Ok(mut guard) = pending_perm_responder.lock() {
-                *guard = Some(tx);
+                *guard = Some((req.display_name, tx));
             }
             rx.recv_timeout(std::time::Duration::from_secs(300))
                 .unwrap_or(ail_core::runner::PermissionResponse::Deny(
@@ -371,6 +393,7 @@ fn run_once_json(session: &mut ail_core::session::Session, runner: &dyn Runner, 
     let pause_stdin = Arc::clone(&pause_requested);
     let kill_stdin = Arc::clone(&kill_requested);
     let pending_perm_stdin = Arc::clone(&pending_permission);
+    let allowlist_stdin = Arc::clone(&tool_allowlist);
     std::thread::spawn(move || {
         use std::io::BufRead;
         let stdin = std::io::stdin();
@@ -398,6 +421,10 @@ fn run_once_json(session: &mut ail_core::session::Session, runner: &dyn Runner, 
                         .get("allowed")
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false);
+                    let allow_for_session = msg
+                        .get("allow_for_session")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
                     let response = if allowed {
                         ail_core::runner::PermissionResponse::Allow
                     } else {
@@ -409,7 +436,14 @@ fn run_once_json(session: &mut ail_core::session::Session, runner: &dyn Runner, 
                         ail_core::runner::PermissionResponse::Deny(reason)
                     };
                     let mut guard = pending_perm_stdin.lock().unwrap_or_else(|e| e.into_inner());
-                    if let Some(tx) = guard.take() {
+                    if let Some((tool_name, tx)) = guard.take() {
+                        // If "allow for session" was requested, add tool to the allowlist
+                        // before sending Allow so future identical calls skip the prompt.
+                        if allowed && allow_for_session {
+                            if let Ok(mut al) = allowlist_stdin.lock() {
+                                al.insert(tool_name);
+                            }
+                        }
                         let _ = tx.send(response);
                     }
                 }

--- a/spec/core/s13-hitl-gates.md
+++ b/spec/core/s13-hitl-gates.md
@@ -1,6 +1,6 @@
 ## 13. Human-in-the-Loop (HITL) Gates
 
-> **Implementation status:** Partial. `pause_for_human` action is implemented in `execute_with_control()` (the controlled executor used by TUI and `--output-format json` mode): it blocks execution and emits a `HitlGateReached` event. In simple `execute()` mode (`--once` text output), `pause_for_human` is a no-op. The "Modify" response for tool permissions is deferred to v0.2.
+> **Implementation status:** Partial. `pause_for_human` action is implemented in `execute_with_control()` (the controlled executor used by `--output-format json` mode and `chat --stream`): it blocks execution and emits a `HitlGateReached` event. In simple `execute()` mode (`--once` text output), `pause_for_human` is a no-op. "Allow for session" is implemented for `--output-format json` and `chat --stream`: consumers send `{"type":"permission_response","allowed":true,"allow_for_session":true}` on stdin and the tool name is added to an in-memory allowlist for the remainder of the session. The "Modify" response for tool permissions is deferred to v0.2.
 
 HITL gates are intentional checkpoints, not error states.
 
@@ -72,7 +72,7 @@ Preferred over explicit gates — interrupts only when something genuinely requi
 
 For automated runs (CI, the autonomous agent use case, Docker sandbox), HITL prompts are not viable. Pass `--dangerously-skip-permissions` to the Claude CLI invocation to bypass all tool permission checks. This is only appropriate in a fully trusted, sandboxed environment. `ail` will expose this as a session-level flag — not a pipeline YAML option — to prevent it from being accidentally committed to a shared pipeline file.
 
-**`--once --output-format json` mode:** Full interactive HITL is available. Both the invocation step and all pipeline steps use a `permission_responder` wired to the stdin control protocol (§23.7). Consumers receive `permission_requested` events on stdout and respond via `permission_response` messages on stdin. `pause_for_human` steps and `on_result: pause_for_human` branches both block the executor and emit `hitl_gate_reached` events, unblocked by `hitl_response` messages on stdin.
+**`--once --output-format json` mode:** Full interactive HITL is available. Both the invocation step and all pipeline steps use a `permission_responder` wired to the stdin control protocol (§23.7). Consumers receive `permission_requested` events on stdout and respond via `permission_response` messages on stdin. The `permission_response` message accepts an optional `"allow_for_session": true` field: when `"allowed": true` and `"allow_for_session": true`, the tool name is inserted into an in-memory allowlist and subsequent identical permission requests are auto-approved without prompting. `pause_for_human` steps and `on_result: pause_for_human` branches both block the executor and emit `hitl_gate_reached` events, unblocked by `hitl_response` messages on stdin.
 
 **`--once` text mode:** The `--once --output-format text` flow does not set a `permission_responder` and does not spawn a stdin reader thread. Interactive permission HITL is not available. Tools in text mode require either `--headless` (bypass all permissions) or `tools: allow:` in the pipeline YAML (pre-approve specific tools).
 


### PR DESCRIPTION
## Summary

- Adds "Allow for Session" support to the NDJSON permission protocol. When a consumer sends `{"type":"permission_response","allowed":true,"allow_for_session":true}`, the tool name is inserted into an in-memory `HashSet` allowlist. Subsequent permission requests for that tool are auto-approved without prompting for the remainder of the session.
- Implemented in both `run_once_json()` (`--output-format json`) and `run_chat_stream()` / `run_turn_stream()` (`chat --stream`). The allowlist persists across turns in chat mode.
- Removes the dead `tool_allowlist: Vec<String>` field from `Session` in `ail-core` — it was never wired to any logic. The live allowlist is now owned by the binary layer (`ail`), consistent with the architecture rule that `ail-core` never manages interactive session state.
- Spec updated: `spec/core/s13-hitl-gates.md` implementation status note and §13.6 stdin protocol description.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo nextest run` — 258/258 pass, 6 skipped
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Fixes #59