### PR TITLE
Improve VS Code theme integration for React Flow components

### DIFF
--- a/vscode-ail-chat/src/pipeline-graph/PipelineGraphPanel.ts
+++ b/vscode-ail-chat/src/pipeline-graph/PipelineGraphPanel.ts
@@ -212,6 +212,27 @@ export class PipelineGraphPanel {
       color: var(--vscode-editor-foreground);
       font-family: var(--vscode-font-family);
     }
+    /* React Flow Controls — match VS Code theme */
+    .react-flow__controls-button {
+      background: var(--vscode-button-secondaryBackground) !important;
+      border-color: var(--vscode-panel-border) !important;
+      fill: var(--vscode-button-secondaryForeground) !important;
+    }
+    .react-flow__controls-button:hover {
+      background: var(--vscode-button-secondaryHoverBackground) !important;
+    }
+    /* React Flow MiniMap — theme-aware mask */
+    .react-flow__minimap-mask {
+      fill: var(--vscode-sideBar-background) !important;
+      fill-opacity: 0.8 !important;
+    }
+    /* React Flow edge labels — ensure theme foreground */
+    .react-flow__edge-textbg {
+      fill: var(--vscode-editor-background) !important;
+    }
+    .react-flow__edge-text {
+      fill: var(--vscode-editor-foreground) !important;
+    }
   </style>
 </head>
 <body>

--- a/vscode-ail-chat/src/webview-graph/App.tsx
+++ b/vscode-ail-chat/src/webview-graph/App.tsx
@@ -290,12 +290,11 @@ export function App(): React.ReactElement {
           maxZoom={2}
           proOptions={{ hideAttribution: true }}
         >
-          <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+          <Background variant={BackgroundVariant.Dots} gap={16} size={1} color="var(--vscode-panel-border)" />
           <Controls />
           <MiniMap
             nodeStrokeWidth={3}
             style={{ background: 'var(--vscode-sideBar-background)' }}
-            maskColor="rgba(0, 0, 0, 0.2)"
           />
         </ReactFlow>
       </div>

--- a/vscode-ail-chat/src/webview-graph/components/DetailPanel.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/DetailPanel.tsx
@@ -209,7 +209,7 @@ function TypeBadge({ type }: { type: StepNodeData['type'] }): React.ReactElement
     <span
       style={{
         background: colors[type] ?? colors.prompt,
-        color: '#fff',
+        color: 'var(--vscode-button-foreground, #fff)',
         borderRadius: 3,
         padding: '2px 6px',
         fontSize: 10,
@@ -227,7 +227,7 @@ function Badge({ text, color }: { text: string; color?: string }): React.ReactEl
     <span
       style={{
         background: color ?? 'var(--vscode-badge-background)',
-        color: color ? '#fff' : 'var(--vscode-badge-foreground)',
+        color: color ? 'var(--vscode-button-foreground, #fff)' : 'var(--vscode-badge-foreground)',
         borderRadius: 3,
         padding: '1px 5px',
         fontSize: 10,
@@ -297,7 +297,7 @@ function AppendEntryRow({ entry }: { entry: AppendSystemPromptEntry }): React.Re
       <span
         style={{
           background: typeColors[entry.type] ?? typeColors.text,
-          color: '#fff',
+          color: 'var(--vscode-button-foreground, #fff)',
           borderRadius: 2,
           padding: '0 4px',
           fontSize: 9,

--- a/vscode-ail-chat/src/webview-graph/components/StepNode.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/StepNode.tsx
@@ -65,7 +65,7 @@ function StepNodeInner({ data, selected }: NodeProps): React.ReactElement {
       <span
         style={{
           background: color,
-          color: '#fff',
+          color: 'var(--vscode-button-foreground, #fff)',
           borderRadius: 3,
           padding: '2px 6px',
           fontSize: 9,
@@ -92,7 +92,7 @@ function StepNodeInner({ data, selected }: NodeProps): React.ReactElement {
           style={{
             marginLeft: 'auto',
             background: 'var(--vscode-charts-orange, #f97316)',
-            color: '#fff',
+            color: 'var(--vscode-button-foreground, #fff)',
             borderRadius: 8,
             padding: '0 5px',
             fontSize: 9,

--- a/vscode-ail-chat/src/webview-graph/components/SubPipelineGroupNode.tsx
+++ b/vscode-ail-chat/src/webview-graph/components/SubPipelineGroupNode.tsx
@@ -67,7 +67,7 @@ function SubPipelineGroupNodeInner({ data }: NodeProps): React.ReactElement {
       <span
         style={{
           background: color,
-          color: '#fff',
+          color: 'var(--vscode-button-foreground, #fff)',
           borderRadius: 3,
           padding: '2px 6px',
           fontSize: 9,

--- a/vscode-ail-chat/src/webview-graph/layout.ts
+++ b/vscode-ail-chat/src/webview-graph/layout.ts
@@ -78,7 +78,7 @@ export function layoutGraph(
     style: edge.conditional
       ? { stroke: 'var(--vscode-charts-orange, #f97316)', strokeWidth: 2, strokeDasharray: '6 3' }
       : { stroke: 'var(--vscode-charts-blue, #3b82f6)', strokeWidth: 2 },
-    labelStyle: { fontSize: 10, fontWeight: 600, fontFamily: 'var(--vscode-font-family)' },
+    labelStyle: { fontSize: 10, fontWeight: 600, fontFamily: 'var(--vscode-font-family)', fill: 'var(--vscode-editor-foreground)' },
     labelBgStyle: edge.conditional
       ? { fill: 'var(--vscode-editor-background)', fillOpacity: 0.9 }
       : undefined,


### PR DESCRIPTION
## Summary
This PR enhances the theming of React Flow components to better match VS Code's native design system by replacing hardcoded colors with CSS variables and adding missing theme-aware styling for controls, minimap, and edge labels.

## Key Changes
- **PipelineGraphPanel.ts**: Added comprehensive CSS styling for React Flow controls, minimap, and edge labels using VS Code theme variables
  - Controls button styling with secondary button colors and hover states
  - MiniMap mask with theme-aware background and opacity
  - Edge label text and background colors matching the editor theme

- **DetailPanel.tsx, StepNode.tsx, SubPipelineGroupNode.tsx**: Replaced hardcoded `#fff` text colors with `var(--vscode-button-foreground, #fff)` for better theme consistency across badges and type indicators

- **App.tsx**: 
  - Updated Background component to use `var(--vscode-panel-border)` for dots color instead of default
  - Removed hardcoded `maskColor` from MiniMap to allow CSS styling to take precedence

- **layout.ts**: Added `fill` property to edge label styles using `var(--vscode-editor-foreground)` for proper text color in different themes

## Implementation Details
All changes use VS Code CSS variables with appropriate fallbacks to ensure compatibility. The approach maintains backward compatibility while providing a more cohesive visual experience that respects user theme preferences.

https://claude.ai/code/session_01HpfHmS5LKwvkZzmaYEAqat