### PR TITLE
fix(#81): warn when resume suppressed due to non-default base_url

### DIFF
--- a/ail-core/src/runner/claude/mod.rs
+++ b/ail-core/src/runner/claude/mod.rs
@@ -167,7 +167,15 @@ impl ClaudeCliRunner {
         // (Ollama, Bedrock, etc.) have no knowledge of Claude session IDs and will
         // hang waiting to resolve them, causing the pipeline step to time out.
         if let Some(sid) = &options.resume_session_id {
-            if base_url.is_none() {
+            if let Some(url) = base_url {
+                tracing::warn!(
+                    base_url = %url,
+                    session_id = %sid,
+                    "resume suppressed: --resume is only supported on the default Claude API \
+                     endpoint; non-default base_url detected. The step will run as a fresh \
+                     session. Set resume: false on this step to silence this warning."
+                );
+            } else {
                 args.push("--resume".into());
                 args.push(sid.clone());
             }

--- a/ail-core/src/session/log_provider.rs
+++ b/ail-core/src/session/log_provider.rs
@@ -236,10 +236,8 @@ mod tests {
     fn composite_provider_returns_err_when_all_providers_fail() {
         use super::test_support::FailingProvider;
 
-        let mut composite = CompositeProvider::new(vec![
-            Box::new(FailingProvider),
-            Box::new(FailingProvider),
-        ]);
+        let mut composite =
+            CompositeProvider::new(vec![Box::new(FailingProvider), Box::new(FailingProvider)]);
         let value = json!({"step_id": "all-fail"});
         let result = composite.write_entry("run-all-fail", &value);
         assert!(result.is_err(), "should return Err when all providers fail");
@@ -249,13 +247,14 @@ mod tests {
     fn composite_provider_returns_ok_when_one_of_two_providers_succeeds() {
         use super::test_support::FailingProvider;
 
-        let mut composite = CompositeProvider::new(vec![
-            Box::new(FailingProvider),
-            Box::new(NullProvider),
-        ]);
+        let mut composite =
+            CompositeProvider::new(vec![Box::new(FailingProvider), Box::new(NullProvider)]);
         let value = json!({"step_id": "partial-fail"});
         let result = composite.write_entry("run-partial-fail", &value);
-        assert!(result.is_ok(), "should return Ok when at least one provider succeeds");
+        assert!(
+            result.is_ok(),
+            "should return Ok when at least one provider succeeds"
+        );
     }
 }
 

--- a/spec/runner/r02-claude-cli.md
+++ b/spec/runner/r02-claude-cli.md
@@ -221,6 +221,12 @@ The `--resume` flag is not documented in the Claude CLI `--help` output but is f
 2. Each subsequent pipeline step spawns a new subprocess with `--resume <last_session_id>` and `-p <resolved_prompt>`
 3. The runner has full conversation history; template variable injection is used for cross-step references outside the active conversation thread
 
+#### Resume Limitation: Non-Default Base URLs
+
+`--resume` is only supported when connecting to the default Claude API endpoint. When a step is configured with a custom `base_url` (e.g. Bedrock, Vertex, or a local proxy), `--resume` is silently suppressed — the provider has no knowledge of Claude session IDs and attempting to pass one would cause the request to hang.
+
+When `resume: true` is declared on a step but a custom `base_url` is in effect (from `defaults.provider.base_url` or a step-level runner override), the runner emits a `WARN`-level log message that identifies the suppressed session ID and the active base URL. The step runs as a fresh session. To suppress the warning, set `resume: false` explicitly on the step.
+
 ### Flags Summary
 
 | Flag | Purpose | `ail` usage |


### PR DESCRIPTION
When resume_session_id is set but base_url is Some(_), the runner now emits tracing::warn! with the active base_url and suppressed session ID rather than silently skipping --resume. Spec r02-claude-cli.md updated to document the limitation and the warning behaviour.

https://claude.ai/code/session_013fGRuyk7ghRhJJxZEgXR9X