### PR TITLE
Add pipeline graph visualizer with React Flow

### DIFF
--- a/vscode-ail-chat/esbuild.js
+++ b/vscode-ail-chat/esbuild.js
@@ -33,6 +33,20 @@ const webviewOptions = {
   minify: production,
 };
 
+/** @type {import('esbuild').BuildOptions} */
+const graphWebviewOptions = {
+  entryPoints: ['src/webview-graph/index.tsx'],
+  bundle: true,
+  outfile: 'dist/graphWebview.js',
+  format: 'iife',
+  platform: 'browser',
+  target: 'es2020',
+  sourcemap: !production,
+  minify: production,
+  // React Flow ships CSS that we inline via the css loader.
+  loader: { '.css': 'css' },
+};
+
 function copyCodiconAssets() {
   const dist = path.join(__dirname, 'dist');
   if (!fs.existsSync(dist)) fs.mkdirSync(dist, { recursive: true });
@@ -64,18 +78,20 @@ async function build() {
   copyCodiconAssets();
 
   if (watch) {
-    const [extCtx, webCtx] = await Promise.all([
+    const [extCtx, webCtx, graphCtx] = await Promise.all([
       esbuild.context(extensionOptions),
       esbuild.context(webviewOptions),
+      esbuild.context(graphWebviewOptions),
     ]);
-    await Promise.all([extCtx.watch(), webCtx.watch()]);
+    await Promise.all([extCtx.watch(), webCtx.watch(), graphCtx.watch()]);
     console.log('esbuild watching...');
   } else {
     await Promise.all([
       esbuild.build(extensionOptions),
       esbuild.build(webviewOptions),
+      esbuild.build(graphWebviewOptions),
     ]);
-    console.log('esbuild: dist/extension.js + dist/webview.js');
+    console.log('esbuild: dist/extension.js + dist/webview.js + dist/graphWebview.js');
   }
 }
 

--- a/vscode-ail-chat/package-lock.json
+++ b/vscode-ail-chat/package-lock.json
@@ -9,9 +9,12 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "@vscode/codicons": "^0.0.45",
+        "@xyflow/react": "^12.10.2",
         "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react-dom": "^18.0.0",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@testing-library/react": "^16.0.0",
@@ -262,6 +265,21 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -1338,6 +1356,55 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1366,14 +1433,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1728,6 +1795,38 @@
       "integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==",
       "license": "CC-BY-4.0"
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1936,6 +2035,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1996,8 +2101,113 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -3763,6 +3973,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
@@ -4457,6 +4676,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4468,6 +4702,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/vscode-ail-chat/package.json
+++ b/vscode-ail-chat/package.json
@@ -70,6 +70,11 @@
         "command": "ail-chat.newSession",
         "title": "ail Chat: New Session",
         "category": "ail Chat"
+      },
+      {
+        "command": "ail-chat.openPipelineGraph",
+        "title": "ail Chat: Open Pipeline Graph",
+        "category": "ail Chat"
       }
     ]
   },
@@ -99,9 +104,12 @@
     "vitest": "^2.0.0"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@vscode/codicons": "^0.0.45",
+    "@xyflow/react": "^12.10.2",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "yaml": "^2.8.3"
   },
   "config": {
     "ailMinVersion": "0.0.1"

--- a/vscode-ail-chat/src/extension.ts
+++ b/vscode-ail-chat/src/extension.ts
@@ -6,9 +6,12 @@
  */
 
 import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
 import { clearBinaryCache } from './binary';
 import { SessionManager } from './session-manager';
 import { ChatViewProvider } from './chat-view-provider';
+import { PipelineGraphPanel } from './pipeline-graph/PipelineGraphPanel';
 
 let chatProvider: ChatViewProvider | undefined;
 
@@ -35,6 +38,46 @@ export function activate(context: vscode.ExtensionContext): void {
 
     vscode.commands.registerCommand('ail-chat.newSession', () => {
       chatProvider?.reveal();
+    }),
+
+    vscode.commands.registerCommand('ail-chat.openPipelineGraph', async () => {
+      // Pipeline resolution order:
+      // 1. Active editor (if it's a .ail.yaml file)
+      // 2. File picker dialog
+      const activeEditor = vscode.window.activeTextEditor;
+      const activeFile = activeEditor?.document.uri.fsPath;
+      const isYaml = activeFile && /\.ail\.ya?ml$/i.test(activeFile);
+
+      let pipelinePath: string | undefined;
+      if (isYaml) {
+        pipelinePath = activeFile;
+      } else {
+        // Check workspace root for .ail.yaml
+        const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        if (cwd) {
+          const candidate = path.join(cwd, '.ail.yaml');
+          if (fs.existsSync(candidate)) {
+            pipelinePath = candidate;
+          }
+        }
+      }
+
+      if (!pipelinePath) {
+        const uris = await vscode.window.showOpenDialog({
+          canSelectMany: false,
+          canSelectFolders: false,
+          filters: { 'ail Pipeline': ['yaml', 'yml'] },
+          title: 'Select ail pipeline file to visualize',
+          openLabel: 'Open Pipeline Graph',
+        });
+        if (uris && uris.length > 0) {
+          pipelinePath = uris[0].fsPath;
+        }
+      }
+
+      if (pipelinePath) {
+        PipelineGraphPanel.show(context.extensionPath, pipelinePath);
+      }
     })
   );
 }

