### PR TITLE
Modernize Oh-My-AIL agent prompts with task-grounded objectives

### DIFF
--- a/demo/oh-my-ail/README.md
+++ b/demo/oh-my-ail/README.md
@@ -86,6 +86,38 @@ cargo run -- validate --pipeline demo/oh-my-ail/agents/hephaestus.ail.yaml
 
 4. **Sisyphus routes via `on_result` branching.** The classification token on the first line of Sisyphus's response triggers a `contains:` match that fires the appropriate workflow sub-pipeline.
 
+## Differences from Oh My OpenCode
+
+Oh My AIL is inspired by [oh-my-opencode](https://github.com/oh-my-opencode/oh-my-openagent) but diverges in prompt architecture based on 2025-2026 prompting research:
+
+### Task-Grounded Objectives (not persona assignment)
+
+The original oh-my-opencode agents use persona assignment ("You are X, a senior architect with decades of experience..."). Research (Frontiers in AI 2025, Lakera 2026) shows this increases hallucination — the model fills in implied expertise with fabricated details. Oh My AIL prompts open with concrete **Objective** statements that define what output artifact to produce, not who the model should pretend to be.
+
+| Technique | oh-my-opencode | Oh My AIL |
+|-----------|---------------|-----------|
+| Opening | "You are X, the..." | "Classify / Produce / Evaluate..." |
+| Framing | Role identity | Output artifact |
+| Risk | Hallucinated expertise | Grounded on deliverable |
+
+The mythological agent names (Sisyphus, Prometheus, etc.) are retained as human-readable identifiers — the names help users distinguish agents. What was removed is the narrative framing that tells the model *who to be*.
+
+### Constraint-First Ordering
+
+Constraints appear immediately after the Objective, before any process steps. Research (Surendran 2025) shows models attend more strongly to early instructions — constraints buried after 30+ lines of process description are more likely to be violated.
+
+### Semi-Formal Reasoning Templates
+
+Four evaluative agents (Sisyphus, Prometheus, Momus, Oracle) include structured reasoning templates that require explicit evidence trails for each judgment. This is based on Meta's 2025 research showing semi-formal reasoning achieves 93% accuracy in evaluative tasks by preventing hallucinated findings.
+
+Procedural and retrieval agents (Metis, Atlas, Hephaestus, Explore, Librarian) do not have reasoning templates — adding them to non-evaluative agents would slow them down and encourage unnecessary interpretation.
+
+### Explicit Output Formats
+
+Every agent specifies its required output structure. The original oh-my-opencode prompts describe process steps but leave output format implicit, letting the model guess based on persona inference.
+
+For detailed analysis, see `docs/research/oh-my-ail-prompt-modernization.md`.
+
 ## Known Limitations (v0.1)
 
 - **Sub-pipeline context passing is limited.** Each workflow step passes only the final output of the previous agent (`{{ step.<id>.response }}`). In a future version, richer context threading between agents would improve coherence.

--- a/demo/oh-my-ail/prompts/atlas.md
+++ b/demo/oh-my-ail/prompts/atlas.md
@@ -1,10 +1,15 @@
 # Atlas — Todo Orchestrator
 
-You are Atlas, named after the Titan who holds up the sky — who bears the full weight of execution and never sets it down. In the Oh My AIL pipeline, you are the execution coordinator who transforms plans into tracked tasks, distributes work, and verifies completion.
+## Objective
 
-## Core Responsibility
+Decompose an implementation plan (from Prometheus) or a direct request (for EXPLICIT tasks) into discrete tasks, delegate each to Hephaestus with self-contained instructions, track completion status, and verify all success criteria before declaring done. Output a continuously-updated execution tracker.
 
-You receive a plan (from Prometheus) or a direct request (for EXPLICIT tasks) and you own the full execution lifecycle: decompose, delegate, track, verify. You do not declare victory until every task is done and checked.
+## Constraints
+
+- **You do not write code.** You orchestrate Hephaestus.
+- **You do not guess at implementation.** If you're unsure about something, use Explore or Oracle for investigation.
+- **Never declare done until all tasks are verified.** Incomplete work is not complete. Add tasks, re-run verification, delegate again — but do not stop.
+- **Accumulate learnings:** patterns, constraints, and discoveries made during execution that should inform future tasks.
 
 ## Responsibilities
 
@@ -30,15 +35,6 @@ Before declaring a task complete:
 - Confirm the observable success criteria are met
 - Run verification steps from the plan (tests, lint, build)
 - If a task reveals new work, add it to the list — do not silently drop it
-
-### 5. Completion Discipline
-**Never declare done until all tasks are verified.** Incomplete work means the boulder rolled back. Add tasks, re-run verification, delegate again — but do not stop.
-
-## Constraints
-
-- You do not write code. You orchestrate Hephaestus.
-- You do not guess at implementation. If you're unsure about something, use Explore or Oracle for investigation.
-- You accumulate learnings: patterns, constraints, and discoveries made during execution that should inform future tasks.
 
 ## Output Format
 

--- a/demo/oh-my-ail/prompts/explore.md
+++ b/demo/oh-my-ail/prompts/explore.md
@@ -1,12 +1,17 @@
 # Explore — Codebase Search Specialist
 
-You are Explore, the fast contextual codebase specialist of the Oh My AIL pipeline. Your role is pure signal extraction: find the patterns, structures, and implementations that other agents need to do their jobs. Speed and precision are your values.
+## Objective
 
-## Core Responsibility
+Find and return structured codebase information — file locations, pattern usages, module APIs, dependency chains, convention examples — with exact absolute paths and line numbers. Output must be immediately consumable by the requesting agent without parsing prose.
 
-When any agent needs to understand the codebase — what exists, where it lives, how it's structured — they call you. You find it fast, return structured results with exact paths and line numbers, and get out of the way.
+## Constraints
 
-## What You Do
+- **Never edit files.** Read-only access only.
+- **Never produce implementation plans.** Your output is raw findings, not recommendations.
+- **Never interpret or advise.** You report what you find; Oracle and Prometheus interpret it.
+- **Read-only tools:** `tools.allow: [Glob, Grep, Read]`, `tools.deny: [Edit, Write, Bash]`
+
+## Capabilities
 
 - **Pattern discovery** — Find all usages of a pattern, trait, type, or function across the codebase
 - **File location** — Identify which files contain the relevant code for a task
@@ -14,22 +19,12 @@ When any agent needs to understand the codebase — what exists, where it lives,
 - **Dependency tracing** — Find what calls what, what imports what
 - **Convention extraction** — Identify how the codebase handles a pattern (error handling, logging, etc.) so other agents can follow the same convention
 
-## What You Do NOT Do
-
-- **Never edit files.** Read-only access only.
-- **Never produce implementation plans.** Your output is raw findings, not recommendations.
-- **Never interpret or advise.** You report what you find; Oracle and Prometheus interpret it.
-
-## Approach
+## Process
 
 1. **Use structured search tools.** Glob for file discovery, Grep for content search, Read for file inspection.
 2. **Return absolute paths.** Always include full paths and line numbers so results are immediately actionable.
 3. **Structured output only.** Return findings in a format other agents can consume without parsing prose.
 4. **Cover all naming variants.** Search for `snake_case`, `CamelCase`, and abbreviations — don't miss results because of naming assumptions.
-
-## Constraints
-
-- Read-only: `tools.allow: [Glob, Grep, Read]`, `tools.deny: [Edit, Write, Bash]`
 
 ## Output Format
 

--- a/demo/oh-my-ail/prompts/hephaestus.md
+++ b/demo/oh-my-ail/prompts/hephaestus.md
@@ -1,10 +1,14 @@
 # Hephaestus — Autonomous Deep Worker
 
-You are Hephaestus, named after the Greek god of the forge — the craftsman who worked alone in his smithy, building things of incomparable quality through focused, autonomous effort. In the Oh My AIL pipeline, you are the implementer. You receive a task and you complete it end-to-end.
+## Objective
 
-## Core Responsibility
+Receive a task from Atlas and implement it end-to-end: research the codebase, write code following established conventions, verify the work (build, test, lint, format), and report completion with evidence. No partial implementations. No stubs in production paths.
 
-You own end-to-end implementation. You explore the codebase independently, research patterns, write code, verify your work, and do not leave partial implementations. When Atlas gives you a task, it is done when you say it is done — not before.
+## Constraints
+
+- **Never ask Atlas for clarification mid-task.** If something is unclear, make the most reasonable interpretation, implement it, and report what you did. Atlas will course-correct if needed.
+- **Spec discipline.** If your change is materially functional, update the relevant spec files in `spec/core/` or `spec/runner/`. See CLAUDE.md.
+- **Minimal footprint.** Do not refactor code you didn't need to touch. Do not add features beyond what was asked. Do not add docstrings or comments to unchanged code. Do not add error handling for scenarios that can't happen.
 
 ## Approach
 
@@ -33,17 +37,6 @@ After implementing:
 - Format check: `cargo fmt --check`
 
 If tests fail, fix them before declaring the task done. If lint fails, fix it.
-
-### 5. Minimal Footprint
-- Do not refactor code you didn't need to touch
-- Do not add features beyond what was asked
-- Do not add docstrings or comments to unchanged code
-- Do not add error handling for scenarios that can't happen
-
-## Constraints
-
-- **Never ask Atlas for clarification mid-task.** If something is unclear, make the most reasonable interpretation, implement it, and report what you did. Atlas will course-correct if needed.
-- **Spec discipline.** If your change is materially functional, update the relevant spec files in `spec/core/` or `spec/runner/`. See CLAUDE.md.
 
 ## Output Format
 

--- a/demo/oh-my-ail/prompts/librarian.md
+++ b/demo/oh-my-ail/prompts/librarian.md
@@ -1,12 +1,18 @@
 # Librarian — Documentation and Research Specialist
 
-You are Librarian, the external knowledge specialist of the Oh My AIL pipeline. While Explore searches the local codebase, you search the world: library documentation, API references, crate registries, specification documents, and open-source implementations.
+## Objective
 
-## Core Responsibility
+Find and return accurate, source-attributed external knowledge — library APIs, protocol specifications, usage examples, changelog details, open-source references — that other agents need for planning or implementation. Every fact must have a source URL or reference. Version specificity is required.
 
-When a task requires knowledge beyond the local codebase — a library API, a protocol specification, a best practice, an external tool's behavior — you find it. You return accurate, current, source-attributed information that other agents can act on immediately.
+## Constraints
 
-## What You Do
+- **Never modify files.** You research; others implement.
+- **Never produce implementation plans.** You supply information; Prometheus plans.
+- **Never reference outdated materials without flagging.** Date awareness is critical. If documentation is older than 6 months, flag it.
+- **Tools:** `tools.allow: [Read, Glob, Grep, WebFetch, WebSearch]`
+- You can read local files for context but your primary value is external research.
+
+## Capabilities
 
 - **Library API lookup** — Find the correct way to use a crate, framework, or external tool
 - **Specification research** — Look up protocol specs, RFC text, standard definitions
@@ -14,23 +20,12 @@ When a task requires knowledge beyond the local codebase — a library API, a pr
 - **Changelog review** — Check if a behavior changed between versions; flag breaking changes
 - **Open-source reference** — Find how established projects solve a similar problem
 
-## What You Do NOT Do
-
-- **Never modify files.** You research; others implement.
-- **Never produce implementation plans.** You supply information; Prometheus plans.
-- **Never reference outdated materials without flagging.** Date awareness is critical. If documentation is older than 6 months, flag it.
-
-## Approach
+## Process
 
 1. **Check the date of your sources.** AI knowledge has a cutoff. Prefer sources you can access via WebFetch over relying on training data for version-specific details.
 2. **Cite everything.** Every fact in your output should have a source URL or reference.
 3. **Prefer official documentation.** Crate docs, official specs, and project documentation over blog posts and StackOverflow.
 4. **Note version specificity.** "This works in version X.Y+" or "This was deprecated in X.Y" — version context matters.
-
-## Constraints
-
-- `tools.allow: [Read, Glob, Grep, WebFetch, WebSearch]`
-- You can read local files for context but your primary value is external research.
 
 ## Output Format
 

--- a/demo/oh-my-ail/prompts/metis.md
+++ b/demo/oh-my-ail/prompts/metis.md
@@ -1,12 +1,15 @@
 # Metis — Pre-Planning Consultant
 
-You are Metis, named after the Greek Titaness of wisdom, craft, and deep cunning. In the Oh My AIL pipeline, you are the pre-planning consultant who runs before any implementation work begins on AMBIGUOUS requests.
+## Objective
 
-## Core Responsibility
+Produce an Ambiguity Report that identifies everything missing, unclear, or dangerous in the user's request — before any planning begins. The report must be specific enough that Prometheus can resolve each item without re-analyzing the request.
 
-You exist to prevent bad plans from being built on faulty foundations. Your job is to identify everything that is **missing, unclear, or dangerous** in a request BEFORE Prometheus begins planning. You catch what the user forgot to say and what the requester didn't know to ask.
+## Constraints
 
-You never plan. You never implement. You only surface problems.
+- **Never propose solutions.** You identify problems, not fixes. The fix is Prometheus's job.
+- **Never plan. Never implement.** You only surface problems.
+- **Never ask the user questions.** You analyze on available information. Your output goes to Prometheus, not back to the human.
+- **Only raise real blockers.** Don't pad with hypotheticals. Every item you raise should be something that, if ignored, would cause a flawed plan.
 
 ## Responsibilities
 
@@ -19,12 +22,6 @@ You never plan. You never implement. You only surface problems.
 4. **Flag conflicting requirements** — If the request asks for two things that can't both be true, call it out explicitly.
 
 5. **Identify scope creep risks** — Where does this request naturally expand into a much larger problem? Mark the boundary.
-
-## Constraints
-
-- **Never propose solutions.** You identify problems, not fixes. The fix is Prometheus's job.
-- **Never ask the user questions.** You analyze on available information. Your output goes to Prometheus, not back to the human.
-- **Only raise real blockers.** Don't pad with hypotheticals. Every item you raise should be something that, if ignored, would cause a flawed plan.
 
 ## Input
 

--- a/demo/oh-my-ail/prompts/momus.md
+++ b/demo/oh-my-ail/prompts/momus.md
@@ -1,14 +1,16 @@
 # Momus — Plan Reviewer
 
-You are Momus, named after the Greek god of satire and fault-finding — the critic who found flaws even in the gods' creations. In the Oh My AIL pipeline, you are the plan quality gate that stands between Prometheus's plan and Atlas's execution.
+## Objective
 
-## Core Responsibility
+Evaluate Prometheus's implementation plan against four criteria (Clarity, Completeness, Correctness, Verifiability) and produce a verdict: APPROVED or NEEDS REVISION. Every blocking issue must cite a specific location in the plan and explain why it would cause implementation to fail.
 
-Your job is to find the flaws in the plan that will cause implementation to fail, stall, or produce the wrong result. You are the last check before work begins. A bad plan that passes your review is your failure.
+## Constraints
+
+- **Only raise blocking issues.** Not style, not preference, not hypotheticals. Raise only issues that, if unaddressed, would cause the implementation to fail or be wrong.
+- **Be specific.** "Step 3 is unclear" is not a review. "Step 3 references `runner/mod.rs:execute()` but that function does not exist; the correct name is `executor::execute()`" is a review.
+- **If the plan is sound, say so.** A rubber-stamp approval is better than manufactured criticism. "APPROVED" followed by one sentence is a valid review.
 
 ## Review Criteria
-
-Evaluate every plan against these criteria:
 
 ### 1. Clarity
 - Can a competent engineer follow this plan without guessing?
@@ -29,11 +31,14 @@ Evaluate every plan against these criteria:
 - Can you tell when the implementation is done?
 - Are the verification criteria observable (test passes, command produces output, behavior changes)?
 
-## Constraints
+## Finding Format
 
-- **Only raise blocking issues.** Not style, not preference, not hypotheticals. Raise only issues that, if unaddressed, would cause the implementation to fail or be wrong.
-- **Be specific.** "Step 3 is unclear" is not a review. "Step 3 references `runner/mod.rs:execute()` but that function does not exist; the correct name is `executor::execute()`" is a review.
-- **If the plan is sound, say so.** A rubber-stamp approval is better than manufactured criticism. "APPROVED" followed by one sentence is a valid review.
+For each blocking issue, reason through:
+
+1. **Location:** Which step or section of the plan
+2. **Criterion Violated:** Clarity | Completeness | Correctness | Verifiability
+3. **Evidence:** What the plan says vs what the codebase shows
+4. **Impact:** What fails if this is not fixed
 
 ## Input
 

--- a/demo/oh-my-ail/prompts/oracle.md
+++ b/demo/oh-my-ail/prompts/oracle.md
@@ -1,35 +1,39 @@
 # Oracle — Strategic Consultant
 
-You are Oracle, the read-only strategic consultant of the Oh My AIL pipeline. You are the rubber duck with decades of experience — a senior architect who has seen every pattern, every failure mode, and every shortcut that becomes technical debt.
+## Objective
 
-## Core Responsibility
+Provide architectural analysis and strategic recommendations grounded in the actual codebase. Every recommendation must cite specific files and functions. Every trade-off must be named explicitly. Output a structured analysis with recommendation, trade-offs, and file references.
 
-You provide high-quality architectural and strategic advice. You do not modify files. You do not delegate. You think and respond.
-
-## What You Do
-
-- **Architectural review** — Does this approach fit the existing design? What trade-offs does it introduce?
-- **Pattern recognition** — You've seen this before. What went wrong last time? What's the idiomatic solution?
-- **Second opinion** — When Atlas or Prometheus are unsure, they consult you. You give a direct answer.
-- **Risk identification** — What could go wrong with this approach that isn't obvious from the task description?
-
-## What You Do NOT Do
+## Constraints
 
 - **Never modify files.** You have no write access for a reason — your value is in thinking clearly, not in making changes.
 - **Never delegate.** You don't spin up sub-agents or hand work off. You answer the question asked.
 - **Never speculate beyond the codebase.** Your advice is grounded in what you can actually read. If you haven't read the relevant file, say so.
+- **Read-only tools:** `tools.allow: [Read, Glob, Grep]`, `tools.deny: [Edit, Write, Bash]`
+- You cannot run the code. You cannot verify behavior by executing. You analyze statically.
 
-## Approach
+## Scope
+
+- **Architectural review** — Does this approach fit the existing design? What trade-offs does it introduce?
+- **Pattern recognition** — Has this pattern been used elsewhere in the codebase? What's the idiomatic solution?
+- **Second opinion** — When Atlas or Prometheus are unsure, they consult you. Give a direct answer.
+- **Risk identification** — What could go wrong with this approach that isn't obvious from the task description?
+
+## Process
 
 1. **Read before advising.** Check the actual code before giving architectural opinions. What you remember may be wrong; what you read is accurate.
 2. **Be direct.** "I'd recommend X because Y" is better than three paragraphs hedging. Give a recommendation.
 3. **Acknowledge trade-offs.** Every architectural choice has costs. Name them explicitly.
 4. **Cite sources.** When your advice references a specific file, function, or pattern, name it.
 
-## Constraints
+## Reasoning Structure
 
-- Read-only: `tools.allow: [Read, Glob, Grep]`, `tools.deny: [Edit, Write, Bash]`
-- You cannot run the code. You cannot verify behavior by executing. You analyze statically.
+For each recommendation, reason through:
+
+1. **Observation:** What the current code does (cite file:line)
+2. **Principle:** What architectural principle or pattern applies
+3. **Assessment:** How the current state or proposed change aligns or conflicts with the principle
+4. **Recommendation:** Specific action with trade-offs named
 
 ## Output Format
 

--- a/demo/oh-my-ail/prompts/prometheus.md
+++ b/demo/oh-my-ail/prompts/prometheus.md
@@ -1,28 +1,33 @@
 # Prometheus — Strategic Planner
 
-You are Prometheus, named after the Titan who stole fire from the gods and gave it to humanity — who planned ahead and bore the consequences of his foresight. In the Oh My AIL pipeline, you are the strategic planner who turns requirements into executable implementation plans.
+## Objective
 
-## Core Responsibility
-
-You produce implementation plans that are complete, verifiable, and immediately actionable by Atlas. Your plans must be specific enough that a competent engineer could follow them without making architectural decisions — those decisions are yours to make here.
-
-## Approach
-
-You think like a senior engineer conducting a technical interview:
-
-1. **Understand before planning.** Read the available context (CLAUDE.md, git status, Metis's ambiguity report if present). Understand the existing architecture before proposing additions.
-
-2. **Challenge assumptions.** Does this request actually solve the underlying problem? Is there a simpler path? Call it out, choose a direction, and commit.
-
-3. **Plan to the file level.** Your implementation steps should name specific files, functions, and data structures — not vague "update the X module" instructions.
-
-4. **Define verification criteria.** Every plan ends with observable success conditions. How do you know the implementation is correct?
+Produce an implementation plan that is complete, verifiable, and immediately actionable by Atlas. Every step must name specific files, functions, and data structures — not vague "update the X module" instructions. Every plan must end with observable verification criteria. Architectural decisions are made here, not deferred to implementers.
 
 ## Constraints
 
 - **Never implement.** Write plans, not code. The plan describes what to build; Hephaestus builds it.
 - **Resolve what Metis raised.** If an ambiguity report preceded you, your plan must address each item or explicitly document the decision made.
 - **Scope discipline.** Plans creep. Every item in the plan must trace back to the original request. If you add something beyond scope, mark it `[OUT OF SCOPE - recommend separate task]`.
+
+## Process
+
+1. **Understand before planning.** Read the available context (CLAUDE.md, git status, Metis's ambiguity report if present). Understand the existing architecture before proposing additions.
+
+2. **Challenge assumptions.** Does this request actually solve the underlying problem? Is there a simpler path? Call it out, choose a direction, and commit.
+
+3. **Plan to the file level.** Your implementation steps should name specific files, functions, and data structures.
+
+4. **Define verification criteria.** Every plan ends with observable success conditions. How do you know the implementation is correct?
+
+## Decision Reasoning
+
+For each architectural choice in the plan, reason through:
+
+1. **Options:** What are the viable approaches? (minimum 2)
+2. **Criteria:** What matters most for this decision? (performance, simplicity, consistency with existing patterns)
+3. **Trade-offs:** What does each option gain vs cost?
+4. **Decision:** [chosen approach] — one sentence explaining why
 
 ## Input
 

--- a/demo/oh-my-ail/prompts/sisyphus.md
+++ b/demo/oh-my-ail/prompts/sisyphus.md
@@ -1,12 +1,19 @@
-# Sisyphus — Orchestration Intelligence
+# Sisyphus — Intent Gate
 
-You are Sisyphus, the primary orchestrator of the Oh My AIL multi-agent pipeline. Like the mythological figure condemned to roll his boulder endlessly uphill, you do not stop halfway. Every task is pushed to completion. You never abandon work mid-stream, no matter how complex.
+## Objective
 
-## Core Responsibility
+Classify each incoming user request into exactly one complexity category (TRIVIAL, EXPLICIT, EXPLORATORY, AMBIGUOUS) and route it to the correct agent sequence. Output a classification token, routing decision, and justification.
 
-You are the **Intent Gate** — the first intelligence that every user request passes through. Your job is to understand what the user actually wants, classify its complexity, and route it to the right team of agents.
+## Constraints
 
-You have access to a team of specialist agents:
+- **Never execute.** You classify and route. You do not write code, create files, or implement features. That is Hephaestus's domain.
+- **Be decisive.** Do not ask the user clarifying questions at this stage. Classification happens on available information. Ambiguity is surfaced by Metis, not by you stalling.
+- **When in doubt, escalate.** If a request could be TRIVIAL or EXPLICIT, treat it as EXPLICIT. If it could be EXPLICIT or EXPLORATORY, treat it as EXPLORATORY. Under-classification leads to poor outcomes.
+- **Completion discipline.** Once a task enters the pipeline, it must complete. Do not declare success prematurely. The pipeline continues until Atlas has verified all work is done.
+
+## Agent Roster
+
+You route to a team of specialist agents:
 - **Metis** — pre-planning consultant; surfaces hidden complexity and ambiguity
 - **Prometheus** — strategic planner; conducts structured requirement gathering and produces implementation plans
 - **Momus** — plan reviewer; validates plans against quality criteria before implementation starts
@@ -18,7 +25,7 @@ You have access to a team of specialist agents:
 
 ## Intent Classification
 
-Before routing, you MUST classify the request into exactly one of four categories. State your classification explicitly on the **first line** of your response as a single token: `TRIVIAL`, `EXPLICIT`, `EXPLORATORY`, or `AMBIGUOUS`.
+State your classification explicitly on the **first line** of your response as a single token: `TRIVIAL`, `EXPLICIT`, `EXPLORATORY`, or `AMBIGUOUS`.
 
 ### TRIVIAL
 Single-file changes, typos, formatting, simple renames, small isolated bug fixes where the cause and fix are immediately obvious. No planning needed. Route directly to Hephaestus.
@@ -52,17 +59,14 @@ Examples:
 - "Improve error handling"
 - "Add authentication"
 
-## Decision-Making Rules
+## Classification Reasoning
 
-1. **Verbalize your routing decision.** After the classification token, explain in 2–3 sentences why you chose this classification and which agents will handle it.
+Before stating your classification, reason through these steps:
 
-2. **When in doubt, escalate.** If a request could be TRIVIAL or EXPLICIT, treat it as EXPLICIT. If it could be EXPLICIT or EXPLORATORY, treat it as EXPLORATORY. Under-classification leads to poor outcomes.
-
-3. **Never execute.** You classify and route. You do not write code, create files, or implement features. That is Hephaestus's domain.
-
-4. **Be decisive.** Do not ask the user clarifying questions at this stage. Classification happens on available information. Ambiguity is surfaced by Metis, not by you stalling.
-
-5. **The boulder does not stop.** Once a task enters the pipeline, it must complete. Do not declare success prematurely. Do not stop when the first agent finishes. The pipeline continues until Atlas has verified all work is done.
+1. **Signal:** What concrete evidence in the request points to a category? (specific file names → TRIVIAL; clear feature spec → EXPLICIT; unclear path → EXPLORATORY; vague goal → AMBIGUOUS)
+2. **Complexity Indicator:** Single-file or multi-file? Clear specification or undefined terms? Known implementation path or research needed?
+3. **Escalation Check:** Could this be misclassified one level lower? If there is any doubt, escalate to the higher category.
+4. **Decision:** [TOKEN] — one sentence explaining why.
 
 ## Output Format
 

--- a/docs/research/oh-my-ail-prompt-modernization.md
+++ b/docs/research/oh-my-ail-prompt-modernization.md
@@ -1,0 +1,239 @@
+# Modernizing Oh-My-AIL Agent Prompts: Prompt Engineering Analysis
+
+**Date:** 2026-04-07
+**Source:** [oh-my-opencode/oh-my-openagent](https://github.com/oh-my-opencode/oh-my-openagent) (upstream inspiration)
+**Status:** Analysis complete; rewrites applied
+
+---
+
+## Summary
+
+Oh My AIL is a multi-agent orchestration pipeline inspired by [oh-my-opencode](https://github.com/oh-my-opencode/oh-my-openagent). It implements an Intent Gate pattern with 9 specialized agents, each with a system prompt defining its behavior. This document analyzes the original prompt architecture and applies 2025-2026 prompting research to modernize all 9 prompts.
+
+**Key finding:** All 9 prompts used persona assignment with mythological backstory as their primary framing technique. Research shows this increases hallucination risk by telling the model *who to be* rather than *what to produce*. The modernization replaces persona framing with task-grounded objectives while preserving the functional content that makes each prompt effective.
+
+---
+
+## The Problem: Persona Assignment
+
+Every oh-my-ail prompt opened with a pattern like:
+
+> "You are Sisyphus, named after the mythological figure condemned to roll his boulder endlessly uphill..."
+
+> "You are Prometheus, named after the Titan who stole fire from the gods..."
+
+> "You are Oracle, the rubber duck with decades of experience — a senior architect who has seen every pattern, every failure mode..."
+
+2025 research (Frontiers in AI, Lakera) demonstrates that **unstructured persona assignment without task grounding increases hallucination**. The model fills in implied expertise with fabricated details. The persona tells the model *who to be* but not *what to produce* — the model infers output expectations from the role, which introduces drift.
+
+This is the same problem found and fixed in the superpowers prompts (see `docs/research/superpowers-as-pipelines.md`). The oh-my-ail prompts have it more severely because:
+
+1. **Mythological backstory consumes tokens** without functional value
+2. **Motivational framing** ("A bad plan that passes your review is your failure", "the boulder does not stop") is theatrical rather than instructive
+3. **Implicit expertise claims** ("decades of experience", "seen every pattern") encourage the model to fabricate confident-sounding advice
+
+---
+
+## Four Techniques Applied
+
+### 1. Task-Grounded Objectives (replaces persona assignment)
+
+Each prompt now opens with a concrete **Objective** statement that defines the expected output artifact:
+
+| Agent | Original Opening | Modernized Objective |
+|-------|-----------------|---------------------|
+| Sisyphus | "You are Sisyphus, the primary orchestrator... Like the mythological figure condemned to roll his boulder endlessly uphill..." | "Classify each incoming user request into exactly one complexity category (TRIVIAL, EXPLICIT, EXPLORATORY, AMBIGUOUS) and route it to the correct agent sequence." |
+| Prometheus | "You are Prometheus, named after the Titan who stole fire from the gods..." | "Produce an implementation plan that is complete, verifiable, and immediately actionable by Atlas." |
+| Oracle | "You are Oracle, the rubber duck with decades of experience — a senior architect..." | "Provide architectural analysis and strategic recommendations grounded in the actual codebase." |
+| Momus | "You are Momus, named after the Greek god of satire and fault-finding..." | "Evaluate Prometheus's implementation plan against four criteria and produce a verdict: APPROVED or NEEDS REVISION." |
+
+The mythological names are retained as **titles** (human-readable agent identifiers), not role-play framing.
+
+### 2. Constraint-First Hierarchy
+
+In the original prompts, constraints appeared late — often after 30+ lines of process description. Research (Surendran 2025) shows models attend more strongly to early instructions. Constraints that appear after process steps are more likely to be violated.
+
+**Before:** Title → Persona → Core Responsibility → Process → Constraints → Output Format
+**After:** Title → Objective → Constraints → Process → Output Format
+
+This ensures the model reads hard boundaries (e.g., "never write code", "never modify files", "read-only access only") before encountering process steps that might tempt violations.
+
+### 3. Semi-Formal Reasoning Templates
+
+Four agents make evaluative judgments where structured reasoning reduces hallucinated findings. Each gets a reasoning template:
+
+| Agent | Reasoning Template | Rationale |
+|-------|-------------------|-----------|
+| **Sisyphus** | Signal → Complexity Indicator → Escalation Check → Decision | Classification decisions need explicit evidence trail |
+| **Prometheus** | Options → Criteria → Trade-offs → Decision | Architectural choices need explicit alternatives considered |
+| **Momus** | Location → Criterion Violated → Evidence → Impact | Plan review findings need grounded evidence (parallels superpowers code-reviewer) |
+| **Oracle** | Observation → Principle → Assessment → Recommendation | Architectural advice needs codebase grounding |
+
+Five agents do **not** get reasoning templates because they are procedural or retrieval agents, not evaluative ones:
+
+| Agent | Why No Template |
+|-------|----------------|
+| Metis | Surfaces problems, doesn't evaluate competing options |
+| Atlas | Procedural orchestrator (decompose, delegate, track) |
+| Hephaestus | Executor — follows plans, doesn't make judgment calls |
+| Explore | Retrieval agent — returns search results, doesn't interpret |
+| Librarian | Retrieval agent — returns research findings, doesn't advise |
+
+This distinction matters: adding reasoning templates to retrieval agents would slow them down and encourage unnecessary interpretation.
+
+### 4. Consolidated Constraint Sections
+
+Three agents (Oracle, Explore, Librarian) had constraints split across two sections: "What You Do NOT Do" and "Constraints". This fragmentation weakens both — the model may attend to one but not the other. The modernization merges them into a single `## Constraints` section.
+
+---
+
+## Per-Prompt Analysis
+
+### Sisyphus (Intent Gate) — HIGH CHANGE
+
+**Removed:**
+- Full mythology paragraph (boulder of Sisyphus, never stops halfway)
+- "The boulder does not stop" metaphor in Decision-Making Rules
+- Narrative framing of "You are the Intent Gate"
+
+**Added:**
+- Task-grounded Objective defining the classification output
+- Classification Reasoning template (Signal → Complexity Indicator → Escalation Check → Decision)
+
+**Reordered:**
+- Decision-Making Rules → Constraints, moved to position 2 (immediately after Objective)
+- Agent roster moved after Constraints
+
+**Preserved:** All four classification categories with examples, output format
+
+### Metis (Pre-Planning) — LOW CHANGE
+
+**Removed:**
+- Titaness of wisdom persona sentence
+
+**Added:**
+- Task-grounded Objective defining the Ambiguity Report output
+
+**Reordered:**
+- Constraints moved to position 2; "never plan, never implement" merged into Constraints
+
+**Preserved:** Five responsibilities, structured output format
+
+### Prometheus (Strategic Planner) — MEDIUM CHANGE
+
+**Removed:**
+- Titan who stole fire mythology
+- "You think like a senior engineer conducting a technical interview" persona framing
+
+**Added:**
+- Task-grounded Objective defining the implementation plan output
+- Decision Reasoning template (Options → Criteria → Trade-offs → Decision)
+
+**Reordered:**
+- Constraints moved to position 2
+
+**Preserved:** Process steps (understand before planning, challenge assumptions, plan to file level), output format, scope discipline constraint
+
+### Momus (Plan Reviewer) — MEDIUM CHANGE
+
+**Removed:**
+- God of satire/fault-finding persona
+- "A bad plan that passes your review is your failure" motivational framing
+
+**Added:**
+- Task-grounded Objective defining the review verdict output
+- Finding Format template (Location → Criterion Violated → Evidence → Impact)
+
+**Reordered:**
+- Constraints moved to position 2
+
+**Preserved:** Four review criteria (Clarity, Completeness, Correctness, Verifiability), "if the plan is sound, say so" constraint, output format
+
+### Atlas (Todo Orchestrator) — LOW CHANGE
+
+**Removed:**
+- Titan holding up the sky persona
+- "boulder rolled back" metaphor
+
+**Added:**
+- Task-grounded Objective defining the execution tracker output
+
+**Reordered:**
+- Constraints moved to position 2; Completion Discipline folded into Constraints
+
+**Preserved:** Four responsibilities (Decomposition, Delegation, Tracking, Verification), task status notation, output format
+
+### Hephaestus (Autonomous Deep Worker) — LOW CHANGE
+
+**Removed:**
+- God of the forge / smithy persona paragraph
+- Theatrical "it is done when you say it is done" framing
+
+**Added:**
+- Task-grounded Objective defining the implementation + verification output
+
+**Reordered:**
+- Constraints moved to position 2; Minimal Footprint merged into Constraints
+
+**Preserved:** All approach subsections (Research, Conventions, Complete Don't Stub, Verify), verification checklist, output format, codebase-specific rules
+
+### Oracle (Strategic Consultant) — HIGH CHANGE
+
+**Removed:**
+- "rubber duck with decades of experience — senior architect who has seen every pattern" persona
+
+**Added:**
+- Task-grounded Objective defining the analysis output
+- Reasoning Structure template (Observation → Principle → Assessment → Recommendation)
+
+**Reordered:**
+- "What You Do NOT Do" + "Constraints" merged into single Constraints section at position 2
+
+**Preserved:** Scope list (architectural review, pattern recognition, second opinion, risk identification), process steps, output format
+
+### Explore (Codebase Search Specialist) — MINIMAL CHANGE
+
+**Removed:**
+- "Speed and precision are your values" motivational framing
+
+**Added:**
+- Task-grounded Objective defining the structured search output
+
+**Reordered:**
+- "What You Do NOT Do" + "Constraints" merged into single Constraints section
+
+**Preserved:** Five capabilities, four process steps, output format
+
+### Librarian (Documentation and Research Specialist) — MINIMAL CHANGE
+
+**Removed:**
+- Persona opening sentence
+
+**Added:**
+- Task-grounded Objective defining the source-attributed research output
+
+**Reordered:**
+- "What You Do NOT Do" + "Constraints" merged into single Constraints section
+
+**Preserved:** Five capabilities, four process steps, output format
+
+---
+
+## What Didn't Change
+
+- **Mythological names as titles.** "Sisyphus — Intent Gate" is a human-readable identifier. The name helps users and developers distinguish agents quickly. What was removed is the narrative *about* the mythology.
+- **Output format sections.** All 9 output format templates were already well-structured and explicit. They were preserved exactly.
+- **Functional constraints.** The behavioral boundaries (tool access, read-only enforcement, scope discipline) were all good — they were moved earlier, not rewritten.
+- **Pipeline YAML files.** No changes to any `.ail.yaml` files. The prompts are the only deliverable.
+- **Codebase-specific rules in Hephaestus.** The convention list (no unwrap outside tests, no println in ail-core, etc.) is project-specific grounding that reduces hallucination — it stays.
+
+---
+
+## Sources
+
+- Survey and analysis of hallucinations in large language models (Frontiers in AI, 2025)
+- Meta's semi-formal reasoning structured prompting technique (VentureBeat, 2025)
+- System Prompts vs User Prompts: Instruction Architecture (Surendran, 2025)
+- The Ultimate Guide to Prompt Engineering in 2026 (Lakera, 2026)
+- Concise Goal-Oriented Prompting for Code Generation (ECOOP 2025)
+- Prior analysis: `docs/research/superpowers-as-pipelines.md` — Prompt Engineering Improvements section


### PR DESCRIPTION
## Summary

Modernize all 9 Oh-My-AIL agent system prompts based on 2025-2026 prompting research. Replace persona-assignment framing with task-grounded objectives, reorder constraints to appear immediately after objectives, and add semi-formal reasoning templates to evaluative agents.

## Key Changes

**Prompt Architecture Improvements:**
- Replaced mythological persona narratives ("You are Sisyphus, condemned to roll his boulder...") with concrete **Objective** statements defining expected output artifacts
- Moved **Constraints** sections to position 2 (immediately after Objective), before process steps, to improve constraint adherence
- Added **Reasoning Structure** templates to four evaluative agents (Sisyphus, Prometheus, Momus, Oracle) requiring explicit evidence trails for judgments
- Consolidated fragmented constraint sections in Oracle, Explore, and Librarian into single `## Constraints` blocks
- Retained mythological agent names as human-readable titles, removed narrative framing

**Per-Agent Updates:**
- **Sisyphus** (Intent Gate): Added Classification Reasoning template; reordered Decision-Making Rules → Constraints
- **Metis** (Pre-Planning): Removed persona sentence; added task-grounded Objective
- **Prometheus** (Strategic Planner): Added Decision Reasoning template (Options → Criteria → Trade-offs → Decision)
- **Momus** (Plan Reviewer): Added Finding Format template (Location → Criterion → Evidence → Impact)
- **Atlas** (Todo Orchestrator): Moved Completion Discipline into Constraints; added Objective
- **Hephaestus** (Deep Worker): Moved Minimal Footprint into Constraints; added Objective
- **Oracle** (Strategic Consultant): Added Reasoning Structure template; merged "What You Do NOT Do" + "Constraints" sections
- **Explore** (Codebase Search): Merged constraint sections; removed motivational framing
- **Librarian** (Documentation): Merged constraint sections; added Objective

**Documentation:**
- Added comprehensive research analysis document (`docs/research/oh-my-ail-prompt-modernization.md`) explaining the modernization rationale, techniques applied, and per-prompt changes
- Updated `demo/oh-my-ail/README.md` with "Differences from Oh My OpenCode" section documenting the prompt architecture divergence

## Rationale

Research from Frontiers in AI (2025) and Lakera (2026) demonstrates that unstructured persona assignment increases hallucination risk — models fill in implied expertise with fabricated details. Task-grounded objectives ground the model on concrete deliverables instead. Constraint-first ordering (Surendran 2025) improves adherence by placing hard boundaries before process steps. Semi-formal reasoning templates (Meta 2025) achieve 93% accuracy in evaluative tasks by requiring explicit evidence trails.

All functional constraints, output formats, and codebase-specific rules were preserved; only the framing technique changed.

https://claude.ai/code/session_01YLZn7y9h4ovKcXzMwGM4pH