### PR TITLE
Canonicalize paths to resolve symlinks for consistent hashing

### DIFF
--- a/ail-core/src/session/log_provider.rs
+++ b/ail-core/src/session/log_provider.rs
@@ -18,10 +18,13 @@ pub trait LogProvider: Send {
 
 /// SHA-1 hex digest of the current working directory path.
 /// Used to partition project data under `~/.ail/projects/<hash>/` (SPEC §4.4).
+/// Canonicalizes to resolve symlinks so that equivalent paths (e.g. macOS
+/// `/tmp/foo` vs `/private/tmp/foo`) produce the same hash.
 pub fn cwd_hash() -> String {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let canonical = cwd.canonicalize().unwrap_or(cwd);
     let mut hasher = Sha1::new();
-    hasher.update(cwd.to_string_lossy().as_bytes());
+    hasher.update(canonical.to_string_lossy().as_bytes());
     format!("{:x}", hasher.finalize())
 }
 

--- a/ail-core/tests/spec/s03_file_format.rs
+++ b/ail-core/tests/spec/s03_file_format.rs
@@ -22,14 +22,17 @@ mod s3_1_discovery {
     #[test]
     fn falls_back_to_ail_yaml_in_cwd() {
         let tmp = tempfile::tempdir().unwrap();
-        let ail_yaml = tmp.path().join(".ail.yaml");
+        // Canonicalize to resolve symlinks (macOS: /tmp -> /private/tmp) so the
+        // expected path matches what current_dir() returns inside discover().
+        let tmp_path = tmp.path().canonicalize().unwrap();
+        let ail_yaml = tmp_path.join(".ail.yaml");
         std::fs::write(
             &ail_yaml,
             "version: \"0.0.1\"\npipeline:\n  - id: s\n    prompt: x\n",
         )
         .unwrap();
         let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(tmp.path()).unwrap();
+        std::env::set_current_dir(&tmp_path).unwrap();
         let result = discover(None);
         std::env::set_current_dir(original_dir).unwrap();
         // Discovery now returns absolute paths so parent() is always usable (SPEC §9).


### PR DESCRIPTION
## Summary
This PR fixes path handling to canonicalize filesystem paths before hashing and comparison, ensuring that symlinked paths (particularly on macOS where `/tmp` is a symlink to `/private/tmp`) are treated consistently.

## Key Changes
- **`cwd_hash()` function**: Now canonicalizes the current working directory before hashing to ensure equivalent paths produce the same hash, regardless of symlink resolution
- **`falls_back_to_ail_yaml_in_cwd()` test**: Updated to canonicalize the temporary directory path before use, ensuring the expected path matches what `current_dir()` returns inside the `discover()` function

## Implementation Details
- The canonicalization gracefully falls back to the original path if canonicalization fails (`unwrap_or`)
- This ensures that project data partitioning under `~/.ail/projects/<hash>/` (per SPEC §4.4) works correctly even when the working directory is accessed through symlinks
- The test fix resolves a platform-specific issue where macOS's `/tmp` symlink could cause path mismatches during discovery

https://claude.ai/code/session_01MRNDvov8MSn9pLJYcGyLBY