--- a/vscode-ail-chat/src/pipeline-graph/PipelineGraphPanel.ts
+++ b/vscode-ail-chat/src/pipeline-graph/PipelineGraphPanel.ts
@@ -1,0 +1,224 @@
+/**
+ * PipelineGraphPanel — singleton WebviewPanel that hosts the React Flow
+ * pipeline graph visualizer.
+ *
+ * Opened via the `ail-chat.openPipelineGraph` command.
+ * Communicates with the React webview via postMessage.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { transformPipeline, TransformResult } from './graphTransform';
+
+/** Messages from the graph webview to the extension host. */
+export type GraphWebviewToHostMessage =
+  | { type: 'ready' }
+  | { type: 'openStepInEditor'; sourceFile: string; sourceLine: number };
+
+/** Messages from the extension host to the graph webview. */
+export type GraphHostToWebviewMessage =
+  | { type: 'init'; data: TransformResult; pipelinePath: string; pipelineName: string }
+  | { type: 'update'; data: TransformResult; pipelinePath: string; pipelineName: string }
+  | { type: 'error'; message: string };
+
+export class PipelineGraphPanel {
+  public static readonly viewType = 'ail-chat.pipelineGraph';
+
+  private static _instance: PipelineGraphPanel | undefined;
+  private readonly _panel: vscode.WebviewPanel;
+  private readonly _extensionPath: string;
+  private _pipelinePath: string;
+  private _disposables: vscode.Disposable[] = [];
+  private _fileWatchers: vscode.FileSystemWatcher[] = [];
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    extensionPath: string,
+    pipelinePath: string
+  ) {
+    this._panel = panel;
+    this._extensionPath = extensionPath;
+    this._pipelinePath = pipelinePath;
+
+    this._panel.webview.html = this._getHtml();
+
+    this._panel.webview.onDidReceiveMessage(
+      (msg: GraphWebviewToHostMessage) => this._handleMessage(msg),
+      null,
+      this._disposables
+    );
+
+    this._panel.onDidDispose(() => this._dispose(), null, this._disposables);
+
+    this._setupFileWatchers();
+  }
+
+  /**
+   * Show the pipeline graph panel. Creates it if it doesn't exist,
+   * otherwise reveals and updates the pipeline.
+   */
+  static show(extensionPath: string, pipelinePath: string): void {
+    if (PipelineGraphPanel._instance) {
+      PipelineGraphPanel._instance._pipelinePath = pipelinePath;
+      PipelineGraphPanel._instance._panel.reveal(vscode.ViewColumn.One);
+      PipelineGraphPanel._instance._sendUpdate();
+      PipelineGraphPanel._instance._setupFileWatchers();
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      PipelineGraphPanel.viewType,
+      `Pipeline: ${path.basename(pipelinePath)}`,
+      vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          vscode.Uri.file(path.join(extensionPath, 'dist')),
+        ],
+      }
+    );
+
+    PipelineGraphPanel._instance = new PipelineGraphPanel(panel, extensionPath, pipelinePath);
+  }
+
+  private _handleMessage(msg: GraphWebviewToHostMessage): void {
+    switch (msg.type) {
+      case 'ready':
+        this._sendInit();
+        break;
+
+      case 'openStepInEditor': {
+        const uri = vscode.Uri.file(msg.sourceFile);
+        const line = Math.max(0, msg.sourceLine);
+        const range = new vscode.Range(line, 0, line, 0);
+        void vscode.window.showTextDocument(uri, {
+          selection: range,
+          preview: true,
+        });
+        break;
+      }
+    }
+  }
+
+  private _sendInit(): void {
+    const result = transformPipeline(this._pipelinePath);
+    const name = this._extractPipelineName();
+    const msg: GraphHostToWebviewMessage = {
+      type: 'init',
+      data: result,
+      pipelinePath: this._pipelinePath,
+      pipelineName: name,
+    };
+    void this._panel.webview.postMessage(msg);
+
+    if (result.errors.length > 0) {
+      void this._panel.webview.postMessage({
+        type: 'error',
+        message: result.errors.join('\n'),
+      } satisfies GraphHostToWebviewMessage);
+    }
+  }
+
+  private _sendUpdate(): void {
+    const result = transformPipeline(this._pipelinePath);
+    const name = this._extractPipelineName();
+    this._panel.title = `Pipeline: ${path.basename(this._pipelinePath)}`;
+    const msg: GraphHostToWebviewMessage = {
+      type: 'update',
+      data: result,
+      pipelinePath: this._pipelinePath,
+      pipelineName: name,
+    };
+    void this._panel.webview.postMessage(msg);
+  }
+
+  private _extractPipelineName(): string {
+    try {
+      const content = fs.readFileSync(this._pipelinePath, 'utf-8');
+      const match = content.match(/^\s*name:\s*["']?(.+?)["']?\s*$/m);
+      return match?.[1] ?? path.basename(this._pipelinePath);
+    } catch {
+      return path.basename(this._pipelinePath);
+    }
+  }
+
+  private _setupFileWatchers(): void {
+    // Dispose old watchers.
+    for (const w of this._fileWatchers) w.dispose();
+    this._fileWatchers = [];
+
+    // Watch the pipeline file and its directory for YAML changes.
+    const dir = path.dirname(this._pipelinePath);
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(dir, '**/*.{yaml,yml}')
+    );
+    watcher.onDidChange(() => this._sendUpdate());
+    watcher.onDidCreate(() => this._sendUpdate());
+    watcher.onDidDelete(() => this._sendUpdate());
+    this._fileWatchers.push(watcher);
+  }
+
+  private _dispose(): void {
+    PipelineGraphPanel._instance = undefined;
+    for (const d of this._disposables) d.dispose();
+    for (const w of this._fileWatchers) w.dispose();
+    this._disposables = [];
+    this._fileWatchers = [];
+  }
+
+  private _getHtml(): string {
+    const webview = this._panel.webview;
+    const scriptUri = webview.asWebviewUri(
+      vscode.Uri.file(path.join(this._extensionPath, 'dist', 'graphWebview.js'))
+    );
+    const cssUri = webview.asWebviewUri(
+      vscode.Uri.file(path.join(this._extensionPath, 'dist', 'graphWebview.css'))
+    );
+    const nonce = generateNonce();
+
+    // React Flow requires its own CSS. We bundle it into the JS via esbuild's
+    // CSS loader, but also need to allow inline styles for the node positioning.
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'none';
+    script-src 'nonce-${nonce}';
+    style-src ${webview.cspSource} 'unsafe-inline';
+    font-src ${webview.cspSource};
+  ">
+  <title>Pipeline Graph</title>
+  <link rel="stylesheet" href="${cssUri.toString()}">
+  <style>
+    html, body, #root {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: var(--vscode-editor-background);
+      color: var(--vscode-editor-foreground);
+      font-family: var(--vscode-font-family);
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script nonce="${nonce}" src="${scriptUri.toString()}"></script>
+</body>
+</html>`;
+  }
+}
+
+function generateNonce(): string {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}

--- a/vscode-ail-chat/src/pipeline-graph/graphTransform.ts
+++ b/vscode-ail-chat/src/pipeline-graph/graphTransform.ts
@@ -37,6 +37,8 @@ export interface StepNodeData {
   isSubPipelineGroup?: boolean;
   /** Human-readable label for on_result edge. */
   branchLabel?: string;
+  /** Step count inside a sub-pipeline group (for collapsed display). */
+  childStepCount?: number;
 }
 
 export interface GraphEdge {
@@ -64,7 +66,7 @@ export interface TransformResult {
   errors: string[];
 }
 
-// ── YAML parsing (lightweight, no domain validation) ────────────────────────
+// ── YAML parsing ────────────────────────────────────────────────────────────
 
 // The `yaml` package is a dependency — esbuild bundles it into the extension host.
 import { parse as yamlParse } from 'yaml';
@@ -100,18 +102,28 @@ interface RawPipelineFile {
   pipeline?: RawStep[];
 }
 
+/** Tracks already-expanded sub-pipeline files for deduplication. */
+interface SubPipelineRef {
+  groupNodeId: string;
+  firstNodeId: string;
+  lastNodeId: string;
+}
+
 /**
  * Transform a pipeline YAML file into graph nodes and edges.
  *
  * Recursively expands sub-pipeline references up to MAX_DEPTH.
+ * Deduplicates: if multiple branches reference the same sub-pipeline file,
+ * only one group is created and all edges point to it.
  */
 export function transformPipeline(filePath: string): TransformResult {
   const nodes: GraphNode[] = [];
   const edges: GraphEdge[] = [];
   const errors: string[] = [];
   const visited = new Set<string>();
+  const subPipelineCache = new Map<string, SubPipelineRef>();
 
-  processFile(filePath, nodes, edges, errors, visited, undefined, 0);
+  processFile(filePath, nodes, edges, errors, visited, subPipelineCache, undefined, 0);
 
   return { nodes, edges, errors };
 }
@@ -122,14 +134,15 @@ function processFile(
   edges: GraphEdge[],
   errors: string[],
   visited: Set<string>,
+  subPipelineCache: Map<string, SubPipelineRef>,
   parentGroupId: string | undefined,
   depth: number
-): { firstNodeId: string | null; lastNodeId: string | null } {
+): { firstNodeId: string | null; lastNodeId: string | null; groupNodeId: string | null } {
   const absPath = path.resolve(filePath);
 
   if (depth > MAX_DEPTH) {
     errors.push(`Max sub-pipeline depth (${MAX_DEPTH}) exceeded at ${absPath}`);
-    return { firstNodeId: null, lastNodeId: null };
+    return { firstNodeId: null, lastNodeId: null, groupNodeId: null };
   }
 
   if (visited.has(absPath)) {
@@ -149,7 +162,7 @@ function processFile(
         pipelineName: path.basename(absPath) + ' (recursive)',
       },
     });
-    return { firstNodeId: placeholderId, lastNodeId: placeholderId };
+    return { firstNodeId: placeholderId, lastNodeId: placeholderId, groupNodeId: null };
   }
 
   visited.add(absPath);
@@ -160,7 +173,7 @@ function processFile(
   } catch (err) {
     errors.push(`Cannot read ${absPath}: ${err instanceof Error ? err.message : String(err)}`);
     visited.delete(absPath);
-    return { firstNodeId: null, lastNodeId: null };
+    return { firstNodeId: null, lastNodeId: null, groupNodeId: null };
   }
 
   let parsed: RawPipelineFile;
@@ -169,18 +182,41 @@ function processFile(
   } catch (err) {
     errors.push(`Cannot parse ${absPath}: ${err instanceof Error ? err.message : String(err)}`);
     visited.delete(absPath);
-    return { firstNodeId: null, lastNodeId: null };
+    return { firstNodeId: null, lastNodeId: null, groupNodeId: null };
   }
 
   const steps = parsed?.pipeline;
   if (!Array.isArray(steps) || steps.length === 0) {
     errors.push(`No pipeline steps found in ${absPath}`);
     visited.delete(absPath);
-    return { firstNodeId: null, lastNodeId: null };
+    return { firstNodeId: null, lastNodeId: null, groupNodeId: null };
   }
 
   const baseDir = path.dirname(absPath);
-  const lineMap = buildLineMap(content, steps);
+  const lineMap = buildLineMap(content);
+  const pipelineName = parsed.meta?.name ?? path.basename(absPath, path.extname(absPath));
+
+  // Create a group node for sub-pipelines (depth > 0).
+  let groupNodeId: string | null = null;
+  if (depth > 0) {
+    groupNodeId = `${absPath}::group`;
+    nodes.push({
+      id: groupNodeId,
+      type: 'subPipelineGroup',
+      position: { x: 0, y: 0 },
+      parentId: parentGroupId,
+      data: {
+        stepId: pipelineName,
+        type: 'pipeline',
+        sourceFile: absPath,
+        sourceLine: 0,
+        pipelineName,
+        isSubPipelineGroup: true,
+        childStepCount: steps.length,
+        subPipelinePath: absPath,
+      },
+    });
+  }
 
   let firstNodeId: string | null = null;
   let prevNodeId: string | null = null;
@@ -203,7 +239,7 @@ function processFile(
       tools: step.tools ? { allow: step.tools.allow ?? [], deny: step.tools.deny ?? [] } : undefined,
       model: step.model,
       onResultCount: step.on_result?.length,
-      pipelineName: parsed.meta?.name,
+      pipelineName,
     };
 
     // If this step is a sub-pipeline reference (body is `pipeline:`), note the path.
@@ -215,7 +251,7 @@ function processFile(
       id: nodeId,
       type: 'stepNode',
       position: { x: 0, y: 0 },
-      parentId: parentGroupId,
+      parentId: groupNodeId ?? parentGroupId,
       data: nodeData,
     });
 
@@ -241,45 +277,80 @@ function processFile(
         const pipelineMatch = branchAction.match(/^pipeline:\s*(.+)$/);
         if (pipelineMatch) {
           const subPath = resolveRelativePath(pipelineMatch[1].trim(), baseDir);
-          const subResult = processFile(subPath, nodes, edges, errors, visited, parentGroupId, depth + 1);
-          if (subResult.firstNodeId) {
+          const subAbsPath = path.resolve(subPath);
+
+          // Deduplication: reuse already-expanded sub-pipeline.
+          const cached = subPipelineCache.get(subAbsPath);
+          if (cached) {
             edges.push({
-              id: `${nodeId}->branch_${bi}_${subResult.firstNodeId}`,
+              id: `${nodeId}->branch_${bi}_${cached.groupNodeId ?? cached.firstNodeId}`,
               source: nodeId,
-              target: subResult.firstNodeId,
+              target: cached.groupNodeId ?? cached.firstNodeId,
               label: branchLabel,
               conditional: true,
             });
+          } else {
+            const subResult = processFile(subPath, nodes, edges, errors, visited, subPipelineCache, parentGroupId, depth + 1);
+            if (subResult.firstNodeId) {
+              const target = subResult.groupNodeId ?? subResult.firstNodeId;
+              edges.push({
+                id: `${nodeId}->branch_${bi}_${target}`,
+                source: nodeId,
+                target,
+                label: branchLabel,
+                conditional: true,
+              });
+              subPipelineCache.set(subAbsPath, {
+                groupNodeId: subResult.groupNodeId ?? subResult.firstNodeId,
+                firstNodeId: subResult.firstNodeId,
+                lastNodeId: subResult.lastNodeId ?? subResult.firstNodeId,
+              });
+            }
           }
         }
         // Other branch actions (continue, break, abort, pause_for_human)
         // don't create edges to new nodes — they affect control flow but
         // don't add graph structure.
       }
-      // on_result branches consumed — don't connect sequentially to next step
-      // unless there are non-pipeline branches that continue.
+      // on_result branches consumed — don't connect sequentially to next step.
       prevNodeId = null;
     } else if (step.pipeline && !step.prompt) {
       // Inline sub-pipeline step (not via on_result): expand it.
       const subPath = resolveRelativePath(step.pipeline, baseDir);
-      const subResult = processFile(subPath, nodes, edges, errors, visited, parentGroupId, depth + 1);
-      if (subResult.firstNodeId) {
-        // Replace the step node with an edge into the sub-pipeline.
+      const subAbsPath = path.resolve(subPath);
+
+      const cached = subPipelineCache.get(subAbsPath);
+      if (cached) {
         edges.push({
-          id: `${nodeId}->${subResult.firstNodeId}`,
+          id: `${nodeId}->${cached.groupNodeId ?? cached.firstNodeId}`,
           source: nodeId,
-          target: subResult.firstNodeId,
+          target: cached.groupNodeId ?? cached.firstNodeId,
         });
+        prevNodeId = cached.lastNodeId;
+      } else {
+        const subResult = processFile(subPath, nodes, edges, errors, visited, subPipelineCache, groupNodeId ?? parentGroupId, depth + 1);
+        if (subResult.firstNodeId) {
+          const target = subResult.groupNodeId ?? subResult.firstNodeId;
+          edges.push({
+            id: `${nodeId}->${target}`,
+            source: nodeId,
+            target,
+          });
+          subPipelineCache.set(subAbsPath, {
+            groupNodeId: subResult.groupNodeId ?? subResult.firstNodeId,
+            firstNodeId: subResult.firstNodeId,
+            lastNodeId: subResult.lastNodeId ?? subResult.firstNodeId,
+          });
+        }
+        prevNodeId = subResult.lastNodeId ?? nodeId;
       }
-      // The sequential chain continues from the sub-pipeline's last node.
-      prevNodeId = subResult.lastNodeId ?? nodeId;
     } else {
       prevNodeId = nodeId;
     }
   }
 
   visited.delete(absPath);
-  return { firstNodeId, lastNodeId: prevNodeId };
+  return { firstNodeId, lastNodeId: prevNodeId, groupNodeId };
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -295,9 +366,9 @@ function classifyStep(step: RawStep): StepNodeData['type'] {
 }
 
 function describeMatcher(branch: RawOnResult): string {
-  if (branch.contains) return `contains: "${branch.contains}"`;
+  if (branch.contains) return branch.contains;
   if (branch.exit_code !== undefined) return `exit_code: ${branch.exit_code}`;
-  if (branch.always) return 'always';
+  if (branch.always) return 'fallback';
   return '?';
 }
 
@@ -309,9 +380,8 @@ function resolveRelativePath(ref: string, baseDir: string): string {
 
 /**
  * Build a map from step id → 0-based line number by scanning for `- id:` patterns.
- * This is a best-effort heuristic (not a full YAML parser with source maps).
  */
-function buildLineMap(content: string, _steps: RawStep[]): Map<string, number> {
+function buildLineMap(content: string): Map<string, number> {
   const map = new Map<string, number>();
   const lines = content.split('\n');
   const idPattern = /^\s*-\s*id:\s*(.+)$/;
@@ -322,7 +392,6 @@ function buildLineMap(content: string, _steps: RawStep[]): Map<string, number> {
     if (m) {
       const id = m[1].trim().replace(/^["']|["']$/g, '');
       map.set(id, lineNo);
-      // Also map by index for steps without explicit id matching.
       map.set(`step_${stepIdx}`, lineNo);
       stepIdx++;
     }

--- a/vscode-ail-chat/src/pipeline-graph/graphTransform.ts
+++ b/vscode-ail-chat/src/pipeline-graph/graphTransform.ts
@@ -9,36 +9,45 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 // ── Public types (shared with webview via postMessage) ──────────────────────
+// Canonical definitions live in webview-graph/types.ts (browser side).
+// We re-declare them here to avoid cross-bundle imports. Keep in sync.
+
+export interface OnResultBranch {
+  matcher: string;
+  action: string;
+  prompt?: string;
+}
+
+export interface AppendSystemPromptEntry {
+  type: 'text' | 'file' | 'shell';
+  value: string;
+}
 
 export interface StepNodeData {
   stepId: string;
   type: 'prompt' | 'context' | 'pipeline' | 'action' | 'skill' | 'invocation';
-  /** Pipeline meta.name or filename for sub-pipeline group headers. */
   pipelineName?: string;
-  /** Source .ail.yaml file path (absolute). */
   sourceFile: string;
-  /** 0-based line number of this step in the source file. */
   sourceLine: number;
-  /** Raw prompt text (may be long — truncated by the UI). */
   prompt?: string;
-  /** System prompt path or inline text. */
+  promptIsFile?: boolean;
   systemPrompt?: string;
-  /** append_system_prompt entries count. */
+  systemPromptIsFile?: boolean;
   appendSystemPromptCount?: number;
-  /** Tool policy summary. */
+  appendSystemPromptEntries?: AppendSystemPromptEntry[];
   tools?: { allow: string[]; deny: string[] };
-  /** Model override, if any. */
   model?: string;
-  /** on_result branch count (edges are created separately). */
   onResultCount?: number;
-  /** For sub-pipeline steps: the referenced pipeline path (raw, unresolved). */
+  onResultBranches?: OnResultBranch[];
   subPipelinePath?: string;
-  /** Whether this is a sub-pipeline group wrapper node. */
   isSubPipelineGroup?: boolean;
-  /** Human-readable label for on_result edge. */
   branchLabel?: string;
-  /** Step count inside a sub-pipeline group (for collapsed display). */
   childStepCount?: number;
+  shellCommand?: string;
+  actionKind?: string;
+  condition?: string;
+  resume?: boolean;
+  message?: string;
 }
 
 export interface GraphEdge {
@@ -81,12 +90,16 @@ interface RawStep {
   action?: string;
   context?: { shell?: string } | string;
   system_prompt?: string;
-  append_system_prompt?: unknown[];
+  append_system_prompt?: RawAppendEntry[];
   tools?: { allow?: string[]; deny?: string[] };
   model?: string;
   on_result?: RawOnResult[];
   message?: string;
+  condition?: string;
+  resume?: boolean;
 }
+
+type RawAppendEntry = string | { text?: string; file?: string; shell?: string };
 
 interface RawOnResult {
   contains?: string;
@@ -234,12 +247,25 @@ function processFile(
       sourceFile: absPath,
       sourceLine: line,
       prompt: step.prompt,
+      promptIsFile: isFilePath(step.prompt),
       systemPrompt: step.system_prompt,
+      systemPromptIsFile: isFilePath(step.system_prompt),
       appendSystemPromptCount: step.append_system_prompt?.length,
+      appendSystemPromptEntries: parseAppendEntries(step.append_system_prompt),
       tools: step.tools ? { allow: step.tools.allow ?? [], deny: step.tools.deny ?? [] } : undefined,
       model: step.model,
       onResultCount: step.on_result?.length,
+      onResultBranches: step.on_result?.map((b) => ({
+        matcher: describeMatcher(b),
+        action: b.action ?? 'continue',
+        prompt: b.prompt,
+      })),
       pipelineName,
+      shellCommand: extractShellCommand(step.context),
+      actionKind: step.action,
+      condition: step.condition,
+      resume: step.resume,
+      message: step.message,
     };
 
     // If this step is a sub-pipeline reference (body is `pipeline:`), note the path.
@@ -376,6 +402,30 @@ function resolveRelativePath(ref: string, baseDir: string): string {
   if (ref.startsWith('/')) return ref;
   if (ref.startsWith('~/')) return path.join(process.env.HOME ?? '~', ref.slice(2));
   return path.resolve(baseDir, ref);
+}
+
+function isFilePath(value: string | undefined): boolean {
+  if (!value) return false;
+  return /^(\.\/|\.\.\/|~\/|\/)/.test(value.trim());
+}
+
+function extractShellCommand(context: RawStep['context']): string | undefined {
+  if (!context) return undefined;
+  if (typeof context === 'string') return context;
+  return context.shell;
+}
+
+function parseAppendEntries(entries: RawAppendEntry[] | undefined): AppendSystemPromptEntry[] | undefined {
+  if (!entries || entries.length === 0) return undefined;
+  return entries.map((entry) => {
+    if (typeof entry === 'string') {
+      return { type: 'text' as const, value: entry };
+    }
+    if (entry.shell) return { type: 'shell' as const, value: entry.shell };
+    if (entry.file) return { type: 'file' as const, value: entry.file };
+    if (entry.text) return { type: 'text' as const, value: entry.text };
+    return { type: 'text' as const, value: JSON.stringify(entry) };
+  });
 }
 
 /**

--- a/vscode-ail-chat/src/pipeline-graph/graphTransform.ts
+++ b/vscode-ail-chat/src/pipeline-graph/graphTransform.ts
@@ -1,0 +1,331 @@
+/**
+ * graphTransform — converts a pipeline YAML file (and its sub-pipelines)
+ * into React Flow nodes and edges for the pipeline graph visualizer.
+ *
+ * Pure function, no VS Code dependency. Fully unit-testable.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ── Public types (shared with webview via postMessage) ──────────────────────
+
+export interface StepNodeData {
+  stepId: string;
+  type: 'prompt' | 'context' | 'pipeline' | 'action' | 'skill' | 'invocation';
+  /** Pipeline meta.name or filename for sub-pipeline group headers. */
+  pipelineName?: string;
+  /** Source .ail.yaml file path (absolute). */
+  sourceFile: string;
+  /** 0-based line number of this step in the source file. */
+  sourceLine: number;
+  /** Raw prompt text (may be long — truncated by the UI). */
+  prompt?: string;
+  /** System prompt path or inline text. */
+  systemPrompt?: string;
+  /** append_system_prompt entries count. */
+  appendSystemPromptCount?: number;
+  /** Tool policy summary. */
+  tools?: { allow: string[]; deny: string[] };
+  /** Model override, if any. */
+  model?: string;
+  /** on_result branch count (edges are created separately). */
+  onResultCount?: number;
+  /** For sub-pipeline steps: the referenced pipeline path (raw, unresolved). */
+  subPipelinePath?: string;
+  /** Whether this is a sub-pipeline group wrapper node. */
+  isSubPipelineGroup?: boolean;
+  /** Human-readable label for on_result edge. */
+  branchLabel?: string;
+}
+
+export interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  /** Label for conditional edges (on_result branches). */
+  label?: string;
+  /** Whether this is a conditional (on_result) edge vs sequential. */
+  conditional?: boolean;
+}
+
+export interface GraphNode {
+  id: string;
+  type: 'stepNode' | 'subPipelineGroup';
+  position: { x: number; y: number };
+  data: StepNodeData;
+  /** For group nodes: ID of the parent group. */
+  parentId?: string;
+}
+
+export interface TransformResult {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  errors: string[];
+}
+
+// ── YAML parsing (lightweight, no domain validation) ────────────────────────
+
+// The `yaml` package is a dependency — esbuild bundles it into the extension host.
+import { parse as yamlParse } from 'yaml';
+
+const MAX_DEPTH = 16;
+
+interface RawStep {
+  id?: string;
+  prompt?: string;
+  skill?: string;
+  pipeline?: string;
+  action?: string;
+  context?: { shell?: string } | string;
+  system_prompt?: string;
+  append_system_prompt?: unknown[];
+  tools?: { allow?: string[]; deny?: string[] };
+  model?: string;
+  on_result?: RawOnResult[];
+  message?: string;
+}
+
+interface RawOnResult {
+  contains?: string;
+  exit_code?: number | string;
+  always?: boolean;
+  action?: string;
+  prompt?: string;
+}
+
+interface RawPipelineFile {
+  version?: string;
+  meta?: { name?: string };
+  pipeline?: RawStep[];
+}
+
+/**
+ * Transform a pipeline YAML file into graph nodes and edges.
+ *
+ * Recursively expands sub-pipeline references up to MAX_DEPTH.
+ */
+export function transformPipeline(filePath: string): TransformResult {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  const errors: string[] = [];
+  const visited = new Set<string>();
+
+  processFile(filePath, nodes, edges, errors, visited, undefined, 0);
+
+  return { nodes, edges, errors };
+}
+
+function processFile(
+  filePath: string,
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  errors: string[],
+  visited: Set<string>,
+  parentGroupId: string | undefined,
+  depth: number
+): { firstNodeId: string | null; lastNodeId: string | null } {
+  const absPath = path.resolve(filePath);
+
+  if (depth > MAX_DEPTH) {
+    errors.push(`Max sub-pipeline depth (${MAX_DEPTH}) exceeded at ${absPath}`);
+    return { firstNodeId: null, lastNodeId: null };
+  }
+
+  if (visited.has(absPath)) {
+    // Recursive reference — create a placeholder node, don't expand.
+    const placeholderId = `${absPath}::recursive::${depth}`;
+    nodes.push({
+      id: placeholderId,
+      type: 'stepNode',
+      position: { x: 0, y: 0 },
+      parentId: parentGroupId,
+      data: {
+        stepId: '(recursive)',
+        type: 'pipeline',
+        sourceFile: absPath,
+        sourceLine: 0,
+        subPipelinePath: absPath,
+        pipelineName: path.basename(absPath) + ' (recursive)',
+      },
+    });
+    return { firstNodeId: placeholderId, lastNodeId: placeholderId };
+  }
+
+  visited.add(absPath);
+
+  let content: string;
+  try {
+    content = fs.readFileSync(absPath, 'utf-8');
+  } catch (err) {
+    errors.push(`Cannot read ${absPath}: ${err instanceof Error ? err.message : String(err)}`);
+    visited.delete(absPath);
+    return { firstNodeId: null, lastNodeId: null };
+  }
+
+  let parsed: RawPipelineFile;
+  try {
+    parsed = yamlParse(content) as RawPipelineFile;
+  } catch (err) {
+    errors.push(`Cannot parse ${absPath}: ${err instanceof Error ? err.message : String(err)}`);
+    visited.delete(absPath);
+    return { firstNodeId: null, lastNodeId: null };
+  }
+
+  const steps = parsed?.pipeline;
+  if (!Array.isArray(steps) || steps.length === 0) {
+    errors.push(`No pipeline steps found in ${absPath}`);
+    visited.delete(absPath);
+    return { firstNodeId: null, lastNodeId: null };
+  }
+
+  const baseDir = path.dirname(absPath);
+  const lineMap = buildLineMap(content, steps);
+
+  let firstNodeId: string | null = null;
+  let prevNodeId: string | null = null;
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const stepId = step.id ?? `step_${i}`;
+    const nodeId = `${absPath}::${stepId}`;
+    const stepType = classifyStep(step);
+    const line = lineMap.get(stepId) ?? lineMap.get(`step_${i}`) ?? 0;
+
+    const nodeData: StepNodeData = {
+      stepId,
+      type: stepType,
+      sourceFile: absPath,
+      sourceLine: line,
+      prompt: step.prompt,
+      systemPrompt: step.system_prompt,
+      appendSystemPromptCount: step.append_system_prompt?.length,
+      tools: step.tools ? { allow: step.tools.allow ?? [], deny: step.tools.deny ?? [] } : undefined,
+      model: step.model,
+      onResultCount: step.on_result?.length,
+      pipelineName: parsed.meta?.name,
+    };
+
+    // If this step is a sub-pipeline reference (body is `pipeline:`), note the path.
+    if (step.pipeline && !step.prompt) {
+      nodeData.subPipelinePath = step.pipeline;
+    }
+
+    nodes.push({
+      id: nodeId,
+      type: 'stepNode',
+      position: { x: 0, y: 0 },
+      parentId: parentGroupId,
+      data: nodeData,
+    });
+
+    if (!firstNodeId) firstNodeId = nodeId;
+
+    // Sequential edge from previous step.
+    if (prevNodeId) {
+      edges.push({
+        id: `${prevNodeId}->${nodeId}`,
+        source: prevNodeId,
+        target: nodeId,
+      });
+    }
+
+    // Handle on_result branches.
+    if (step.on_result && step.on_result.length > 0) {
+      for (let bi = 0; bi < step.on_result.length; bi++) {
+        const branch = step.on_result[bi];
+        const branchLabel = describeMatcher(branch);
+        const branchAction = branch.action ?? '';
+
+        // Check if this branch calls a sub-pipeline.
+        const pipelineMatch = branchAction.match(/^pipeline:\s*(.+)$/);
+        if (pipelineMatch) {
+          const subPath = resolveRelativePath(pipelineMatch[1].trim(), baseDir);
+          const subResult = processFile(subPath, nodes, edges, errors, visited, parentGroupId, depth + 1);
+          if (subResult.firstNodeId) {
+            edges.push({
+              id: `${nodeId}->branch_${bi}_${subResult.firstNodeId}`,
+              source: nodeId,
+              target: subResult.firstNodeId,
+              label: branchLabel,
+              conditional: true,
+            });
+          }
+        }
+        // Other branch actions (continue, break, abort, pause_for_human)
+        // don't create edges to new nodes — they affect control flow but
+        // don't add graph structure.
+      }
+      // on_result branches consumed — don't connect sequentially to next step
+      // unless there are non-pipeline branches that continue.
+      prevNodeId = null;
+    } else if (step.pipeline && !step.prompt) {
+      // Inline sub-pipeline step (not via on_result): expand it.
+      const subPath = resolveRelativePath(step.pipeline, baseDir);
+      const subResult = processFile(subPath, nodes, edges, errors, visited, parentGroupId, depth + 1);
+      if (subResult.firstNodeId) {
+        // Replace the step node with an edge into the sub-pipeline.
+        edges.push({
+          id: `${nodeId}->${subResult.firstNodeId}`,
+          source: nodeId,
+          target: subResult.firstNodeId,
+        });
+      }
+      // The sequential chain continues from the sub-pipeline's last node.
+      prevNodeId = subResult.lastNodeId ?? nodeId;
+    } else {
+      prevNodeId = nodeId;
+    }
+  }
+
+  visited.delete(absPath);
+  return { firstNodeId, lastNodeId: prevNodeId };
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function classifyStep(step: RawStep): StepNodeData['type'] {
+  if (step.id === 'invocation') return 'invocation';
+  if (step.pipeline && !step.prompt) return 'pipeline';
+  if (step.prompt) return 'prompt';
+  if (step.context) return 'context';
+  if (step.action) return 'action';
+  if (step.skill) return 'skill';
+  return 'prompt'; // fallback
+}
+
+function describeMatcher(branch: RawOnResult): string {
+  if (branch.contains) return `contains: "${branch.contains}"`;
+  if (branch.exit_code !== undefined) return `exit_code: ${branch.exit_code}`;
+  if (branch.always) return 'always';
+  return '?';
+}
+
+function resolveRelativePath(ref: string, baseDir: string): string {
+  if (ref.startsWith('/')) return ref;
+  if (ref.startsWith('~/')) return path.join(process.env.HOME ?? '~', ref.slice(2));
+  return path.resolve(baseDir, ref);
+}
+
+/**
+ * Build a map from step id → 0-based line number by scanning for `- id:` patterns.
+ * This is a best-effort heuristic (not a full YAML parser with source maps).
+ */
+function buildLineMap(content: string, _steps: RawStep[]): Map<string, number> {
+  const map = new Map<string, number>();
+  const lines = content.split('\n');
+  const idPattern = /^\s*-\s*id:\s*(.+)$/;
+
+  let stepIdx = 0;
+  for (let lineNo = 0; lineNo < lines.length; lineNo++) {
+    const m = lines[lineNo].match(idPattern);
+    if (m) {
+      const id = m[1].trim().replace(/^["']|["']$/g, '');
+      map.set(id, lineNo);
+      // Also map by index for steps without explicit id matching.
+      map.set(`step_${stepIdx}`, lineNo);
+      stepIdx++;
+    }
+  }
+  return map;
+}

--- a/vscode-ail-chat/src/webview-graph/App.tsx
+++ b/vscode-ail-chat/src/webview-graph/App.tsx
@@ -1,0 +1,181 @@
+/**
+ * App — root component for the pipeline graph webview.
+ *
+ * Receives pipeline graph data from the extension host via postMessage,
+ * lays it out with dagre, and renders it with React Flow.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  useNodesState,
+  useEdgesState,
+  BackgroundVariant,
+  type Node,
+  type Edge,
+  type NodeTypes,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+
+import { StepNode } from './components/StepNode';
+import { DetailPanel } from './components/DetailPanel';
+import { layoutGraph } from './layout';
+import type {
+  GraphHostToWebviewMessage,
+  GraphWebviewToHostMessage,
+  StepNodeData,
+  GraphNode,
+  GraphEdge,
+} from './types';
+
+// ── VS Code API ────────────────────────────────────────────────────────────────
+
+declare function acquireVsCodeApi(): {
+  postMessage: (msg: GraphWebviewToHostMessage) => void;
+  getState: () => unknown;
+  setState: (state: unknown) => void;
+};
+
+const vscode = typeof acquireVsCodeApi !== 'undefined' ? acquireVsCodeApi() : null;
+
+function postToHost(msg: GraphWebviewToHostMessage): void {
+  vscode?.postMessage(msg);
+}
+
+// ── Custom node types ───────────────────────────────────────────────────────
+
+const nodeTypes: NodeTypes = {
+  stepNode: StepNode,
+};
+
+// ── App ─────────────────────────────────────────────────────────────────────
+
+export function App(): React.ReactElement {
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [pipelineName, setPipelineName] = useState<string>('');
+  const [selectedNode, setSelectedNode] = useState<StepNodeData | null>(null);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const applyGraphData = useCallback(
+    (graphNodes: GraphNode[], graphEdges: GraphEdge[], name: string) => {
+      const { nodes: laid, edges: styledEdges } = layoutGraph(graphNodes, graphEdges);
+      setNodes(laid);
+      setEdges(styledEdges);
+      setPipelineName(name);
+      setSelectedNode(null);
+    },
+    [setNodes, setEdges]
+  );
+
+  useEffect(() => {
+    const handler = (event: MessageEvent<GraphHostToWebviewMessage>) => {
+      const msg = event.data;
+      switch (msg.type) {
+        case 'init':
+        case 'update':
+          applyGraphData(msg.data.nodes, msg.data.edges, msg.pipelineName);
+          if (msg.data.errors.length > 0) {
+            setErrors(msg.data.errors);
+          } else {
+            setErrors([]);
+          }
+          break;
+        case 'error':
+          setErrors((prev) => [...prev, msg.message]);
+          break;
+      }
+    };
+
+    window.addEventListener('message', handler);
+    postToHost({ type: 'ready' });
+
+    return () => window.removeEventListener('message', handler);
+  }, [applyGraphData]);
+
+  const onNodeClick = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      const data = node.data as unknown as StepNodeData;
+      setSelectedNode(data);
+    },
+    []
+  );
+
+  const onPaneClick = useCallback(() => {
+    setSelectedNode(null);
+  }, []);
+
+  return (
+    <div style={{ width: '100%', height: '100%', display: 'flex' }}>
+      <div style={{ flex: 1, position: 'relative' }}>
+        {pipelineName && (
+          <div
+            style={{
+              position: 'absolute',
+              top: 8,
+              left: 8,
+              zIndex: 10,
+              padding: '4px 10px',
+              background: 'var(--vscode-badge-background)',
+              color: 'var(--vscode-badge-foreground)',
+              borderRadius: 4,
+              fontSize: 12,
+              fontWeight: 600,
+            }}
+          >
+            {pipelineName}
+          </div>
+        )}
+        {errors.length > 0 && (
+          <div
+            style={{
+              position: 'absolute',
+              top: 8,
+              right: selectedNode ? 308 : 8,
+              zIndex: 10,
+              padding: '6px 10px',
+              background: 'var(--vscode-inputValidation-errorBackground)',
+              border: '1px solid var(--vscode-inputValidation-errorBorder)',
+              color: 'var(--vscode-errorForeground)',
+              borderRadius: 4,
+              fontSize: 11,
+              maxWidth: 300,
+            }}
+          >
+            {errors.map((e, i) => (
+              <div key={i}>{e}</div>
+            ))}
+          </div>
+        )}
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onNodeClick={onNodeClick}
+          onPaneClick={onPaneClick}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.2 }}
+          minZoom={0.1}
+          maxZoom={2}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+          <Controls />
+        </ReactFlow>
+      </div>
+      {selectedNode && (
+        <DetailPanel
+          data={selectedNode}
+          onClose={() => setSelectedNode(null)}
+          onOpenInEditor={(sourceFile, sourceLine) =>
+            postToHost({ type: 'openStepInEditor', sourceFile, sourceLine })
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/vscode-ail-chat/src/webview-graph/App.tsx
+++ b/vscode-ail-chat/src/webview-graph/App.tsx
@@ -125,6 +125,31 @@ export function App(): React.ReactElement {
     [applyLayout]
   );
 
+  const allGroupIds = useMemo(() => {
+    return new Set(
+      fullGraphRef.current.nodes
+        .filter((n) => n.type === 'subPipelineGroup')
+        .map((n) => n.id)
+    );
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  }, [nodes]);
+
+  const expandAll = useCallback(() => {
+    const all = new Set(
+      fullGraphRef.current.nodes
+        .filter((n) => n.type === 'subPipelineGroup')
+        .map((n) => n.id)
+    );
+    setExpandedGroups(all);
+    applyLayout(fullGraphRef.current.nodes, fullGraphRef.current.edges, all);
+  }, [applyLayout]);
+
+  const collapseAll = useCallback(() => {
+    const none = new Set<string>();
+    setExpandedGroups(none);
+    applyLayout(fullGraphRef.current.nodes, fullGraphRef.current.edges, none);
+  }, [applyLayout]);
+
   const onNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
       const data = node.data as unknown as StepNodeData;
@@ -152,6 +177,17 @@ export function App(): React.ReactElement {
     markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
   };
 
+  const toolbarBtnStyle: React.CSSProperties = {
+    background: 'var(--vscode-button-secondaryBackground)',
+    color: 'var(--vscode-button-secondaryForeground)',
+    border: 'none',
+    borderRadius: 3,
+    padding: '3px 8px',
+    fontSize: 11,
+    cursor: 'pointer',
+    fontFamily: 'var(--vscode-font-family)',
+  };
+
   // Memoize node types to include the toggle callback via wrapper.
   const nodeTypes: NodeTypes = useMemo(
     () => ({
@@ -173,24 +209,43 @@ export function App(): React.ReactElement {
   return (
     <div style={{ width: '100%', height: '100%', display: 'flex' }}>
       <div style={{ flex: 1, position: 'relative' }}>
-        {pipelineName && (
-          <div
-            style={{
-              position: 'absolute',
-              top: 8,
-              left: 8,
-              zIndex: 10,
-              padding: '4px 10px',
-              background: 'var(--vscode-badge-background)',
-              color: 'var(--vscode-badge-foreground)',
-              borderRadius: 4,
-              fontSize: 12,
-              fontWeight: 600,
-            }}
-          >
-            {pipelineName}
-          </div>
-        )}
+        {/* Toolbar */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 8,
+            left: 8,
+            zIndex: 10,
+            display: 'flex',
+            gap: 6,
+            alignItems: 'center',
+          }}
+        >
+          {pipelineName && (
+            <div
+              style={{
+                padding: '4px 10px',
+                background: 'var(--vscode-badge-background)',
+                color: 'var(--vscode-badge-foreground)',
+                borderRadius: 4,
+                fontSize: 12,
+                fontWeight: 600,
+              }}
+            >
+              {pipelineName}
+            </div>
+          )}
+          {allGroupIds.size > 0 && (
+            <>
+              <button onClick={expandAll} style={toolbarBtnStyle} title="Expand all sub-pipelines">
+                Expand All
+              </button>
+              <button onClick={collapseAll} style={toolbarBtnStyle} title="Collapse all sub-pipelines">
+                Collapse All
+              </button>
+            </>
+          )}
+        </div>
         {errors.length > 0 && (
           <div
             style={{

--- a/vscode-ail-chat/src/webview-graph/App.tsx
+++ b/vscode-ail-chat/src/webview-graph/App.tsx
@@ -10,9 +10,11 @@ import {
   ReactFlow,
   Background,
   Controls,
+  MiniMap,
   useNodesState,
   useEdgesState,
   BackgroundVariant,
+  MarkerType,
   type Node,
   type Edge,
   type NodeTypes,
@@ -20,6 +22,7 @@ import {
 import '@xyflow/react/dist/style.css';
 
 import { StepNode } from './components/StepNode';
+import { SubPipelineGroupNode } from './components/SubPipelineGroupNode';
 import { DetailPanel } from './components/DetailPanel';
 import { layoutGraph } from './layout';
 import type {
@@ -48,6 +51,7 @@ function postToHost(msg: GraphWebviewToHostMessage): void {
 
 const nodeTypes: NodeTypes = {
   stepNode: StepNode,
+  subPipelineGroup: SubPipelineGroupNode,
 };
 
 // ── App ─────────────────────────────────────────────────────────────────────
@@ -107,6 +111,11 @@ export function App(): React.ReactElement {
     setSelectedNode(null);
   }, []);
 
+  const defaultEdgeOptions = {
+    type: 'smoothstep' as const,
+    markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
+  };
+
   return (
     <div style={{ width: '100%', height: '100%', display: 'flex' }}>
       <div style={{ flex: 1, position: 'relative' }}>
@@ -157,6 +166,7 @@ export function App(): React.ReactElement {
           onNodeClick={onNodeClick}
           onPaneClick={onPaneClick}
           nodeTypes={nodeTypes}
+          defaultEdgeOptions={defaultEdgeOptions}
           fitView
           fitViewOptions={{ padding: 0.2 }}
           minZoom={0.1}
@@ -165,6 +175,11 @@ export function App(): React.ReactElement {
         >
           <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
           <Controls />
+          <MiniMap
+            nodeStrokeWidth={3}
+            style={{ background: 'var(--vscode-sideBar-background)' }}
+            maskColor="rgba(0, 0, 0, 0.2)"
+          />
         </ReactFlow>
       </div>
       {selectedNode && (

--- a/vscode-ail-chat/src/webview-graph/App.tsx
+++ b/vscode-ail-chat/src/webview-graph/App.tsx
@@ -2,10 +2,10 @@
  * App — root component for the pipeline graph webview.
  *
  * Receives pipeline graph data from the extension host via postMessage,
- * lays it out with dagre, and renders it with React Flow.
+ * filters by expansion state, lays it out with dagre, and renders with React Flow.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ReactFlow,
   Background,
@@ -25,6 +25,7 @@ import { StepNode } from './components/StepNode';
 import { SubPipelineGroupNode } from './components/SubPipelineGroupNode';
 import { DetailPanel } from './components/DetailPanel';
 import { layoutGraph } from './layout';
+import { filterByExpansion } from './filterByExpansion';
 import type {
   GraphHostToWebviewMessage,
   GraphWebviewToHostMessage,
@@ -47,13 +48,6 @@ function postToHost(msg: GraphWebviewToHostMessage): void {
   vscode?.postMessage(msg);
 }
 
-// ── Custom node types ───────────────────────────────────────────────────────
-
-const nodeTypes: NodeTypes = {
-  stepNode: StepNode,
-  subPipelineGroup: SubPipelineGroupNode,
-};
-
 // ── App ─────────────────────────────────────────────────────────────────────
 
 export function App(): React.ReactElement {
@@ -62,16 +56,32 @@ export function App(): React.ReactElement {
   const [pipelineName, setPipelineName] = useState<string>('');
   const [selectedNode, setSelectedNode] = useState<StepNodeData | null>(null);
   const [errors, setErrors] = useState<string[]>([]);
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+
+  // Keep full graph data so we can re-filter on expand/collapse.
+  const fullGraphRef = useRef<{ nodes: GraphNode[]; edges: GraphEdge[] }>({ nodes: [], edges: [] });
+
+  const applyLayout = useCallback(
+    (graphNodes: GraphNode[], graphEdges: GraphEdge[], expanded: Set<string>) => {
+      const { nodes: filtered, edges: filteredEdges } = filterByExpansion(graphNodes, graphEdges, expanded);
+      const { nodes: laid, edges: styledEdges } = layoutGraph(filtered, filteredEdges);
+      setNodes(laid);
+      setEdges(styledEdges);
+    },
+    [setNodes, setEdges]
+  );
 
   const applyGraphData = useCallback(
     (graphNodes: GraphNode[], graphEdges: GraphEdge[], name: string) => {
-      const { nodes: laid, edges: styledEdges } = layoutGraph(graphNodes, graphEdges);
-      setNodes(laid);
-      setEdges(styledEdges);
+      fullGraphRef.current = { nodes: graphNodes, edges: graphEdges };
+      // Reset expansion state on new data.
+      const newExpanded = new Set<string>();
+      setExpandedGroups(newExpanded);
+      applyLayout(graphNodes, graphEdges, newExpanded);
       setPipelineName(name);
       setSelectedNode(null);
     },
-    [setNodes, setEdges]
+    [applyLayout]
   );
 
   useEffect(() => {
@@ -99,12 +109,38 @@ export function App(): React.ReactElement {
     return () => window.removeEventListener('message', handler);
   }, [applyGraphData]);
 
+  const toggleGroup = useCallback(
+    (groupId: string) => {
+      setExpandedGroups((prev) => {
+        const next = new Set(prev);
+        if (next.has(groupId)) {
+          next.delete(groupId);
+        } else {
+          next.add(groupId);
+        }
+        applyLayout(fullGraphRef.current.nodes, fullGraphRef.current.edges, next);
+        return next;
+      });
+    },
+    [applyLayout]
+  );
+
   const onNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
       const data = node.data as unknown as StepNodeData;
       setSelectedNode(data);
     },
     []
+  );
+
+  const onNodeDoubleClick = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      // Double-click on group nodes toggles expansion.
+      if (node.type === 'subPipelineGroup') {
+        toggleGroup(node.id);
+      }
+    },
+    [toggleGroup]
   );
 
   const onPaneClick = useCallback(() => {
@@ -115,6 +151,24 @@ export function App(): React.ReactElement {
     type: 'smoothstep' as const,
     markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
   };
+
+  // Memoize node types to include the toggle callback via wrapper.
+  const nodeTypes: NodeTypes = useMemo(
+    () => ({
+      stepNode: StepNode,
+      subPipelineGroup: (props: Record<string, unknown>) => {
+        const nodeProps = props as Parameters<typeof SubPipelineGroupNode>[0];
+        const nodeData = nodeProps.data as unknown as StepNodeData;
+        const nodeId = nodeProps.id as unknown as string;
+        const isExpanded = expandedGroups.has(nodeId);
+        return SubPipelineGroupNode({
+          ...nodeProps,
+          data: { ...nodeData, _expanded: isExpanded, _onToggle: () => toggleGroup(nodeId) } as unknown as typeof nodeProps.data,
+        });
+      },
+    }),
+    [expandedGroups, toggleGroup]
+  );
 
   return (
     <div style={{ width: '100%', height: '100%', display: 'flex' }}>
@@ -164,6 +218,7 @@ export function App(): React.ReactElement {
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           onNodeClick={onNodeClick}
+          onNodeDoubleClick={onNodeDoubleClick}
           onPaneClick={onPaneClick}
           nodeTypes={nodeTypes}
           defaultEdgeOptions={defaultEdgeOptions}

--- a/vscode-ail-chat/src/webview-graph/components/DetailPanel.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/DetailPanel.tsx
@@ -1,0 +1,270 @@
+/**
+ * DetailPanel — right-side panel showing expanded step details.
+ *
+ * Progressive disclosure: shows summary by default, sections expand on click.
+ */
+
+import React, { useState } from 'react';
+import type { StepNodeData } from '../types';
+
+interface DetailPanelProps {
+  data: StepNodeData;
+  onClose: () => void;
+  onOpenInEditor: (sourceFile: string, sourceLine: number) => void;
+}
+
+export function DetailPanel({ data, onClose, onOpenInEditor }: DetailPanelProps): React.ReactElement {
+  return (
+    <div
+      style={{
+        width: 300,
+        borderLeft: '1px solid var(--vscode-panel-border)',
+        background: 'var(--vscode-sideBar-background)',
+        color: 'var(--vscode-sideBar-foreground)',
+        overflow: 'auto',
+        padding: 12,
+        fontSize: 12,
+        fontFamily: 'var(--vscode-font-family)',
+      }}
+    >
+      {/* Header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <strong style={{ fontSize: 14 }}>{data.stepId}</strong>
+        <button
+          onClick={onClose}
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--vscode-icon-foreground)',
+            cursor: 'pointer',
+            fontSize: 16,
+            padding: '2px 6px',
+          }}
+          title="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Type badge */}
+      <div style={{ marginBottom: 12 }}>
+        <TypeBadge type={data.type} />
+        {data.model && (
+          <span
+            style={{
+              marginLeft: 6,
+              background: 'var(--vscode-badge-background)',
+              color: 'var(--vscode-badge-foreground)',
+              borderRadius: 3,
+              padding: '1px 5px',
+              fontSize: 10,
+            }}
+          >
+            {data.model}
+          </span>
+        )}
+      </div>
+
+      {/* Open in Editor link */}
+      <div style={{ marginBottom: 12 }}>
+        <button
+          onClick={() => onOpenInEditor(data.sourceFile, data.sourceLine)}
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--vscode-textLink-foreground)',
+            cursor: 'pointer',
+            padding: 0,
+            fontSize: 11,
+            textDecoration: 'underline',
+          }}
+        >
+          Open in editor →
+        </button>
+        <div style={{ fontSize: 10, color: 'var(--vscode-descriptionForeground)', marginTop: 2 }}>
+          {data.sourceFile.split('/').slice(-2).join('/')}:{data.sourceLine + 1}
+        </div>
+      </div>
+
+      {/* Expandable sections */}
+      {data.prompt && (
+        <ExpandableSection title="Prompt" preview={truncate(data.prompt, 80)}>
+          <pre style={preStyle}>{data.prompt}</pre>
+        </ExpandableSection>
+      )}
+
+      {data.systemPrompt && (
+        <ExpandableSection title="System Prompt" preview={truncate(data.systemPrompt, 60)}>
+          <pre style={preStyle}>{data.systemPrompt}</pre>
+        </ExpandableSection>
+      )}
+
+      {data.appendSystemPromptCount != null && data.appendSystemPromptCount > 0 && (
+        <div style={sectionStyle}>
+          <span style={sectionLabelStyle}>Append System Prompt</span>
+          <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+            {data.appendSystemPromptCount} {data.appendSystemPromptCount === 1 ? 'entry' : 'entries'}
+          </span>
+        </div>
+      )}
+
+      {data.tools && (
+        <ExpandableSection
+          title="Tools"
+          preview={`${data.tools.allow.length} allowed${data.tools.deny.length ? `, ${data.tools.deny.length} denied` : ''}`}
+        >
+          {data.tools.allow.length > 0 && (
+            <div style={{ marginBottom: 4 }}>
+              <strong style={{ fontSize: 10, color: 'var(--vscode-charts-green)' }}>Allow:</strong>
+              <div style={{ paddingLeft: 8 }}>
+                {data.tools.allow.map((t) => (
+                  <div key={t} style={{ fontSize: 11 }}>{t}</div>
+                ))}
+              </div>
+            </div>
+          )}
+          {data.tools.deny.length > 0 && (
+            <div>
+              <strong style={{ fontSize: 10, color: 'var(--vscode-charts-red)' }}>Deny:</strong>
+              <div style={{ paddingLeft: 8 }}>
+                {data.tools.deny.map((t) => (
+                  <div key={t} style={{ fontSize: 11 }}>{t}</div>
+                ))}
+              </div>
+            </div>
+          )}
+        </ExpandableSection>
+      )}
+
+      {data.onResultCount != null && data.onResultCount > 0 && (
+        <div style={sectionStyle}>
+          <span style={sectionLabelStyle}>on_result</span>
+          <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+            {data.onResultCount} {data.onResultCount === 1 ? 'branch' : 'branches'}
+          </span>
+        </div>
+      )}
+
+      {data.subPipelinePath && (
+        <div style={sectionStyle}>
+          <span style={sectionLabelStyle}>Sub-pipeline</span>
+          <span style={{ color: 'var(--vscode-descriptionForeground)', fontSize: 11 }}>
+            {data.subPipelinePath}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+function TypeBadge({ type }: { type: StepNodeData['type'] }): React.ReactElement {
+  const colors: Record<string, string> = {
+    invocation: 'var(--vscode-charts-purple, #a855f7)',
+    prompt: 'var(--vscode-charts-blue, #3b82f6)',
+    context: 'var(--vscode-charts-green, #22c55e)',
+    pipeline: 'var(--vscode-charts-orange, #f97316)',
+    action: 'var(--vscode-charts-yellow, #eab308)',
+    skill: 'var(--vscode-charts-red, #ef4444)',
+  };
+  return (
+    <span
+      style={{
+        background: colors[type] ?? colors.prompt,
+        color: '#fff',
+        borderRadius: 3,
+        padding: '2px 6px',
+        fontSize: 10,
+        fontWeight: 600,
+        textTransform: 'uppercase',
+      }}
+    >
+      {type}
+    </span>
+  );
+}
+
+function ExpandableSection({
+  title,
+  preview,
+  children,
+}: {
+  title: string;
+  preview: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div style={{ ...sectionStyle, flexDirection: 'column', alignItems: 'stretch' }}>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          color: 'var(--vscode-editor-foreground)',
+          cursor: 'pointer',
+          padding: 0,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          width: '100%',
+          textAlign: 'left',
+        }}
+      >
+        <span style={sectionLabelStyle}>{title}</span>
+        <span style={{ fontSize: 10, color: 'var(--vscode-descriptionForeground)' }}>
+          {expanded ? '▾' : '▸'}
+        </span>
+      </button>
+      {!expanded && (
+        <div
+          style={{
+            color: 'var(--vscode-descriptionForeground)',
+            fontSize: 11,
+            marginTop: 2,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {preview}
+        </div>
+      )}
+      {expanded && <div style={{ marginTop: 4 }}>{children}</div>}
+    </div>
+  );
+}
+
+// ── Styles ──────────────────────────────────────────────────────────────────
+
+const sectionStyle: React.CSSProperties = {
+  padding: '8px 0',
+  borderBottom: '1px solid var(--vscode-panel-border)',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+};
+
+const sectionLabelStyle: React.CSSProperties = {
+  fontWeight: 600,
+  fontSize: 11,
+  color: 'var(--vscode-editor-foreground)',
+};
+
+const preStyle: React.CSSProperties = {
+  background: 'var(--vscode-textCodeBlock-background)',
+  padding: 8,
+  borderRadius: 4,
+  fontSize: 11,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  maxHeight: 200,
+  overflow: 'auto',
+  margin: 0,
+};
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) + '…' : text;
+}

--- a/vscode-ail-chat/src/webview-graph/components/DetailPanel.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/DetailPanel.tsx
@@ -2,10 +2,12 @@
  * DetailPanel — right-side panel showing expanded step details.
  *
  * Progressive disclosure: shows summary by default, sections expand on click.
+ * P3: rich content for on_result branches, append_system_prompt entries,
+ * shell commands, action kinds, conditions, and file path detection.
  */
 
 import React, { useState } from 'react';
-import type { StepNodeData } from '../types';
+import type { StepNodeData, OnResultBranch, AppendSystemPromptEntry } from '../types';
 
 interface DetailPanelProps {
   data: StepNodeData;
@@ -32,52 +34,26 @@ export function DetailPanel({ data, onClose, onOpenInEditor }: DetailPanelProps)
         <strong style={{ fontSize: 14 }}>{data.stepId}</strong>
         <button
           onClick={onClose}
-          style={{
-            background: 'transparent',
-            border: 'none',
-            color: 'var(--vscode-icon-foreground)',
-            cursor: 'pointer',
-            fontSize: 16,
-            padding: '2px 6px',
-          }}
+          style={closeBtnStyle}
           title="Close"
         >
           ✕
         </button>
       </div>
 
-      {/* Type badge */}
-      <div style={{ marginBottom: 12 }}>
+      {/* Type badge + model + condition */}
+      <div style={{ marginBottom: 12, display: 'flex', flexWrap: 'wrap', gap: 4, alignItems: 'center' }}>
         <TypeBadge type={data.type} />
-        {data.model && (
-          <span
-            style={{
-              marginLeft: 6,
-              background: 'var(--vscode-badge-background)',
-              color: 'var(--vscode-badge-foreground)',
-              borderRadius: 3,
-              padding: '1px 5px',
-              fontSize: 10,
-            }}
-          >
-            {data.model}
-          </span>
-        )}
+        {data.model && <Badge text={data.model} />}
+        {data.condition === 'never' && <Badge text="skipped" color="var(--vscode-charts-yellow, #eab308)" />}
+        {data.resume && <Badge text="resume" color="var(--vscode-charts-green, #22c55e)" />}
       </div>
 
       {/* Open in Editor link */}
       <div style={{ marginBottom: 12 }}>
         <button
           onClick={() => onOpenInEditor(data.sourceFile, data.sourceLine)}
-          style={{
-            background: 'transparent',
-            border: 'none',
-            color: 'var(--vscode-textLink-foreground)',
-            cursor: 'pointer',
-            padding: 0,
-            fontSize: 11,
-            textDecoration: 'underline',
-          }}
+          style={linkBtnStyle}
         >
           Open in editor →
         </button>
@@ -86,28 +62,58 @@ export function DetailPanel({ data, onClose, onOpenInEditor }: DetailPanelProps)
         </div>
       </div>
 
-      {/* Expandable sections */}
+      {/* Prompt */}
       {data.prompt && (
-        <ExpandableSection title="Prompt" preview={truncate(data.prompt, 80)}>
-          <pre style={preStyle}>{data.prompt}</pre>
+        <ExpandableSection
+          title="Prompt"
+          preview={data.promptIsFile ? data.prompt : truncate(data.prompt, 80)}
+          icon={data.promptIsFile ? 'file' : 'text'}
+        >
+          {data.promptIsFile ? (
+            <div style={filePathStyle}>{data.prompt}</div>
+          ) : (
+            <pre style={preStyle}>{data.prompt}</pre>
+          )}
         </ExpandableSection>
       )}
 
+      {/* System Prompt */}
       {data.systemPrompt && (
-        <ExpandableSection title="System Prompt" preview={truncate(data.systemPrompt, 60)}>
-          <pre style={preStyle}>{data.systemPrompt}</pre>
+        <ExpandableSection
+          title="System Prompt"
+          preview={data.systemPromptIsFile ? data.systemPrompt : truncate(data.systemPrompt, 60)}
+          icon={data.systemPromptIsFile ? 'file' : 'text'}
+        >
+          {data.systemPromptIsFile ? (
+            <div style={filePathStyle}>{data.systemPrompt}</div>
+          ) : (
+            <pre style={preStyle}>{data.systemPrompt}</pre>
+          )}
         </ExpandableSection>
       )}
 
-      {data.appendSystemPromptCount != null && data.appendSystemPromptCount > 0 && (
-        <div style={sectionStyle}>
-          <span style={sectionLabelStyle}>Append System Prompt</span>
-          <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
-            {data.appendSystemPromptCount} {data.appendSystemPromptCount === 1 ? 'entry' : 'entries'}
-          </span>
-        </div>
+      {/* Append System Prompt */}
+      {data.appendSystemPromptEntries && data.appendSystemPromptEntries.length > 0 && (
+        <ExpandableSection
+          title="Append System Prompt"
+          preview={`${data.appendSystemPromptEntries.length} ${data.appendSystemPromptEntries.length === 1 ? 'entry' : 'entries'}`}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {data.appendSystemPromptEntries.map((entry, i) => (
+              <AppendEntryRow key={i} entry={entry} />
+            ))}
+          </div>
+        </ExpandableSection>
       )}
 
+      {/* Shell Command (context steps) */}
+      {data.shellCommand && (
+        <ExpandableSection title="Shell Command" preview={truncate(data.shellCommand.trim(), 60)}>
+          <pre style={preStyle}>{data.shellCommand}</pre>
+        </ExpandableSection>
+      )}
+
+      {/* Tools */}
       {data.tools && (
         <ExpandableSection
           title="Tools"
@@ -115,20 +121,20 @@ export function DetailPanel({ data, onClose, onOpenInEditor }: DetailPanelProps)
         >
           {data.tools.allow.length > 0 && (
             <div style={{ marginBottom: 4 }}>
-              <strong style={{ fontSize: 10, color: 'var(--vscode-charts-green)' }}>Allow:</strong>
-              <div style={{ paddingLeft: 8 }}>
+              <strong style={{ fontSize: 10, color: 'var(--vscode-charts-green, #22c55e)' }}>Allow:</strong>
+              <div style={toolListStyle}>
                 {data.tools.allow.map((t) => (
-                  <div key={t} style={{ fontSize: 11 }}>{t}</div>
+                  <span key={t} style={toolChipStyle}>{t}</span>
                 ))}
               </div>
             </div>
           )}
           {data.tools.deny.length > 0 && (
             <div>
-              <strong style={{ fontSize: 10, color: 'var(--vscode-charts-red)' }}>Deny:</strong>
-              <div style={{ paddingLeft: 8 }}>
+              <strong style={{ fontSize: 10, color: 'var(--vscode-charts-red, #ef4444)' }}>Deny:</strong>
+              <div style={toolListStyle}>
                 {data.tools.deny.map((t) => (
-                  <div key={t} style={{ fontSize: 11 }}>{t}</div>
+                  <span key={t} style={{ ...toolChipStyle, borderColor: 'var(--vscode-charts-red, #ef4444)' }}>{t}</span>
                 ))}
               </div>
             </div>
@@ -136,15 +142,36 @@ export function DetailPanel({ data, onClose, onOpenInEditor }: DetailPanelProps)
         </ExpandableSection>
       )}
 
-      {data.onResultCount != null && data.onResultCount > 0 && (
+      {/* on_result branches */}
+      {data.onResultBranches && data.onResultBranches.length > 0 && (
+        <ExpandableSection
+          title="on_result"
+          preview={`${data.onResultBranches.length} ${data.onResultBranches.length === 1 ? 'branch' : 'branches'}`}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {data.onResultBranches.map((branch, i) => (
+              <OnResultRow key={i} branch={branch} />
+            ))}
+          </div>
+        </ExpandableSection>
+      )}
+
+      {/* Action kind */}
+      {data.actionKind && (
         <div style={sectionStyle}>
-          <span style={sectionLabelStyle}>on_result</span>
-          <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
-            {data.onResultCount} {data.onResultCount === 1 ? 'branch' : 'branches'}
-          </span>
+          <span style={sectionLabelStyle}>Action</span>
+          <Badge text={data.actionKind} color="var(--vscode-charts-yellow, #eab308)" />
         </div>
       )}
 
+      {/* HITL Message */}
+      {data.message && (
+        <ExpandableSection title="HITL Message" preview={truncate(data.message, 60)}>
+          <pre style={preStyle}>{data.message}</pre>
+        </ExpandableSection>
+      )}
+
+      {/* Sub-pipeline path */}
       {data.subPipelinePath && (
         <div style={sectionStyle}>
           <span style={sectionLabelStyle}>Sub-pipeline</span>
@@ -154,6 +181,7 @@ export function DetailPanel({ data, onClose, onOpenInEditor }: DetailPanelProps)
         </div>
       )}
 
+      {/* Group step count */}
       {data.isSubPipelineGroup && data.childStepCount != null && (
         <div style={sectionStyle}>
           <span style={sectionLabelStyle}>Steps</span>
@@ -194,13 +222,116 @@ function TypeBadge({ type }: { type: StepNodeData['type'] }): React.ReactElement
   );
 }
 
+function Badge({ text, color }: { text: string; color?: string }): React.ReactElement {
+  return (
+    <span
+      style={{
+        background: color ?? 'var(--vscode-badge-background)',
+        color: color ? '#fff' : 'var(--vscode-badge-foreground)',
+        borderRadius: 3,
+        padding: '1px 5px',
+        fontSize: 10,
+        fontWeight: 500,
+      }}
+    >
+      {text}
+    </span>
+  );
+}
+
+function OnResultRow({ branch }: { branch: OnResultBranch }): React.ReactElement {
+  return (
+    <div
+      style={{
+        background: 'var(--vscode-textCodeBlock-background)',
+        borderRadius: 4,
+        padding: '6px 8px',
+        fontSize: 11,
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 4 }}>
+        <span style={{ color: 'var(--vscode-charts-orange, #f97316)', fontWeight: 600 }}>
+          {branch.matcher}
+        </span>
+        <span style={{ color: 'var(--vscode-descriptionForeground)', fontSize: 10, flexShrink: 0 }}>
+          → {branch.action}
+        </span>
+      </div>
+      {branch.prompt && (
+        <div
+          style={{
+            marginTop: 3,
+            color: 'var(--vscode-descriptionForeground)',
+            fontSize: 10,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          prompt: {branch.prompt}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AppendEntryRow({ entry }: { entry: AppendSystemPromptEntry }): React.ReactElement {
+  const typeIcons: Record<string, string> = { text: 'T', file: 'F', shell: '$' };
+  const typeColors: Record<string, string> = {
+    text: 'var(--vscode-charts-blue, #3b82f6)',
+    file: 'var(--vscode-charts-orange, #f97316)',
+    shell: 'var(--vscode-charts-green, #22c55e)',
+  };
+  return (
+    <div
+      style={{
+        background: 'var(--vscode-textCodeBlock-background)',
+        borderRadius: 4,
+        padding: '4px 8px',
+        fontSize: 11,
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 6,
+      }}
+    >
+      <span
+        style={{
+          background: typeColors[entry.type] ?? typeColors.text,
+          color: '#fff',
+          borderRadius: 2,
+          padding: '0 4px',
+          fontSize: 9,
+          fontWeight: 700,
+          flexShrink: 0,
+          marginTop: 1,
+        }}
+      >
+        {typeIcons[entry.type] ?? '?'}
+      </span>
+      <span
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: entry.value.includes('\n') ? 'pre-wrap' : 'nowrap',
+          maxHeight: 60,
+          color: 'var(--vscode-editor-foreground)',
+        }}
+      >
+        {truncate(entry.value.trim(), 120)}
+      </span>
+    </div>
+  );
+}
+
 function ExpandableSection({
   title,
   preview,
+  icon,
   children,
 }: {
   title: string;
   preview: string;
+  icon?: 'file' | 'text';
   children: React.ReactNode;
 }): React.ReactElement {
   const [expanded, setExpanded] = useState(false);
@@ -222,7 +353,10 @@ function ExpandableSection({
           textAlign: 'left',
         }}
       >
-        <span style={sectionLabelStyle}>{title}</span>
+        <span style={{ ...sectionLabelStyle, display: 'flex', alignItems: 'center', gap: 4 }}>
+          {title}
+          {icon === 'file' && <span style={{ fontSize: 9, color: 'var(--vscode-charts-orange, #f97316)' }}>file</span>}
+        </span>
         <span style={{ fontSize: 10, color: 'var(--vscode-descriptionForeground)' }}>
           {expanded ? '▾' : '▸'}
         </span>
@@ -272,6 +406,49 @@ const preStyle: React.CSSProperties = {
   maxHeight: 200,
   overflow: 'auto',
   margin: 0,
+};
+
+const filePathStyle: React.CSSProperties = {
+  background: 'var(--vscode-textCodeBlock-background)',
+  padding: '6px 8px',
+  borderRadius: 4,
+  fontSize: 11,
+  fontFamily: 'var(--vscode-editor-font-family, monospace)',
+  color: 'var(--vscode-charts-orange, #f97316)',
+};
+
+const toolListStyle: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 3,
+  paddingTop: 3,
+};
+
+const toolChipStyle: React.CSSProperties = {
+  fontSize: 10,
+  padding: '1px 5px',
+  borderRadius: 3,
+  border: '1px solid var(--vscode-panel-border)',
+  background: 'var(--vscode-textCodeBlock-background)',
+};
+
+const closeBtnStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  color: 'var(--vscode-icon-foreground)',
+  cursor: 'pointer',
+  fontSize: 16,
+  padding: '2px 6px',
+};
+
+const linkBtnStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  color: 'var(--vscode-textLink-foreground)',
+  cursor: 'pointer',
+  padding: 0,
+  fontSize: 11,
+  textDecoration: 'underline',
 };
 
 function truncate(text: string, max: number): string {

--- a/vscode-ail-chat/src/webview-graph/components/DetailPanel.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/DetailPanel.tsx
@@ -153,6 +153,15 @@ export function DetailPanel({ data, onClose, onOpenInEditor }: DetailPanelProps)
           </span>
         </div>
       )}
+
+      {data.isSubPipelineGroup && data.childStepCount != null && (
+        <div style={sectionStyle}>
+          <span style={sectionLabelStyle}>Steps</span>
+          <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+            {data.childStepCount} {data.childStepCount === 1 ? 'step' : 'steps'}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/vscode-ail-chat/src/webview-graph/components/StepNode.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/StepNode.tsx
@@ -1,0 +1,100 @@
+/**
+ * StepNode — custom React Flow node for a pipeline step.
+ *
+ * Collapsed view: shows step ID + type badge.
+ * Click to select → detail panel opens on the right.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import type { StepNodeData } from '../types';
+
+const TYPE_COLORS: Record<StepNodeData['type'], string> = {
+  invocation: 'var(--vscode-charts-purple, #a855f7)',
+  prompt: 'var(--vscode-charts-blue, #3b82f6)',
+  context: 'var(--vscode-charts-green, #22c55e)',
+  pipeline: 'var(--vscode-charts-orange, #f97316)',
+  action: 'var(--vscode-charts-yellow, #eab308)',
+  skill: 'var(--vscode-charts-red, #ef4444)',
+};
+
+const TYPE_LABELS: Record<StepNodeData['type'], string> = {
+  invocation: 'INV',
+  prompt: 'PRM',
+  context: 'CTX',
+  pipeline: 'SUB',
+  action: 'ACT',
+  skill: 'SKL',
+};
+
+function StepNodeInner({ data }: NodeProps): React.ReactElement {
+  const nodeData = data as unknown as StepNodeData;
+  const color = TYPE_COLORS[nodeData.type] ?? 'var(--vscode-charts-blue)';
+  const label = TYPE_LABELS[nodeData.type] ?? '?';
+
+  return (
+    <div
+      style={{
+        background: 'var(--vscode-editor-background)',
+        border: `2px solid ${color}`,
+        borderRadius: 8,
+        padding: '8px 12px',
+        minWidth: 160,
+        maxWidth: 220,
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        fontSize: 12,
+        fontFamily: 'var(--vscode-font-family)',
+        color: 'var(--vscode-editor-foreground)',
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ background: color }} />
+
+      <span
+        style={{
+          background: color,
+          color: '#fff',
+          borderRadius: 3,
+          padding: '1px 5px',
+          fontSize: 9,
+          fontWeight: 700,
+          letterSpacing: '0.5px',
+          flexShrink: 0,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          fontWeight: 500,
+        }}
+      >
+        {nodeData.stepId}
+      </span>
+      {nodeData.onResultCount != null && nodeData.onResultCount > 0 && (
+        <span
+          style={{
+            marginLeft: 'auto',
+            background: 'var(--vscode-badge-background)',
+            color: 'var(--vscode-badge-foreground)',
+            borderRadius: 8,
+            padding: '0 5px',
+            fontSize: 9,
+            flexShrink: 0,
+          }}
+        >
+          {nodeData.onResultCount}
+        </span>
+      )}
+
+      <Handle type="source" position={Position.Bottom} style={{ background: color }} />
+    </div>
+  );
+}
+
+export const StepNode = memo(StepNodeInner);

--- a/vscode-ail-chat/src/webview-graph/components/StepNode.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/StepNode.tsx
@@ -2,6 +2,7 @@
  * StepNode — custom React Flow node for a pipeline step.
  *
  * Collapsed view: shows step ID + type badge.
+ * Invocation nodes get a distinct double-border diamond-corner style.
  * Click to select → detail panel opens on the right.
  */
 
@@ -27,19 +28,22 @@ const TYPE_LABELS: Record<StepNodeData['type'], string> = {
   skill: 'SKL',
 };
 
-function StepNodeInner({ data }: NodeProps): React.ReactElement {
+function StepNodeInner({ data, selected }: NodeProps): React.ReactElement {
   const nodeData = data as unknown as StepNodeData;
   const color = TYPE_COLORS[nodeData.type] ?? 'var(--vscode-charts-blue)';
   const label = TYPE_LABELS[nodeData.type] ?? '?';
+  const isInvocation = nodeData.type === 'invocation';
 
   return (
     <div
       style={{
-        background: 'var(--vscode-editor-background)',
+        background: isInvocation
+          ? 'var(--vscode-editor-background)'
+          : 'var(--vscode-editor-background)',
         border: `2px solid ${color}`,
-        borderRadius: 8,
-        padding: '8px 12px',
-        minWidth: 160,
+        borderRadius: isInvocation ? 12 : 8,
+        padding: isInvocation ? '10px 16px' : '8px 12px',
+        minWidth: isInvocation ? 180 : 160,
         maxWidth: 220,
         cursor: 'pointer',
         display: 'flex',
@@ -48,16 +52,22 @@ function StepNodeInner({ data }: NodeProps): React.ReactElement {
         fontSize: 12,
         fontFamily: 'var(--vscode-font-family)',
         color: 'var(--vscode-editor-foreground)',
+        boxShadow: isInvocation
+          ? `0 0 0 3px var(--vscode-editor-background), 0 0 0 5px ${color}`
+          : selected
+            ? `0 0 0 2px ${color}40`
+            : 'none',
+        transition: 'box-shadow 0.15s ease',
       }}
     >
-      <Handle type="target" position={Position.Top} style={{ background: color }} />
+      <Handle type="target" position={Position.Top} style={{ background: color, width: 8, height: 8 }} />
 
       <span
         style={{
           background: color,
           color: '#fff',
           borderRadius: 3,
-          padding: '1px 5px',
+          padding: '2px 6px',
           fontSize: 9,
           fontWeight: 700,
           letterSpacing: '0.5px',
@@ -71,7 +81,8 @@ function StepNodeInner({ data }: NodeProps): React.ReactElement {
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
-          fontWeight: 500,
+          fontWeight: isInvocation ? 700 : 500,
+          fontSize: isInvocation ? 13 : 12,
         }}
       >
         {nodeData.stepId}
@@ -80,19 +91,21 @@ function StepNodeInner({ data }: NodeProps): React.ReactElement {
         <span
           style={{
             marginLeft: 'auto',
-            background: 'var(--vscode-badge-background)',
-            color: 'var(--vscode-badge-foreground)',
+            background: 'var(--vscode-charts-orange, #f97316)',
+            color: '#fff',
             borderRadius: 8,
             padding: '0 5px',
             fontSize: 9,
+            fontWeight: 600,
             flexShrink: 0,
           }}
+          title={`${nodeData.onResultCount} on_result branches`}
         >
           {nodeData.onResultCount}
         </span>
       )}
 
-      <Handle type="source" position={Position.Bottom} style={{ background: color }} />
+      <Handle type="source" position={Position.Bottom} style={{ background: color, width: 8, height: 8 }} />
     </div>
   );
 }

--- a/vscode-ail-chat/src/webview-graph/components/SubPipelineGroupNode.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/SubPipelineGroupNode.tsx
@@ -1,0 +1,83 @@
+/**
+ * SubPipelineGroupNode — a container node representing an expanded sub-pipeline.
+ *
+ * Rendered as a labeled card with the pipeline name and step count.
+ * Edges connect to this node; the inner steps are laid out as regular nodes
+ * that visually sit "inside" the group via indented positioning.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import type { StepNodeData } from '../types';
+
+function SubPipelineGroupNodeInner({ data }: NodeProps): React.ReactElement {
+  const nodeData = data as unknown as StepNodeData;
+  const color = 'var(--vscode-charts-orange, #f97316)';
+
+  return (
+    <div
+      style={{
+        background: 'var(--vscode-editor-background)',
+        border: `2px dashed ${color}`,
+        borderRadius: 10,
+        padding: '8px 14px',
+        minWidth: 160,
+        maxWidth: 240,
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        fontSize: 12,
+        fontFamily: 'var(--vscode-font-family)',
+        color: 'var(--vscode-editor-foreground)',
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ background: color, width: 8, height: 8 }} />
+
+      <span
+        style={{
+          background: color,
+          color: '#fff',
+          borderRadius: 3,
+          padding: '2px 6px',
+          fontSize: 9,
+          fontWeight: 700,
+          letterSpacing: '0.5px',
+          flexShrink: 0,
+        }}
+      >
+        SUB
+      </span>
+      <span
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          fontWeight: 600,
+        }}
+      >
+        {nodeData.pipelineName ?? nodeData.stepId}
+      </span>
+      {nodeData.childStepCount != null && (
+        <span
+          style={{
+            marginLeft: 'auto',
+            background: 'var(--vscode-badge-background)',
+            color: 'var(--vscode-badge-foreground)',
+            borderRadius: 8,
+            padding: '0 5px',
+            fontSize: 9,
+            flexShrink: 0,
+          }}
+          title={`${nodeData.childStepCount} steps`}
+        >
+          {nodeData.childStepCount}
+        </span>
+      )}
+
+      <Handle type="source" position={Position.Bottom} style={{ background: color, width: 8, height: 8 }} />
+    </div>
+  );
+}
+
+export const SubPipelineGroupNode = memo(SubPipelineGroupNodeInner);

--- a/vscode-ail-chat/src/webview-graph/components/SubPipelineGroupNode.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/SubPipelineGroupNode.tsx
@@ -1,18 +1,25 @@
 /**
- * SubPipelineGroupNode — a container node representing an expanded sub-pipeline.
+ * SubPipelineGroupNode — a container node representing a sub-pipeline.
  *
- * Rendered as a labeled card with the pipeline name and step count.
- * Edges connect to this node; the inner steps are laid out as regular nodes
- * that visually sit "inside" the group via indented positioning.
+ * When collapsed (default): shows pipeline name + step count. Double-click or
+ * click the toggle button to expand and reveal child steps.
+ * When expanded: the group node is hidden and child steps are shown inline.
  */
 
 import React, { memo } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import type { StepNodeData } from '../types';
 
+interface GroupNodeExtras {
+  _expanded?: boolean;
+  _onToggle?: () => void;
+}
+
 function SubPipelineGroupNodeInner({ data }: NodeProps): React.ReactElement {
-  const nodeData = data as unknown as StepNodeData;
+  const nodeData = data as unknown as StepNodeData & GroupNodeExtras;
   const color = 'var(--vscode-charts-orange, #f97316)';
+  const isExpanded = nodeData._expanded ?? false;
+  const onToggle = nodeData._onToggle;
 
   return (
     <div
@@ -21,8 +28,8 @@ function SubPipelineGroupNodeInner({ data }: NodeProps): React.ReactElement {
         border: `2px dashed ${color}`,
         borderRadius: 10,
         padding: '8px 14px',
-        minWidth: 160,
-        maxWidth: 240,
+        minWidth: 170,
+        maxWidth: 260,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
@@ -33,6 +40,29 @@ function SubPipelineGroupNodeInner({ data }: NodeProps): React.ReactElement {
       }}
     >
       <Handle type="target" position={Position.Top} style={{ background: color, width: 8, height: 8 }} />
+
+      {/* Expand/collapse toggle */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle?.();
+        }}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          color: 'var(--vscode-icon-foreground)',
+          cursor: 'pointer',
+          padding: 0,
+          fontSize: 11,
+          lineHeight: 1,
+          flexShrink: 0,
+          width: 14,
+          textAlign: 'center',
+        }}
+        title={isExpanded ? 'Collapse sub-pipeline' : 'Expand sub-pipeline'}
+      >
+        {isExpanded ? '▾' : '▸'}
+      </button>
 
       <span
         style={{

--- a/vscode-ail-chat/src/webview-graph/filterByExpansion.ts
+++ b/vscode-ail-chat/src/webview-graph/filterByExpansion.ts
@@ -1,0 +1,111 @@
+/**
+ * filterByExpansion — given the full graph and a set of expanded group IDs,
+ * returns only the nodes and edges that should be visible.
+ *
+ * Collapsed groups: hide child nodes, hide internal edges, keep the group
+ * node itself as the edge target/source. Edges that pointed to a child
+ * of a collapsed group are redirected to the group node.
+ *
+ * Expanded groups: the group node is hidden, child nodes are shown directly.
+ */
+
+import type { GraphNode, GraphEdge } from './types';
+
+export function filterByExpansion(
+  allNodes: GraphNode[],
+  allEdges: GraphEdge[],
+  expandedGroups: Set<string>
+): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  // Build lookup: groupId → child node IDs
+  const groupChildren = new Map<string, Set<string>>();
+  // Build lookup: nodeId → its parentId (group)
+  const nodeParent = new Map<string, string>();
+
+  // Collect all group node IDs
+  const groupNodeIds = new Set<string>();
+  for (const node of allNodes) {
+    if (node.type === 'subPipelineGroup') {
+      groupNodeIds.add(node.id);
+      if (!groupChildren.has(node.id)) {
+        groupChildren.set(node.id, new Set());
+      }
+    }
+  }
+
+  // Map children to their groups
+  for (const node of allNodes) {
+    if (node.parentId && groupNodeIds.has(node.parentId)) {
+      groupChildren.get(node.parentId)!.add(node.id);
+      nodeParent.set(node.id, node.parentId);
+    }
+  }
+
+  // Determine which nodes are hidden (children of collapsed groups)
+  const hiddenNodes = new Set<string>();
+  for (const [groupId, children] of groupChildren) {
+    if (!expandedGroups.has(groupId)) {
+      // Group is collapsed — hide all children
+      for (const childId of children) {
+        hiddenNodes.add(childId);
+      }
+    } else {
+      // Group is expanded — hide the group node itself
+      hiddenNodes.add(groupId);
+    }
+  }
+
+  // Filter nodes
+  const visibleNodes = allNodes.filter((n) => !hiddenNodes.has(n.id));
+
+  // Remap edges: if an edge points to/from a hidden node, redirect to its group
+  const visibleNodeIds = new Set(visibleNodes.map((n) => n.id));
+  const remappedEdges: GraphEdge[] = [];
+  const seenEdgeKeys = new Set<string>();
+
+  for (const edge of allEdges) {
+    let source = edge.source;
+    let target = edge.target;
+
+    // Redirect source if it's a hidden child → point from its group
+    if (hiddenNodes.has(source)) {
+      const parent = nodeParent.get(source);
+      if (parent && visibleNodeIds.has(parent)) {
+        source = parent;
+      } else {
+        continue; // Both endpoints hidden, skip
+      }
+    }
+
+    // Redirect target if it's a hidden child → point to its group
+    if (hiddenNodes.has(target)) {
+      const parent = nodeParent.get(target);
+      if (parent && visibleNodeIds.has(parent)) {
+        target = parent;
+      } else {
+        continue;
+      }
+    }
+
+    // Skip self-loops created by remapping
+    if (source === target) continue;
+
+    // Skip if both endpoints are not visible
+    if (!visibleNodeIds.has(source) || !visibleNodeIds.has(target)) continue;
+
+    // Deduplicate edges (remapping can create duplicates)
+    const key = `${source}->${target}::${edge.label ?? ''}`;
+    if (seenEdgeKeys.has(key)) continue;
+    seenEdgeKeys.add(key);
+
+    remappedEdges.push({
+      ...edge,
+      id: source === edge.source && target === edge.target
+        ? edge.id
+        : `${source}->${target}::${edge.label ?? ''}`,
+      source,
+      target,
+    });
+  }
+
+  return { nodes: visibleNodes, edges: remappedEdges };
+}

--- a/vscode-ail-chat/src/webview-graph/index.tsx
+++ b/vscode-ail-chat/src/webview-graph/index.tsx
@@ -1,0 +1,13 @@
+/**
+ * Graph webview entry point — mounts the React Flow pipeline visualizer.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  const root = createRoot(rootEl);
+  root.render(<App />);
+}

--- a/vscode-ail-chat/src/webview-graph/layout.ts
+++ b/vscode-ail-chat/src/webview-graph/layout.ts
@@ -3,11 +3,13 @@
  */
 
 import Dagre from '@dagrejs/dagre';
-import type { Node, Edge } from '@xyflow/react';
+import type { Node, Edge, MarkerType } from '@xyflow/react';
 import type { GraphNode, GraphEdge, StepNodeData } from './types';
 
 const NODE_WIDTH = 200;
 const NODE_HEIGHT = 60;
+const GROUP_NODE_WIDTH = 220;
+const GROUP_NODE_HEIGHT = 52;
 
 export function layoutGraph(
   graphNodes: GraphNode[],
@@ -17,14 +19,18 @@ export function layoutGraph(
   g.setDefaultEdgeLabel(() => ({}));
   g.setGraph({
     rankdir: 'TB',
-    nodesep: 40,
-    ranksep: 80,
+    nodesep: 50,
+    ranksep: 70,
     marginx: 20,
     marginy: 20,
   });
 
   for (const node of graphNodes) {
-    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+    const isGroup = node.type === 'subPipelineGroup';
+    g.setNode(node.id, {
+      width: isGroup ? GROUP_NODE_WIDTH : NODE_WIDTH,
+      height: isGroup ? GROUP_NODE_HEIGHT : NODE_HEIGHT,
+    });
   }
 
   for (const edge of graphEdges) {
@@ -35,12 +41,15 @@ export function layoutGraph(
 
   const nodes: Node[] = graphNodes.map((node) => {
     const pos = g.node(node.id);
+    const isGroup = node.type === 'subPipelineGroup';
+    const w = isGroup ? GROUP_NODE_WIDTH : NODE_WIDTH;
+    const h = isGroup ? GROUP_NODE_HEIGHT : NODE_HEIGHT;
     return {
       id: node.id,
-      type: 'stepNode',
+      type: node.type,
       position: {
-        x: (pos?.x ?? 0) - NODE_WIDTH / 2,
-        y: (pos?.y ?? 0) - NODE_HEIGHT / 2,
+        x: (pos?.x ?? 0) - w / 2,
+        y: (pos?.y ?? 0) - h / 2,
       },
       data: node.data as StepNodeData & Record<string, unknown>,
     };
@@ -53,12 +62,16 @@ export function layoutGraph(
     label: edge.label,
     type: 'smoothstep',
     animated: edge.conditional,
+    markerEnd: { type: 'arrowclosed' as unknown as MarkerType, width: 16, height: 16 },
     style: edge.conditional
-      ? { stroke: 'var(--vscode-charts-orange)', strokeDasharray: '5 3' }
-      : { stroke: 'var(--vscode-charts-blue)' },
-    labelStyle: edge.conditional
-      ? { fill: 'var(--vscode-charts-orange)', fontSize: 10, fontWeight: 500 }
+      ? { stroke: 'var(--vscode-charts-orange, #f97316)', strokeWidth: 2, strokeDasharray: '6 3' }
+      : { stroke: 'var(--vscode-charts-blue, #3b82f6)', strokeWidth: 2 },
+    labelStyle: { fontSize: 10, fontWeight: 600, fontFamily: 'var(--vscode-font-family)' },
+    labelBgStyle: edge.conditional
+      ? { fill: 'var(--vscode-editor-background)', fillOpacity: 0.9 }
       : undefined,
+    labelBgPadding: [4, 2] as [number, number],
+    labelBgBorderRadius: 3,
   }));
 
   return { nodes, edges };

--- a/vscode-ail-chat/src/webview-graph/layout.ts
+++ b/vscode-ail-chat/src/webview-graph/layout.ts
@@ -1,0 +1,65 @@
+/**
+ * layout — positions nodes using dagre (top-to-bottom DAG layout).
+ */
+
+import Dagre from '@dagrejs/dagre';
+import type { Node, Edge } from '@xyflow/react';
+import type { GraphNode, GraphEdge, StepNodeData } from './types';
+
+const NODE_WIDTH = 200;
+const NODE_HEIGHT = 60;
+
+export function layoutGraph(
+  graphNodes: GraphNode[],
+  graphEdges: GraphEdge[]
+): { nodes: Node[]; edges: Edge[] } {
+  const g = new Dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({
+    rankdir: 'TB',
+    nodesep: 40,
+    ranksep: 80,
+    marginx: 20,
+    marginy: 20,
+  });
+
+  for (const node of graphNodes) {
+    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  }
+
+  for (const edge of graphEdges) {
+    g.setEdge(edge.source, edge.target);
+  }
+
+  Dagre.layout(g);
+
+  const nodes: Node[] = graphNodes.map((node) => {
+    const pos = g.node(node.id);
+    return {
+      id: node.id,
+      type: 'stepNode',
+      position: {
+        x: (pos?.x ?? 0) - NODE_WIDTH / 2,
+        y: (pos?.y ?? 0) - NODE_HEIGHT / 2,
+      },
+      data: node.data as StepNodeData & Record<string, unknown>,
+    };
+  });
+
+  const edges: Edge[] = graphEdges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    label: edge.label,
+    type: 'smoothstep',
+    animated: edge.conditional,
+    style: edge.conditional
+      ? { stroke: 'var(--vscode-charts-orange)', strokeDasharray: '5 3' }
+      : { stroke: 'var(--vscode-charts-blue)' },
+    labelStyle: edge.conditional
+      ? { fill: 'var(--vscode-charts-orange)', fontSize: 10, fontWeight: 500 }
+      : undefined,
+  }));
+
+  return { nodes, edges };
+}

--- a/vscode-ail-chat/src/webview-graph/types.ts
+++ b/vscode-ail-chat/src/webview-graph/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared types between the graph webview and the extension host.
+ * These mirror the types in pipeline-graph/graphTransform.ts and
+ * pipeline-graph/PipelineGraphPanel.ts but are defined here so the
+ * webview bundle doesn't import from Node-only code.
+ */
+
+export interface StepNodeData {
+  stepId: string;
+  type: 'prompt' | 'context' | 'pipeline' | 'action' | 'skill' | 'invocation';
+  pipelineName?: string;
+  sourceFile: string;
+  sourceLine: number;
+  prompt?: string;
+  systemPrompt?: string;
+  appendSystemPromptCount?: number;
+  tools?: { allow: string[]; deny: string[] };
+  model?: string;
+  onResultCount?: number;
+  subPipelinePath?: string;
+  isSubPipelineGroup?: boolean;
+  branchLabel?: string;
+}
+
+export interface GraphNode {
+  id: string;
+  type: 'stepNode' | 'subPipelineGroup';
+  position: { x: number; y: number };
+  data: StepNodeData;
+  parentId?: string;
+}
+
+export interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+  conditional?: boolean;
+}
+
+export interface TransformResult {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  errors: string[];
+}
+
+/** Messages from the extension host to the graph webview. */
+export type GraphHostToWebviewMessage =
+  | { type: 'init'; data: TransformResult; pipelinePath: string; pipelineName: string }
+  | { type: 'update'; data: TransformResult; pipelinePath: string; pipelineName: string }
+  | { type: 'error'; message: string };
+
+/** Messages from the graph webview to the extension host. */
+export type GraphWebviewToHostMessage =
+  | { type: 'ready' }
+  | { type: 'openStepInEditor'; sourceFile: string; sourceLine: number };

--- a/vscode-ail-chat/src/webview-graph/types.ts
+++ b/vscode-ail-chat/src/webview-graph/types.ts
@@ -5,6 +5,19 @@
  * webview bundle doesn't import from Node-only code.
  */
 
+/** Describes one on_result branch for display in the detail panel. */
+export interface OnResultBranch {
+  matcher: string;
+  action: string;
+  prompt?: string;
+}
+
+/** Describes one append_system_prompt entry. */
+export interface AppendSystemPromptEntry {
+  type: 'text' | 'file' | 'shell';
+  value: string;
+}
+
 export interface StepNodeData {
   stepId: string;
   type: 'prompt' | 'context' | 'pipeline' | 'action' | 'skill' | 'invocation';
@@ -12,15 +25,33 @@ export interface StepNodeData {
   sourceFile: string;
   sourceLine: number;
   prompt?: string;
+  /** Whether the prompt value is a file path (starts with ./, ../, ~/, or /). */
+  promptIsFile?: boolean;
   systemPrompt?: string;
+  /** Whether system_prompt is a file path. */
+  systemPromptIsFile?: boolean;
   appendSystemPromptCount?: number;
+  /** Detailed append_system_prompt entries for display. */
+  appendSystemPromptEntries?: AppendSystemPromptEntry[];
   tools?: { allow: string[]; deny: string[] };
   model?: string;
   onResultCount?: number;
+  /** Detailed on_result branches for display. */
+  onResultBranches?: OnResultBranch[];
   subPipelinePath?: string;
   isSubPipelineGroup?: boolean;
   branchLabel?: string;
   childStepCount?: number;
+  /** For context steps: the shell command. */
+  shellCommand?: string;
+  /** For action steps: the action kind. */
+  actionKind?: string;
+  /** Step condition (always/never). */
+  condition?: string;
+  /** Whether this step resumes a previous session. */
+  resume?: boolean;
+  /** HITL gate message. */
+  message?: string;
 }
 
 export interface GraphNode {

--- a/vscode-ail-chat/src/webview-graph/types.ts
+++ b/vscode-ail-chat/src/webview-graph/types.ts
@@ -20,6 +20,7 @@ export interface StepNodeData {
   subPipelinePath?: string;
   isSubPipelineGroup?: boolean;
   branchLabel?: string;
+  childStepCount?: number;
 }
 
 export interface GraphNode {


### PR DESCRIPTION
## Summary
Adds a new pipeline graph visualizer feature that converts AIL pipeline YAML files into an interactive React Flow graph view. Open via `Cmd+Shift+P` → "ail Chat: Open Pipeline Graph".

## What's included (P0 + P1 + P2)

### P0 — Foundation
- **`graphTransform.ts`**: Pure function that parses pipeline YAML and recursively expands sub-pipelines into React Flow nodes/edges (cycle detection, max depth 16)
- **`PipelineGraphPanel.ts`**: Singleton WebviewPanel host with file watchers for auto-refresh on YAML edits
- **Webview React app**: `App.tsx`, `StepNode.tsx`, `DetailPanel.tsx`, dagre auto-layout
- **Command**: `ail-chat.openPipelineGraph` (auto-detects active `.ail.yaml` or prompts file picker)
- Second esbuild entry point (`dist/graphWebview.js`) — fully standalone from the chat webview

### P1 — Polish
- **Distinct invocation node**: double-border, larger, bold text
- **Sub-pipeline group nodes**: dashed orange border with step count badge
- **Deduplication**: multiple `on_result` branches pointing to the same `.ail.yaml` share one group node
- **Edge arrows**: `MarkerType.ArrowClosed` on all edges; conditional edges are dashed orange with labels
- **MiniMap** for navigating large graphs
- **Selected node glow** effect

### P2 — Collapse/Expand Sub-Pipelines
- Sub-pipeline groups start **collapsed by default** (pipeline name + step count badge)
- **Double-click** or **toggle button** (▸/▾) expands to show child steps inline
- **`filterByExpansion.ts`**: pure function that filters nodes/edges based on expansion state, with edge remapping and deduplication
- When collapsed, edges to/from child nodes redirect to the group node
- When expanded, the group node hides and child steps appear directly

### Detail Panel (progressive disclosure)
Click any node → right-side panel shows:
- Type badge + model override
- "Open in editor" link (jumps to exact YAML line)
- Expandable: Prompt, System Prompt, Tools (allow/deny), on_result branch count, sub-pipeline path, child step count

## Architecture
- **Standalone**: zero modifications to existing chat webview (`src/webview/`)
- **Integration-ready**: chat ↔ graph communication via extension host message broker (future phase)
- **New dependencies**: `@xyflow/react`, `@dagrejs/dagre`, `yaml`

## Test plan
- [ ] `npm run build` produces `dist/graphWebview.js` + `dist/graphWebview.css`
- [ ] `npm run lint` clean
- [ ] `npm test` — 139 tests pass, no regressions
- [ ] F5 → open oh-my-ail workspace → Cmd+Shift+P → "Open Pipeline Graph"
- [ ] Invocation node with 5 conditional branches → 4 collapsed sub-pipeline groups (EXPLICIT and fallback share one)
- [ ] Double-click a group node → expands to show child steps with edges
- [ ] Double-click again → collapses back
- [ ] Click a node → detail panel opens; "Open in editor" jumps to correct line
- [ ] Edit `.ail.yaml` → graph auto-refreshes
- [ ] MiniMap visible and navigable

https://claude.ai/code/session_01DnyPdcQmtDv3E5W6A3Ezi2