### PR TITLE
fix(#73): durable log entries — sync_data after write, composite fail…

### DIFF
--- a/ail-core/src/session/log_provider.rs
+++ b/ail-core/src/session/log_provider.rs
@@ -76,7 +76,8 @@ impl LogProvider for JsonlProvider {
         let path = dir.join(format!("{run_id}.jsonl"));
         let line = serde_json::to_string(value).map_err(std::io::Error::other)?;
         let mut file = OpenOptions::new().create(true).append(true).open(path)?;
-        writeln!(file, "{line}")
+        writeln!(file, "{line}")?;
+        file.sync_data()
     }
 }
 
@@ -89,8 +90,9 @@ impl LogProvider for NullProvider {
     }
 }
 
-/// Fans out writes to multiple `LogProvider`s. Best-effort: failures in one provider are
-/// logged as warnings but do not prevent writes to the remaining providers.
+/// Fans out writes to multiple `LogProvider`s. Individual provider failures are
+/// logged as warnings. Returns `Err` only when **all** providers fail — if at least
+/// one succeeds the entry is considered durably recorded.
 pub struct CompositeProvider {
     providers: Vec<Box<dyn LogProvider>>,
 }
@@ -103,12 +105,25 @@ impl CompositeProvider {
 
 impl LogProvider for CompositeProvider {
     fn write_entry(&mut self, run_id: &str, value: &Value) -> std::io::Result<()> {
+        let mut last_err: Option<std::io::Error> = None;
+        let mut any_ok = false;
         for provider in &mut self.providers {
-            if let Err(e) = provider.write_entry(run_id, value) {
-                tracing::warn!(run_id = %run_id, error = %e, "composite provider: write_entry failed");
+            match provider.write_entry(run_id, value) {
+                Ok(()) => any_ok = true,
+                Err(e) => {
+                    tracing::warn!(run_id = %run_id, error = %e, "composite provider: write_entry failed");
+                    last_err = Some(e);
+                }
             }
         }
-        Ok(())
+        if any_ok {
+            Ok(())
+        } else if let Some(e) = last_err {
+            Err(e)
+        } else {
+            // No providers configured — treat as success (no-op composite).
+            Ok(())
+        }
     }
 
     fn finish(&mut self, run_id: &str, status: &str) -> std::io::Result<()> {
@@ -216,6 +231,32 @@ mod tests {
         // Suppress unused variable warning
         let _ = (cap1, cap2);
     }
+
+    #[test]
+    fn composite_provider_returns_err_when_all_providers_fail() {
+        use super::test_support::FailingProvider;
+
+        let mut composite = CompositeProvider::new(vec![
+            Box::new(FailingProvider),
+            Box::new(FailingProvider),
+        ]);
+        let value = json!({"step_id": "all-fail"});
+        let result = composite.write_entry("run-all-fail", &value);
+        assert!(result.is_err(), "should return Err when all providers fail");
+    }
+
+    #[test]
+    fn composite_provider_returns_ok_when_one_of_two_providers_succeeds() {
+        use super::test_support::FailingProvider;
+
+        let mut composite = CompositeProvider::new(vec![
+            Box::new(FailingProvider),
+            Box::new(NullProvider),
+        ]);
+        let value = json!({"step_id": "partial-fail"});
+        let result = composite.write_entry("run-partial-fail", &value);
+        assert!(result.is_ok(), "should return Ok when at least one provider succeeds");
+    }
 }
 
 /// Test support types. Not intended for production use.
@@ -245,6 +286,15 @@ pub mod test_support {
         fn write_entry(&mut self, _run_id: &str, value: &Value) -> std::io::Result<()> {
             self.entries.push(value.clone());
             Ok(())
+        }
+    }
+
+    /// Always returns an I/O error. Used to test `CompositeProvider` all-fail behaviour.
+    pub struct FailingProvider;
+
+    impl LogProvider for FailingProvider {
+        fn write_entry(&mut self, _run_id: &str, _value: &Value) -> std::io::Result<()> {
+            Err(std::io::Error::other("injected failure"))
         }
     }
 }

--- a/spec/core/s04-execution-model.md
+++ b/spec/core/s04-execution-model.md
@@ -73,6 +73,8 @@ The `before:` chain on `invocation` is a more powerful variant: rather than inse
 
 Every pipeline execution is backed by a **pipeline run log** — a durable, structured record written to disk before the next step begins. The log is the authoritative source for template variable resolution. An implementation that resolves template variables from an in-memory cache without a durable backing store does not conform to this spec.
 
+Each log entry must be flushed to the storage layer (`fsync`/`sync_data` equivalent) before execution continues. An implementation that buffers log entries without flushing does not conform to this spec. When a composite (multi-backend) log provider is used, the entry is considered durably recorded if at least one backend succeeds; all individual backend failures are logged as warnings, and the run is only aborted if all backends fail.
+
 #### Log Identity
 
 Each pipeline run is identified by a `pipeline.run_id` — the same identifier used in the tracing and observability systems (see §22). There is no separate context identifier; run identity is unified across logging, tracing, and template variable access.


### PR DESCRIPTION
…s when all providers fail

- JsonlProvider::write_entry: add file.sync_data() after writeln! so entries are flushed to the storage layer before execution continues (SPEC §4.4).
- CompositeProvider::write_entry: return Err only when all providers fail; return Ok when at least one succeeds (previously swallowed all errors).
- Add FailingProvider to test_support for injected-failure testing.
- Add tests: composite returns Err on all-fail, Ok on partial-fail.
- spec/core/s04: document fsync requirement and composite-provider semantics.

https://claude.ai/code/session_013fGRuyk7ghRhJJxZEgXR9X