### PR TITLE
fix(#74,#75): on_result derived step ID + headless pause_for_human wa…

### DIFF
--- a/ail-core/src/executor/core.rs
+++ b/ail-core/src/executor/core.rs
@@ -149,10 +149,12 @@ impl StepObserver for NullObserver {
 
     fn on_pipeline_error(&mut self, _: &AilError) {}
 
-    fn on_result_pause(&mut self, step_id: &str, _: Option<&str>) {
-        tracing::info!(
+    fn on_result_pause(&mut self, step_id: &str, message: Option<&str>) {
+        tracing::warn!(
             step_id = %step_id,
-            "on_result pause_for_human (no-op in headless execution)"
+            message = ?message,
+            "on_result: pause_for_human fired in headless mode — pipeline continues; \
+             use controlled mode (--output-format json) for interactive HITL gates"
         );
     }
 }
@@ -480,10 +482,14 @@ pub(super) fn execute_core<O: StepObserver>(
                         ref path,
                         ref prompt,
                     } => {
+                        // Use a derived step ID so the sub-pipeline's response is
+                        // addressable as `{{ step.<id>__on_result.response }}` without
+                        // shadowing the parent step's own turn log entry (SPEC §11).
+                        let on_result_step_id = format!("{step_id}__on_result");
                         let sub_entry = execute_sub_pipeline(
                             path,
                             prompt.as_deref(),
-                            &step_id,
+                            &on_result_step_id,
                             session,
                             runner,
                             depth,

--- a/ail-core/src/runner/claude/mod.rs
+++ b/ail-core/src/runner/claude/mod.rs
@@ -167,7 +167,15 @@ impl ClaudeCliRunner {
         // (Ollama, Bedrock, etc.) have no knowledge of Claude session IDs and will
         // hang waiting to resolve them, causing the pipeline step to time out.
         if let Some(sid) = &options.resume_session_id {
-            if base_url.is_none() {
+            if let Some(url) = base_url {
+                tracing::warn!(
+                    base_url = %url,
+                    session_id = %sid,
+                    "resume suppressed: --resume is only supported on the default Claude API \
+                     endpoint; non-default base_url detected. The step will run as a fresh \
+                     session. Set resume: false on this step to silence this warning."
+                );
+            } else {
                 args.push("--resume".into());
                 args.push(sid.clone());
             }

--- a/ail-core/src/session/log_provider.rs
+++ b/ail-core/src/session/log_provider.rs
@@ -236,10 +236,8 @@ mod tests {
     fn composite_provider_returns_err_when_all_providers_fail() {
         use super::test_support::FailingProvider;
 
-        let mut composite = CompositeProvider::new(vec![
-            Box::new(FailingProvider),
-            Box::new(FailingProvider),
-        ]);
+        let mut composite =
+            CompositeProvider::new(vec![Box::new(FailingProvider), Box::new(FailingProvider)]);
         let value = json!({"step_id": "all-fail"});
         let result = composite.write_entry("run-all-fail", &value);
         assert!(result.is_err(), "should return Err when all providers fail");
@@ -249,13 +247,14 @@ mod tests {
     fn composite_provider_returns_ok_when_one_of_two_providers_succeeds() {
         use super::test_support::FailingProvider;
 
-        let mut composite = CompositeProvider::new(vec![
-            Box::new(FailingProvider),
-            Box::new(NullProvider),
-        ]);
+        let mut composite =
+            CompositeProvider::new(vec![Box::new(FailingProvider), Box::new(NullProvider)]);
         let value = json!({"step_id": "partial-fail"});
         let result = composite.write_entry("run-partial-fail", &value);
-        assert!(result.is_ok(), "should return Ok when at least one provider succeeds");
+        assert!(
+            result.is_ok(),
+            "should return Ok when at least one provider succeeds"
+        );
     }
 }
 

--- a/ail-core/tests/spec/s09_sub_pipeline.rs
+++ b/ail-core/tests/spec/s09_sub_pipeline.rs
@@ -709,6 +709,62 @@ fn sub_pipeline_relative_path_resolves_when_pipeline_loaded_as_bare_filename() {
     assert_eq!(session.turn_log.entries()[0].step_id, "call_child");
 }
 
+/// SPEC §11 — `on_result: pipeline:` appends the sub-pipeline result under the derived
+/// step ID `<parent_id>__on_result`, not under the parent step's ID. This ensures
+/// `{{ step.<id>.response }}` resolves to the parent's own response and
+/// `{{ step.<id>__on_result.response }}` resolves to the sub-pipeline's response.
+#[test]
+fn on_result_pipeline_uses_derived_step_id_in_turn_log() {
+    let _cwd_guard = crate::spec::CWD_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let orig = std::env::current_dir().unwrap();
+    std::env::set_current_dir(tmp.path()).unwrap();
+
+    let child_path = fixtures_dir().join("sub_pipeline_child.ail.yaml");
+    let trigger = Step {
+        id: StepId("trigger".to_string()),
+        body: StepBody::Prompt("trigger prompt".to_string()),
+        message: None,
+        tools: None,
+        on_result: Some(vec![ResultBranch {
+            matcher: ResultMatcher::Always,
+            action: ResultAction::Pipeline {
+                path: child_path.to_str().unwrap().to_string(),
+                prompt: None,
+            },
+        }]),
+        model: None,
+        runner: None,
+        condition: None,
+        append_system_prompt: None,
+        system_prompt: None,
+        resume: false,
+    };
+    let mut session = make_session(vec![trigger]);
+    let runner = StubRunner::new("parent response");
+    let result = execute(&mut session, &runner);
+    assert!(result.is_ok(), "Expected Ok, got: {result:?}");
+
+    let entries = session.turn_log.entries();
+    assert!(
+        entries.len() >= 2,
+        "Expected at least 2 entries (trigger + on_result sub-pipeline), got {}",
+        entries.len()
+    );
+
+    // First entry: the parent step — ID must match the declared step ID exactly.
+    assert_eq!(entries[0].step_id, "trigger", "parent step should use declared step ID");
+
+    // Second entry: the on_result sub-pipeline — ID must use the derived form.
+    assert_eq!(
+        entries[1].step_id,
+        "trigger__on_result",
+        "on_result sub-pipeline entry must use '<id>__on_result' derived step ID (SPEC §11)"
+    );
+
+    std::env::set_current_dir(orig).unwrap();
+}
+
 /// `prompt:` field on `on_result: pipeline:` branches parses from YAML correctly.
 #[test]
 fn pipeline_action_with_prompt_override_parses_from_yaml() {

--- a/ail-core/tests/spec/s09_sub_pipeline.rs
+++ b/ail-core/tests/spec/s09_sub_pipeline.rs
@@ -753,12 +753,14 @@ fn on_result_pipeline_uses_derived_step_id_in_turn_log() {
     );
 
     // First entry: the parent step — ID must match the declared step ID exactly.
-    assert_eq!(entries[0].step_id, "trigger", "parent step should use declared step ID");
+    assert_eq!(
+        entries[0].step_id, "trigger",
+        "parent step should use declared step ID"
+    );
 
     // Second entry: the on_result sub-pipeline — ID must use the derived form.
     assert_eq!(
-        entries[1].step_id,
-        "trigger__on_result",
+        entries[1].step_id, "trigger__on_result",
         "on_result sub-pipeline entry must use '<id>__on_result' derived step ID (SPEC §11)"
     );
 

--- a/spec/core/s11-template-variables.md
+++ b/spec/core/s11-template-variables.md
@@ -10,6 +10,7 @@ Prompt strings, file-based prompts, and `pipeline:` paths may reference runtime 
 | `{{ step.invocation.response }}` | The runner's response before any pipeline steps ran. |
 | `{{ last_response }}` | The full response from the immediately preceding step. |
 | `{{ step.<id>.response }}` | The response from a specific named `prompt:` step in this pipeline run. |
+| `{{ step.<id>__on_result.response }}` | The response from a sub-pipeline triggered by an `on_result: pipeline:` branch on step `<id>`. The derived ID `<id>__on_result` is used to avoid shadowing the parent step's own response in the turn log. |
 | `{{ step.<id>.result }}` | Output of a `context:` step. For `shell:`: stdout+stderr concatenated. For `mcp:`: tool output. |
 | `{{ step.<id>.stdout }}` | Standard output of a `shell:` context step. |
 | `{{ step.<id>.stderr }}` | Standard error of a `shell:` context step. |

--- a/spec/core/s13-hitl-gates.md
+++ b/spec/core/s13-hitl-gates.md
@@ -76,6 +76,8 @@ For automated runs (CI, the autonomous agent use case, Docker sandbox), HITL pro
 
 **`--once` text mode:** The `--once --output-format text` flow does not set a `permission_responder` and does not spawn a stdin reader thread. Interactive permission HITL is not available. Tools in text mode require either `--headless` (bypass all permissions) or `tools: allow:` in the pipeline YAML (pre-approve specific tools).
 
+When `pause_for_human` fires in headless / text mode (either as an explicit step or via `on_result: pause_for_human`), the executor emits a `WARN`-level log message identifying the step and any configured message, then **continues the pipeline**. No HITL gate is raised and no input is awaited. This is visible on stderr (as a structured JSON log entry) when the binary's tracing subscriber is active. Use `--output-format json` mode for interactive HITL gates.
+
 **Interactive questions in Claude's text output:** When the model's response contains a question (e.g., "Do you want option 1, 2, or 3?"), this is the step's completed response — not a HITL event. In `-p` mode (single-turn), there is no follow-up turn within a step. The question text is available to subsequent steps as `{{ step.<id>.response }}`. Pipelines that need human review of model output should use explicit `pause_for_human` gates.
 
 ---

--- a/spec/runner/r02-claude-cli.md
+++ b/spec/runner/r02-claude-cli.md
@@ -221,6 +221,12 @@ The `--resume` flag is not documented in the Claude CLI `--help` output but is f
 2. Each subsequent pipeline step spawns a new subprocess with `--resume <last_session_id>` and `-p <resolved_prompt>`
 3. The runner has full conversation history; template variable injection is used for cross-step references outside the active conversation thread
 
+#### Resume Limitation: Non-Default Base URLs
+
+`--resume` is only supported when connecting to the default Claude API endpoint. When a step is configured with a custom `base_url` (e.g. Bedrock, Vertex, or a local proxy), `--resume` is silently suppressed — the provider has no knowledge of Claude session IDs and attempting to pass one would cause the request to hang.
+
+When `resume: true` is declared on a step but a custom `base_url` is in effect (from `defaults.provider.base_url` or a step-level runner override), the runner emits a `WARN`-level log message that identifies the suppressed session ID and the active base URL. The step runs as a fresh session. To suppress the warning, set `resume: false` explicitly on the step.
+
 ### Flags Summary
 
 | Flag | Purpose | `ail` usage |


### PR DESCRIPTION
…rning

#74: on_result: pipeline: sub-pipeline entries now use '<id>__on_result' as the turn log step ID, preserving the parent step's own entry. This makes {{ step.<id>__on_result.response }} addressable without shadowing the parent step. New test asserts the derived ID is set correctly (SPEC §11).

#75: NullObserver::on_result_pause upgraded from tracing::info! to tracing::warn! with a message explaining headless behavior. The warning is visible on stderr when the tracing subscriber is active. Spec s13-hitl-gates updated to document the headless behavior.

https://claude.ai/code/session_013fGRuyk7ghRhJJxZEgXR9X