### PR TITLE
feat(#101): runner plugin system + command trait refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ It is the control plane for agent behaviour after the human stops typing.
 ail/                        # binary crate — CLI entry point only
   src/main.rs               # --once, materialize, validate handlers
   src/cli.rs                # Cli, Commands (clap derive)
+  src/command.rs            # CommandOutcome — command lifecycle types
 ail-core/                   # library crate — all logic, no UI
   src/
     config/                 # discovery, dto, domain, validation, mod (load())
@@ -18,6 +19,7 @@ ail-core/                   # library crate — all logic, no UI
     executor.rs             # execute() — SPEC §4.2 core invariant
     materialize.rs          # materialize() — annotated YAML with # origin comments
     runner/                 # Runner trait, StubRunner, ClaudeCliRunner
+      plugin/               # runtime plugin system — JSON-RPC protocol, discovery, ProtocolRunner
     session/                # Session, TurnLog, TurnEntry
     template.rs             # resolve() — {{ variable }} syntax
   tests/spec/               # spec-coverage integration tests, one file per SPEC section
@@ -88,7 +90,7 @@ When in doubt, update the spec. A spec that accurately describes what is built i
 - **Why Rust**: steady-state RSS of 2–5MB vs 80–120MB for Node. At 10k concurrent sessions the delta is ~$100k/year in infrastructure cost. This is the primary rationale — not preference.
 - **Two-crate rule**: `ail-core` (library, no UI) and `ail` (binary). `ail` depends on `ail-core`. The inverse is a compile error. All correctness lives in `ail-core`.
 - **DTO→Domain boundary**: `dto.rs` (serde, `Deserialize`) → `validation.rs` (typed errors) → `domain.rs` (no serde). Serde structs never become domain objects.
-- **Runner trait is the seam**: `ClaudeCliRunner` is an implementation detail. The executor sees only `&dyn Runner`. New runners don't touch the executor.
+- **Runner trait is the seam**: `ClaudeCliRunner` is an implementation detail. The executor sees only `&dyn Runner`. New runners don't touch the executor. Third-party runners can be added at runtime via the plugin system (JSON-RPC over stdin/stdout).
 - **Stream parsing isolation**: all NDJSON parsing from Claude CLI lives in `runner/claude.rs`. Nothing else touches raw JSON. When Anthropic changes the wire format, the blast radius is one file.
 - **RFC 9457-inspired errors**: `AilError { error_type (stable const), title, detail, context }`. No `unwrap()`/`panic` in production paths.
 - **Observability from day one**: `tracing` spans and structured fields, never `println!`. The turn log is the durable audit trail; tracing is the live signal.
@@ -149,7 +151,7 @@ Unresolved variables **abort with a typed error** — never silently empty.
 - No `unwrap()`/`expect()` outside tests
 - No `println!`/`eprintln!` in `ail-core` — use `tracing::{info, warn, error}`
 - `dto.rs` derives `Deserialize`; `domain.rs` does not — conversion in `validation.rs`
-- `#[allow(clippy::result_large_err)]` required in every module that returns `Result<_, AilError>`. Apply at file scope (`#![allow(...)]`). Current files: `config/{mod,validation}.rs`, `template.rs`, `executor/{core,headless,controlled,helpers}.rs`, `runner/{mod,factory,http,subprocess,claude/mod,claude/permission}.rs`, `delete.rs`, `fs_util.rs`, `logs.rs`, `formatter.rs`
+- `#[allow(clippy::result_large_err)]` required in every module that returns `Result<_, AilError>`. Apply at file scope (`#![allow(...)]`). Current files: `config/{mod,validation}.rs`, `template.rs`, `executor/{core,headless,controlled,helpers}.rs`, `runner/{mod,factory,http,subprocess,claude/mod,claude/permission}.rs`, `runner/plugin/{mod,validation,discovery,protocol_runner}.rs`, `delete.rs`, `fs_util.rs`, `logs.rs`, `formatter.rs`
 - All errors use `AilError` with a stable `error_type` string constant from `error::error_types`
 - No co-authorship lines in git commits
 

--- a/ail-core/CLAUDE.md
+++ b/ail-core/CLAUDE.md
@@ -20,7 +20,14 @@ Consumed by `ail` (the binary) and future language-server / SDK targets.
 | `runner/claude/mod.rs` | `ClaudeCliRunner` — orchestrates subprocess + decoder + permission listener |
 | `runner/claude/decoder.rs` | `ClaudeNdjsonDecoder` — stateful NDJSON stream decoder, no process coupling; unit-testable with raw byte strings |
 | `runner/claude/permission.rs` | `ClaudePermissionListener` — RAII guard for the tool-permission socket (hook settings file, accept loop, `__close__` sentinel, cleanup on drop) |
-| `runner/factory.rs` | `RunnerFactory` — builds runners by name; honours `AIL_DEFAULT_RUNNER` env |
+| `runner/factory.rs` | `RunnerFactory` — builds runners by name; honours `AIL_DEFAULT_RUNNER` env; checks plugin registry for unknown names |
+| `runner/plugin/mod.rs` | Plugin system entry point — re-exports `PluginRegistry`, `PluginManifest`, `ProtocolRunner` |
+| `runner/plugin/discovery.rs` | `discover_plugins()` — scans `~/.ail/runners/` for manifest files; returns `PluginRegistry` |
+| `runner/plugin/jsonrpc.rs` | JSON-RPC 2.0 wire types (request, response, notification, method/notification constants) |
+| `runner/plugin/manifest_dto.rs` | Serde DTO for runner manifest YAML/JSON |
+| `runner/plugin/manifest.rs` | Validated domain type for plugin manifests — no serde |
+| `runner/plugin/validation.rs` | DTO → domain validation for manifests |
+| `runner/plugin/protocol_runner.rs` | `ProtocolRunner` — generic `Runner` impl that speaks JSON-RPC to any compliant executable |
 | `runner/http.rs` | `HttpRunner` — direct OpenAI-compatible HTTP runner (Ollama, direct API); full system-prompt control, think flag, in-memory session continuity |
 | `runner/stub.rs` | `StubRunner`, `CountingStubRunner`, `EchoStubRunner`, `RecordingStubRunner` — deterministic test doubles |
 | `session/log_provider.rs` | `LogProvider` trait + `JsonlProvider` (NDJSON) + `NullProvider` (tests) |
@@ -131,6 +138,10 @@ pub struct AilError { pub error_type: &'static str, pub title: &'static str, pub
 | `STORAGE_QUERY_FAILED` | `ail:storage/query-failed` |
 | `RUN_NOT_FOUND` | `ail:storage/run-not-found` |
 | `STORAGE_DELETE_FAILED` | `ail:storage/delete-failed` |
+| `PLUGIN_MANIFEST_INVALID` | `ail:plugin/manifest-invalid` |
+| `PLUGIN_SPAWN_FAILED` | `ail:plugin/spawn-failed` |
+| `PLUGIN_PROTOCOL_ERROR` | `ail:plugin/protocol-error` |
+| `PLUGIN_TIMEOUT` | `ail:plugin/timeout` |
 
 ## Invariants (do not break)
 

--- a/ail-core/src/error.rs
+++ b/ail-core/src/error.rs
@@ -106,6 +106,30 @@ pub enum AilError {
         detail: String,
         context: Option<ErrorContext>,
     },
+
+    #[error("[ail:plugin/manifest-invalid] {detail}")]
+    PluginManifestInvalid {
+        detail: String,
+        context: Option<ErrorContext>,
+    },
+
+    #[error("[ail:plugin/spawn-failed] {detail}")]
+    PluginSpawnFailed {
+        detail: String,
+        context: Option<ErrorContext>,
+    },
+
+    #[error("[ail:plugin/protocol-error] {detail}")]
+    PluginProtocolError {
+        detail: String,
+        context: Option<ErrorContext>,
+    },
+
+    #[error("[ail:plugin/timeout] {detail}")]
+    PluginTimeout {
+        detail: String,
+        context: Option<ErrorContext>,
+    },
 }
 
 impl AilError {
@@ -128,6 +152,10 @@ impl AilError {
             Self::StorageQueryFailed { .. } => error_types::STORAGE_QUERY_FAILED,
             Self::RunNotFound { .. } => error_types::RUN_NOT_FOUND,
             Self::StorageDeleteFailed { .. } => error_types::STORAGE_DELETE_FAILED,
+            Self::PluginManifestInvalid { .. } => error_types::PLUGIN_MANIFEST_INVALID,
+            Self::PluginSpawnFailed { .. } => error_types::PLUGIN_SPAWN_FAILED,
+            Self::PluginProtocolError { .. } => error_types::PLUGIN_PROTOCOL_ERROR,
+            Self::PluginTimeout { .. } => error_types::PLUGIN_TIMEOUT,
         }
     }
 
@@ -146,7 +174,11 @@ impl AilError {
             | Self::PipelineAborted { detail, .. }
             | Self::StorageQueryFailed { detail, .. }
             | Self::RunNotFound { detail, .. }
-            | Self::StorageDeleteFailed { detail, .. } => detail,
+            | Self::StorageDeleteFailed { detail, .. }
+            | Self::PluginManifestInvalid { detail, .. }
+            | Self::PluginSpawnFailed { detail, .. }
+            | Self::PluginProtocolError { detail, .. }
+            | Self::PluginTimeout { detail, .. } => detail,
         }
     }
 
@@ -163,7 +195,11 @@ impl AilError {
             | Self::PipelineAborted { detail, .. }
             | Self::StorageQueryFailed { detail, .. }
             | Self::RunNotFound { detail, .. }
-            | Self::StorageDeleteFailed { detail, .. } => detail,
+            | Self::StorageDeleteFailed { detail, .. }
+            | Self::PluginManifestInvalid { detail, .. }
+            | Self::PluginSpawnFailed { detail, .. }
+            | Self::PluginProtocolError { detail, .. }
+            | Self::PluginTimeout { detail, .. } => detail,
         }
     }
 
@@ -182,7 +218,11 @@ impl AilError {
             | Self::PipelineAborted { context, .. }
             | Self::StorageQueryFailed { context, .. }
             | Self::RunNotFound { context, .. }
-            | Self::StorageDeleteFailed { context, .. } => context.as_ref(),
+            | Self::StorageDeleteFailed { context, .. }
+            | Self::PluginManifestInvalid { context, .. }
+            | Self::PluginSpawnFailed { context, .. }
+            | Self::PluginProtocolError { context, .. }
+            | Self::PluginTimeout { context, .. } => context.as_ref(),
         }
     }
 
@@ -236,6 +276,22 @@ impl AilError {
                 detail,
                 context: ctx,
             },
+            Self::PluginManifestInvalid { detail, .. } => Self::PluginManifestInvalid {
+                detail,
+                context: ctx,
+            },
+            Self::PluginSpawnFailed { detail, .. } => Self::PluginSpawnFailed {
+                detail,
+                context: ctx,
+            },
+            Self::PluginProtocolError { detail, .. } => Self::PluginProtocolError {
+                detail,
+                context: ctx,
+            },
+            Self::PluginTimeout { detail, .. } => Self::PluginTimeout {
+                detail,
+                context: ctx,
+            },
         }
     }
 
@@ -249,6 +305,8 @@ impl AilError {
     pub fn recovery_strategy(&self) -> RecoveryStrategy {
         match self {
             Self::RunnerInvocationFailed { .. } => RecoveryStrategy::Retry { max_attempts: 2 },
+            Self::PluginSpawnFailed { .. } => RecoveryStrategy::Retry { max_attempts: 2 },
+            Self::PluginTimeout { .. } => RecoveryStrategy::Retry { max_attempts: 2 },
             _ => RecoveryStrategy::Abort,
         }
     }
@@ -331,6 +389,34 @@ impl AilError {
             context: None,
         }
     }
+
+    pub fn plugin_manifest_invalid(detail: impl Into<String>) -> Self {
+        Self::PluginManifestInvalid {
+            detail: detail.into(),
+            context: None,
+        }
+    }
+
+    pub fn plugin_spawn_failed(detail: impl Into<String>) -> Self {
+        Self::PluginSpawnFailed {
+            detail: detail.into(),
+            context: None,
+        }
+    }
+
+    pub fn plugin_protocol_error(detail: impl Into<String>) -> Self {
+        Self::PluginProtocolError {
+            detail: detail.into(),
+            context: None,
+        }
+    }
+
+    pub fn plugin_timeout(detail: impl Into<String>) -> Self {
+        Self::PluginTimeout {
+            detail: detail.into(),
+            context: None,
+        }
+    }
 }
 
 pub mod error_types {
@@ -345,6 +431,10 @@ pub mod error_types {
     pub const STORAGE_QUERY_FAILED: &str = "ail:storage/query-failed";
     pub const RUN_NOT_FOUND: &str = "ail:storage/run-not-found";
     pub const STORAGE_DELETE_FAILED: &str = "ail:storage/delete-failed";
+    pub const PLUGIN_MANIFEST_INVALID: &str = "ail:plugin/manifest-invalid";
+    pub const PLUGIN_SPAWN_FAILED: &str = "ail:plugin/spawn-failed";
+    pub const PLUGIN_PROTOCOL_ERROR: &str = "ail:plugin/protocol-error";
+    pub const PLUGIN_TIMEOUT: &str = "ail:plugin/timeout";
 }
 
 #[cfg(test)]

--- a/ail-core/src/runner/factory.rs
+++ b/ail-core/src/runner/factory.rs
@@ -17,6 +17,7 @@
 use super::{
     claude::{ClaudeCliRunner, ClaudeCliRunnerConfig},
     http::{HttpRunner, HttpRunnerConfig, HttpSessionStore},
+    plugin::{PluginRegistry, ProtocolRunner},
     stub::StubRunner,
     Runner,
 };
@@ -42,16 +43,40 @@ impl RunnerFactory {
     ///   `http://localhost:11434/v1`), `AIL_HTTP_TOKEN`, `AIL_HTTP_MODEL`, `AIL_HTTP_THINK`
     ///   from the environment.
     /// - `"stub"` — `StubRunner` with a fixed response (test/dev use)
+    /// - Any other name — looks up the plugin registry for a matching runner extension
     ///
-    /// Returns `RUNNER_NOT_FOUND` if the name is not recognised.
+    /// Returns `RUNNER_NOT_FOUND` if the name is not recognised and no matching plugin exists.
     pub fn build(
         runner_name: &str,
         headless: bool,
         http_store: &HttpSessionStore,
         provider: &ProviderConfig,
     ) -> Result<Box<dyn Runner + Send>, AilError> {
+        Self::build_with_registry(
+            runner_name,
+            headless,
+            http_store,
+            provider,
+            &PluginRegistry::empty(),
+        )
+    }
+
+    /// Build a runner by explicit name, consulting the plugin registry for unknown names.
+    ///
+    /// Resolution order:
+    /// 1. Built-in runners (claude, http/ollama, stub)
+    /// 2. Plugin registry (discovered from `~/.ail/runners/`)
+    /// 3. Error: RUNNER_NOT_FOUND
+    pub fn build_with_registry(
+        runner_name: &str,
+        headless: bool,
+        http_store: &HttpSessionStore,
+        provider: &ProviderConfig,
+        registry: &PluginRegistry,
+    ) -> Result<Box<dyn Runner + Send>, AilError> {
         let _ = headless; // consumed by claude only
-        match runner_name.trim().to_lowercase().as_str() {
+        let normalized = runner_name.trim().to_lowercase();
+        match normalized.as_str() {
             "claude" => {
                 let runner: ClaudeCliRunner =
                     ClaudeCliRunnerConfig::default().headless(headless).build();
@@ -86,12 +111,25 @@ impl RunnerFactory {
                 )))
             }
             "stub" => Ok(Box::new(StubRunner::new("stub response"))),
-            other => Err(AilError::RunnerNotFound {
-                detail: format!(
-                    "Runner '{other}' is not recognized. Known runners: claude, http, ollama, stub"
-                ),
-                context: None,
-            }),
+            other => {
+                // Check the plugin registry
+                if let Some(manifest) = registry.get(other) {
+                    tracing::info!(runner = other, plugin = %manifest.manifest_path.display(), "using plugin runner");
+                    return Ok(Box::new(ProtocolRunner::new(manifest.clone())));
+                }
+
+                let mut known: Vec<&str> = vec!["claude", "http", "ollama", "stub"];
+                let plugin_names = registry.runner_names();
+                known.extend(plugin_names.iter().copied());
+
+                Err(AilError::RunnerNotFound {
+                    detail: format!(
+                        "Runner '{other}' is not recognized. Known runners: {}",
+                        known.join(", ")
+                    ),
+                    context: None,
+                })
+            }
         }
     }
 
@@ -107,6 +145,17 @@ impl RunnerFactory {
     ) -> Result<Box<dyn Runner + Send>, AilError> {
         let name = std::env::var("AIL_DEFAULT_RUNNER").unwrap_or_else(|_| "claude".to_string());
         Self::build(&name, headless, http_store, provider)
+    }
+
+    /// Build the default runner with plugin registry support.
+    pub fn build_default_with_registry(
+        headless: bool,
+        http_store: &HttpSessionStore,
+        provider: &ProviderConfig,
+        registry: &PluginRegistry,
+    ) -> Result<Box<dyn Runner + Send>, AilError> {
+        let name = std::env::var("AIL_DEFAULT_RUNNER").unwrap_or_else(|_| "claude".to_string());
+        Self::build_with_registry(&name, headless, http_store, provider, registry)
     }
 }
 

--- a/ail-core/src/runner/mod.rs
+++ b/ail-core/src/runner/mod.rs
@@ -25,6 +25,7 @@
 pub mod claude;
 pub mod factory;
 pub mod http;
+pub mod plugin;
 pub mod stub;
 pub mod subprocess;
 

--- a/ail-core/src/runner/plugin/discovery.rs
+++ b/ail-core/src/runner/plugin/discovery.rs
@@ -1,0 +1,320 @@
+//! Plugin discovery — scans `~/.ail/runners/` for runner manifests.
+
+#![allow(clippy::result_large_err)]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use tracing::{debug, warn};
+
+use super::manifest::PluginManifest;
+use super::manifest_dto::ManifestDto;
+use super::validation;
+use crate::error::AilError;
+
+/// Registry of discovered runner plugins, keyed by runner name.
+#[derive(Debug, Clone, Default)]
+pub struct PluginRegistry {
+    plugins: HashMap<String, PluginManifest>,
+}
+
+impl PluginRegistry {
+    /// Create an empty registry.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Look up a plugin by runner name.
+    pub fn get(&self, name: &str) -> Option<&PluginManifest> {
+        self.plugins.get(name)
+    }
+
+    /// Number of registered plugins.
+    pub fn len(&self) -> usize {
+        self.plugins.len()
+    }
+
+    /// Whether the registry has no plugins.
+    pub fn is_empty(&self) -> bool {
+        self.plugins.is_empty()
+    }
+
+    /// Iterate over all registered plugins.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &PluginManifest)> {
+        self.plugins.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// List all registered runner names.
+    pub fn runner_names(&self) -> Vec<&str> {
+        self.plugins.keys().map(|s| s.as_str()).collect()
+    }
+}
+
+/// Discover all runner plugins from the default directory (`~/.ail/runners/`).
+///
+/// Invalid manifests are logged as warnings and skipped — discovery never fails
+/// unless the directory itself cannot be read. If the directory does not exist,
+/// returns an empty registry.
+pub fn discover_plugins() -> PluginRegistry {
+    let dir = match default_plugin_dir() {
+        Some(d) => d,
+        None => {
+            debug!("plugin discovery: could not determine ~/.ail/runners/ path");
+            return PluginRegistry::empty();
+        }
+    };
+    discover_plugins_in(&dir)
+}
+
+/// Discover runner plugins from a specific directory.
+///
+/// This is the testable entry point — `discover_plugins()` delegates to this
+/// with the default `~/.ail/runners/` path.
+pub fn discover_plugins_in(dir: &Path) -> PluginRegistry {
+    let mut registry = PluginRegistry::empty();
+
+    if !dir.exists() {
+        debug!(path = %dir.display(), "plugin directory does not exist — no plugins loaded");
+        return registry;
+    }
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(err) => {
+            warn!(path = %dir.display(), error = %err, "failed to read plugin directory");
+            return registry;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                warn!(error = %err, "failed to read directory entry");
+                continue;
+            }
+        };
+
+        let path = entry.path();
+        if !is_manifest_file(&path) {
+            continue;
+        }
+
+        match load_manifest(&path) {
+            Ok(manifest) => {
+                let name = manifest.name.clone();
+                if registry.plugins.contains_key(&name) {
+                    warn!(
+                        name = %name,
+                        path = %path.display(),
+                        "duplicate runner name — skipping (first-seen wins)"
+                    );
+                    continue;
+                }
+                debug!(name = %name, path = %path.display(), "discovered runner plugin");
+                registry.plugins.insert(name, manifest);
+            }
+            Err(err) => {
+                warn!(
+                    path = %path.display(),
+                    error = %err.detail(),
+                    "skipping invalid runner manifest"
+                );
+            }
+        }
+    }
+
+    debug!(count = registry.len(), "plugin discovery complete");
+    registry
+}
+
+/// Load and validate a single manifest file.
+fn load_manifest(path: &Path) -> Result<PluginManifest, AilError> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|err| AilError::plugin_manifest_invalid(format!("{}: {}", path.display(), err)))?;
+
+    let dto: ManifestDto = if is_json_file(path) {
+        serde_json::from_str(&contents).map_err(|err| {
+            AilError::plugin_manifest_invalid(format!("{}: {}", path.display(), err))
+        })?
+    } else {
+        serde_yaml::from_str(&contents).map_err(|err| {
+            AilError::plugin_manifest_invalid(format!("{}: {}", path.display(), err))
+        })?
+    };
+
+    validation::validate(dto, path)
+}
+
+fn is_manifest_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("yaml" | "yml" | "json")
+    )
+}
+
+fn is_json_file(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("json")
+}
+
+fn default_plugin_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".ail").join("runners"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_manifest(dir: &Path, filename: &str, content: &str) {
+        let path = dir.join(filename);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+
+    fn create_dummy_exe(dir: &Path, name: &str) -> PathBuf {
+        let exe = dir.join(name);
+        let mut f = std::fs::File::create(&exe).unwrap();
+        f.write_all(b"#!/bin/sh\necho ok").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        exe
+    }
+
+    #[test]
+    fn nonexistent_directory_returns_empty_registry() {
+        let registry = discover_plugins_in(Path::new("/nonexistent/path"));
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn empty_directory_returns_empty_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = discover_plugins_in(dir.path());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn discovers_valid_yaml_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = create_dummy_exe(dir.path(), "my-runner-exe");
+        write_manifest(
+            dir.path(),
+            "my-runner.yaml",
+            &format!(
+                "name: my-runner\nversion: '1.0.0'\nexecutable: '{}'\nprotocol_version: '1'\n",
+                exe.display()
+            ),
+        );
+
+        let registry = discover_plugins_in(dir.path());
+        assert_eq!(registry.len(), 1);
+        let plugin = registry.get("my-runner").unwrap();
+        assert_eq!(plugin.name, "my-runner");
+        assert_eq!(plugin.version, "1.0.0");
+    }
+
+    #[test]
+    fn discovers_valid_json_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = create_dummy_exe(dir.path(), "json-runner");
+        write_manifest(
+            dir.path(),
+            "json-runner.json",
+            &format!(
+                r#"{{"name":"json-runner","version":"0.1.0","executable":"{}","protocol_version":"1"}}"#,
+                exe.display()
+            ),
+        );
+
+        let registry = discover_plugins_in(dir.path());
+        assert_eq!(registry.len(), 1);
+        assert!(registry.get("json-runner").is_some());
+    }
+
+    #[test]
+    fn skips_non_manifest_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "readme.txt", "not a manifest");
+        write_manifest(dir.path(), "notes.md", "# notes");
+
+        let registry = discover_plugins_in(dir.path());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn skips_invalid_manifests_gracefully() {
+        let dir = tempfile::tempdir().unwrap();
+        // Invalid YAML (missing required fields)
+        write_manifest(dir.path(), "bad.yaml", "not_a_manifest: true\n");
+
+        let registry = discover_plugins_in(dir.path());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn duplicate_names_first_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = create_dummy_exe(dir.path(), "dupe-runner");
+
+        // Two manifests with the same runner name but different filenames
+        let content = format!(
+            "name: dupe-runner\nversion: '1.0.0'\nexecutable: '{}'\n",
+            exe.display()
+        );
+        write_manifest(dir.path(), "a-first.yaml", &content);
+        write_manifest(dir.path(), "b-second.yaml", &content);
+
+        let registry = discover_plugins_in(dir.path());
+        // Only one should be registered
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn runner_names_returns_all_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe1 = create_dummy_exe(dir.path(), "runner-a");
+        let exe2 = create_dummy_exe(dir.path(), "runner-b");
+
+        write_manifest(
+            dir.path(),
+            "a.yaml",
+            &format!(
+                "name: runner-a\nversion: '1.0.0'\nexecutable: '{}'\n",
+                exe1.display()
+            ),
+        );
+        write_manifest(
+            dir.path(),
+            "b.yaml",
+            &format!(
+                "name: runner-b\nversion: '1.0.0'\nexecutable: '{}'\n",
+                exe2.display()
+            ),
+        );
+
+        let registry = discover_plugins_in(dir.path());
+        let mut names = registry.runner_names();
+        names.sort();
+        assert_eq!(names, vec!["runner-a", "runner-b"]);
+    }
+
+    #[test]
+    fn relative_executable_resolved_from_manifest_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        create_dummy_exe(dir.path(), "local-runner");
+        write_manifest(
+            dir.path(),
+            "local.yaml",
+            "name: local-runner\nversion: '1.0.0'\nexecutable: './local-runner'\n",
+        );
+
+        let registry = discover_plugins_in(dir.path());
+        assert_eq!(registry.len(), 1);
+        let plugin = registry.get("local-runner").unwrap();
+        assert_eq!(plugin.executable, dir.path().join("local-runner"));
+    }
+}

--- a/ail-core/src/runner/plugin/jsonrpc.rs
+++ b/ail-core/src/runner/plugin/jsonrpc.rs
@@ -1,0 +1,370 @@
+//! Minimal JSON-RPC 2.0 wire types for the AIL Runner Plugin Protocol.
+//!
+//! These are purpose-built for the ail ↔ runner-plugin communication channel.
+//! We do not use a full JSON-RPC library — this is the minimal subset needed:
+//! requests, responses, and notifications over newline-delimited JSON on stdin/stdout.
+
+use serde::{Deserialize, Serialize};
+
+/// JSON-RPC 2.0 request sent from ail to the runner plugin (on stdin).
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: &'static str,
+    pub id: u64,
+    pub method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+impl JsonRpcRequest {
+    pub fn new(id: u64, method: impl Into<String>, params: Option<serde_json::Value>) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+/// JSON-RPC 2.0 response from the runner plugin (on stdout).
+#[derive(Debug, Clone, Deserialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: u64,
+    #[serde(default)]
+    pub result: Option<serde_json::Value>,
+    #[serde(default)]
+    pub error: Option<JsonRpcError>,
+}
+
+impl JsonRpcResponse {
+    /// Returns true if this response indicates an error.
+    pub fn is_error(&self) -> bool {
+        self.error.is_some()
+    }
+}
+
+/// JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
+}
+
+/// JSON-RPC 2.0 notification from the runner plugin (on stdout).
+///
+/// Notifications have no `id` field — they are fire-and-forget.
+/// Used for streaming events (deltas, thinking, tool events, etc.).
+#[derive(Debug, Clone, Deserialize)]
+pub struct JsonRpcNotification {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<serde_json::Value>,
+}
+
+/// A raw JSON-RPC message read from stdout. Could be a response or notification.
+///
+/// We distinguish them by the presence of the `id` field:
+/// - Has `id` → response to a request we sent
+/// - No `id` → notification (streaming event)
+#[derive(Debug, Clone, Deserialize)]
+pub struct RawJsonRpcMessage {
+    pub jsonrpc: String,
+    #[serde(default)]
+    pub id: Option<u64>,
+    #[serde(default)]
+    pub method: Option<String>,
+    #[serde(default)]
+    pub result: Option<serde_json::Value>,
+    #[serde(default)]
+    pub error: Option<JsonRpcError>,
+    #[serde(default)]
+    pub params: Option<serde_json::Value>,
+}
+
+/// Parsed JSON-RPC message — either a response or a notification.
+#[derive(Debug, Clone)]
+pub enum ParsedMessage {
+    Response(JsonRpcResponse),
+    Notification(JsonRpcNotification),
+}
+
+impl RawJsonRpcMessage {
+    /// Parse into a typed response or notification based on the presence of `id`.
+    pub fn parse(self) -> ParsedMessage {
+        if let Some(id) = self.id {
+            ParsedMessage::Response(JsonRpcResponse {
+                jsonrpc: self.jsonrpc,
+                id,
+                result: self.result,
+                error: self.error,
+            })
+        } else {
+            ParsedMessage::Notification(JsonRpcNotification {
+                jsonrpc: self.jsonrpc,
+                method: self.method.unwrap_or_default(),
+                params: self.params,
+            })
+        }
+    }
+}
+
+// ── Protocol method names ────────────────────────────────────────────────────
+
+/// Methods sent from ail to the runner plugin.
+pub mod methods {
+    /// Handshake: exchange protocol version and discover capabilities.
+    pub const INITIALIZE: &str = "initialize";
+    /// Send a prompt, receive a response.
+    pub const INVOKE: &str = "invoke";
+    /// Respond to a tool permission request from the runner.
+    pub const PERMISSION_RESPOND: &str = "permission/respond";
+    /// Request graceful shutdown.
+    pub const SHUTDOWN: &str = "shutdown";
+}
+
+/// Notification methods sent from the runner plugin to ail.
+pub mod notifications {
+    pub const STREAM_DELTA: &str = "stream/delta";
+    pub const STREAM_THINKING: &str = "stream/thinking";
+    pub const STREAM_TOOL_USE: &str = "stream/tool_use";
+    pub const STREAM_TOOL_RESULT: &str = "stream/tool_result";
+    pub const STREAM_COST_UPDATE: &str = "stream/cost_update";
+    pub const STREAM_PERMISSION_REQUEST: &str = "stream/permission_request";
+}
+
+// ── Protocol-level parameter/result types ────────────────────────────────────
+
+/// Parameters for the `initialize` request.
+#[derive(Debug, Clone, Serialize)]
+pub struct InitializeParams {
+    /// The protocol version the host (ail) speaks.
+    pub protocol_version: String,
+    /// The ail version for informational purposes.
+    pub ail_version: String,
+}
+
+/// Result of the `initialize` request.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InitializeResult {
+    /// Runner's declared name (e.g. "codex").
+    pub name: String,
+    /// Runner extension version.
+    pub version: String,
+    /// Protocol version the runner speaks.
+    pub protocol_version: String,
+    /// Declared capabilities.
+    pub capabilities: PluginCapabilities,
+}
+
+/// Capabilities declared by the runner plugin during `initialize`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct PluginCapabilities {
+    /// Runner emits streaming notifications during invoke.
+    #[serde(default)]
+    pub streaming: bool,
+    /// Runner can resume sessions by ID.
+    #[serde(default)]
+    pub session_resume: bool,
+    /// Runner emits tool_use / tool_result events.
+    #[serde(default)]
+    pub tool_events: bool,
+    /// Runner sends permission_request notifications and awaits permission/respond.
+    #[serde(default)]
+    pub permission_requests: bool,
+}
+
+/// Parameters for the `invoke` request.
+#[derive(Debug, Clone, Serialize)]
+pub struct InvokeParams {
+    pub prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_policy: Option<serde_json::Value>,
+}
+
+/// Result of the `invoke` request — maps directly to RunResult fields.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InvokeResult {
+    pub response: String,
+    #[serde(default)]
+    pub cost_usd: Option<f64>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub thinking: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub tool_events: Vec<super::super::ToolEvent>,
+}
+
+/// Parameters for the `permission/respond` request.
+#[derive(Debug, Clone, Serialize)]
+pub struct PermissionRespondParams {
+    pub allow: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+// ── Notification parameter types ─────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreamDeltaParams {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreamThinkingParams {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreamToolUseParams {
+    pub tool_name: String,
+    #[serde(default)]
+    pub tool_use_id: Option<String>,
+    #[serde(default)]
+    pub input: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreamToolResultParams {
+    pub tool_name: String,
+    #[serde(default)]
+    pub tool_use_id: Option<String>,
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub is_error: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreamCostUpdateParams {
+    #[serde(default)]
+    pub cost_usd: f64,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreamPermissionRequestParams {
+    pub display_name: String,
+    pub display_detail: String,
+    #[serde(default)]
+    pub tool_input: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_serializes_with_jsonrpc_version() {
+        let req = JsonRpcRequest::new(1, "initialize", None);
+        let json: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["jsonrpc"], "2.0");
+        assert_eq!(json["id"], 1);
+        assert_eq!(json["method"], "initialize");
+        assert!(json.get("params").is_none());
+    }
+
+    #[test]
+    fn request_serializes_with_params() {
+        let params = serde_json::json!({"protocol_version": "1"});
+        let req = JsonRpcRequest::new(1, "initialize", Some(params.clone()));
+        let json: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["params"], params);
+    }
+
+    #[test]
+    fn response_deserializes_success() {
+        let json = r#"{"jsonrpc":"2.0","id":1,"result":{"name":"codex"}}"#;
+        let resp: JsonRpcResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.id, 1);
+        assert!(resp.result.is_some());
+        assert!(!resp.is_error());
+    }
+
+    #[test]
+    fn response_deserializes_error() {
+        let json =
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}"#;
+        let resp: JsonRpcResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.is_error());
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -32601);
+        assert_eq!(err.message, "Method not found");
+    }
+
+    #[test]
+    fn raw_message_parses_as_response_when_id_present() {
+        let json = r#"{"jsonrpc":"2.0","id":5,"result":{}}"#;
+        let raw: RawJsonRpcMessage = serde_json::from_str(json).unwrap();
+        match raw.parse() {
+            ParsedMessage::Response(resp) => assert_eq!(resp.id, 5),
+            ParsedMessage::Notification(_) => panic!("expected response"),
+        }
+    }
+
+    #[test]
+    fn raw_message_parses_as_notification_when_no_id() {
+        let json = r#"{"jsonrpc":"2.0","method":"stream/delta","params":{"text":"hello"}}"#;
+        let raw: RawJsonRpcMessage = serde_json::from_str(json).unwrap();
+        match raw.parse() {
+            ParsedMessage::Notification(n) => {
+                assert_eq!(n.method, "stream/delta");
+            }
+            ParsedMessage::Response(_) => panic!("expected notification"),
+        }
+    }
+
+    #[test]
+    fn initialize_result_deserializes() {
+        let json = r#"{
+            "name": "codex",
+            "version": "0.1.0",
+            "protocol_version": "1",
+            "capabilities": {
+                "streaming": true,
+                "session_resume": false,
+                "tool_events": false,
+                "permission_requests": false
+            }
+        }"#;
+        let result: InitializeResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.name, "codex");
+        assert!(result.capabilities.streaming);
+        assert!(!result.capabilities.session_resume);
+    }
+
+    #[test]
+    fn invoke_params_serializes() {
+        let params = InvokeParams {
+            prompt: "hello".into(),
+            session_id: Some("ses-1".into()),
+            model: None,
+            system_prompt: None,
+            tool_policy: None,
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["prompt"], "hello");
+        assert_eq!(json["session_id"], "ses-1");
+        assert!(json.get("model").is_none());
+    }
+}

--- a/ail-core/src/runner/plugin/manifest.rs
+++ b/ail-core/src/runner/plugin/manifest.rs
@@ -1,0 +1,26 @@
+//! Validated domain types for runner plugin manifests.
+//!
+//! These types have no serde derives — they are constructed only through
+//! validation in [`super::validation`].
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// A validated runner plugin manifest.
+#[derive(Debug, Clone)]
+pub struct PluginManifest {
+    /// Runner name used in pipeline YAML (`runner: <name>`).
+    pub name: String,
+    /// Version of the runner extension.
+    pub version: String,
+    /// Resolved absolute path to the runner executable.
+    pub executable: PathBuf,
+    /// Protocol version the runner speaks.
+    pub protocol_version: String,
+    /// Environment variables to pass to the runner subprocess.
+    pub env: HashMap<String, String>,
+    /// Command-line arguments to pass to the runner executable.
+    pub args: Vec<String>,
+    /// Path to the manifest file itself (for diagnostics).
+    pub manifest_path: PathBuf,
+}

--- a/ail-core/src/runner/plugin/manifest_dto.rs
+++ b/ail-core/src/runner/plugin/manifest_dto.rs
@@ -1,0 +1,27 @@
+//! Serde DTOs for runner plugin manifest files.
+//!
+//! These are the raw deserialised structs from `~/.ail/runners/<name>.yaml`.
+//! They are converted to domain types in [`super::validation`].
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Raw manifest as read from YAML/JSON.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManifestDto {
+    /// Runner name used in pipeline YAML (`runner: <name>`).
+    pub name: Option<String>,
+    /// Version of the runner extension.
+    pub version: Option<String>,
+    /// Path to the runner executable.
+    /// Can be: absolute, relative to manifest, or a bare name (looked up on PATH).
+    pub executable: Option<String>,
+    /// Protocol version the runner speaks (currently only "1").
+    pub protocol_version: Option<String>,
+    /// Optional environment variables to pass to the runner subprocess.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Optional command-line arguments to pass to the runner executable.
+    #[serde(default)]
+    pub args: Vec<String>,
+}

--- a/ail-core/src/runner/plugin/mod.rs
+++ b/ail-core/src/runner/plugin/mod.rs
@@ -1,0 +1,40 @@
+//! Runner plugin system — runtime-discoverable runner extensions.
+//!
+//! A runner plugin is an executable that speaks the AIL Runner Plugin Protocol
+//! (JSON-RPC 2.0 over stdin/stdout). Users install plugins by placing a manifest
+//! file in `~/.ail/runners/` alongside the plugin binary.
+//!
+//! See `spec/runner/r10-plugin-protocol.md` for the full protocol specification
+//! and `spec/runner/r11-plugin-discovery.md` for manifest and discovery rules.
+
+#![allow(clippy::result_large_err)]
+
+pub mod discovery;
+pub mod jsonrpc;
+pub mod manifest;
+pub mod manifest_dto;
+pub mod protocol_runner;
+pub mod validation;
+
+pub use discovery::{discover_plugins, discover_plugins_in, PluginRegistry};
+pub use manifest::PluginManifest;
+pub use protocol_runner::ProtocolRunner;
+
+use crate::runner::subprocess::SubprocessSpec;
+
+/// Build a [`SubprocessSpec`] from a plugin manifest.
+///
+/// This translates the manifest's executable path, args, and env into the
+/// format expected by [`SubprocessSession::spawn`].
+fn subprocess_spec_from_manifest(manifest: &PluginManifest) -> SubprocessSpec {
+    SubprocessSpec {
+        program: manifest.executable.to_string_lossy().to_string(),
+        args: manifest.args.clone(),
+        env_remove: vec![],
+        env_set: manifest
+            .env
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+    }
+}

--- a/ail-core/src/runner/plugin/protocol_runner.rs
+++ b/ail-core/src/runner/plugin/protocol_runner.rs
@@ -1,0 +1,424 @@
+//! ProtocolRunner — generic Runner implementation that speaks the AIL Runner Plugin Protocol.
+//!
+//! Spawns a plugin executable as a subprocess, communicates via JSON-RPC 2.0 over
+//! stdin/stdout, and translates the wire format to/from ail-core's `RunResult`/`RunnerEvent`.
+
+#![allow(clippy::result_large_err)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::Sender;
+
+use tracing::{debug, warn};
+
+use super::jsonrpc::{
+    self, InitializeParams, InitializeResult, InvokeParams, InvokeResult, JsonRpcRequest,
+    ParsedMessage, PermissionRespondParams, PluginCapabilities, RawJsonRpcMessage,
+    StreamCostUpdateParams, StreamDeltaParams, StreamPermissionRequestParams, StreamThinkingParams,
+    StreamToolResultParams, StreamToolUseParams,
+};
+use super::manifest::PluginManifest;
+use super::subprocess_spec_from_manifest;
+use crate::error::AilError;
+use crate::runner::subprocess::SubprocessSession;
+use crate::runner::{
+    InvokeOptions, PermissionRequest, PermissionResponse, RunResult, Runner, RunnerEvent,
+    ToolPermissionPolicy,
+};
+
+/// A runner that communicates with any AIL Runner Protocol-compliant executable.
+pub struct ProtocolRunner {
+    manifest: PluginManifest,
+}
+
+impl ProtocolRunner {
+    pub fn new(manifest: PluginManifest) -> Self {
+        Self { manifest }
+    }
+}
+
+impl Runner for ProtocolRunner {
+    fn invoke(&self, prompt: &str, options: InvokeOptions) -> Result<RunResult, AilError> {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        self.invoke_streaming(prompt, options, tx)
+    }
+
+    fn invoke_streaming(
+        &self,
+        prompt: &str,
+        options: InvokeOptions,
+        tx: Sender<RunnerEvent>,
+    ) -> Result<RunResult, AilError> {
+        let spec = subprocess_spec_from_manifest(&self.manifest);
+        let cancel_token = options.cancel_token.clone().unwrap_or_default();
+
+        let mut subprocess = SubprocessSession::spawn(spec, Some(cancel_token.clone()))?;
+
+        // Take stdin — we need to write to the child
+        let mut stdin = subprocess.take_stdin().ok_or_else(|| {
+            AilError::plugin_protocol_error("failed to open stdin to plugin process")
+        })?;
+
+        // Take stdout for reading responses
+        let stdout = subprocess.take_stdout().ok_or_else(|| {
+            AilError::plugin_protocol_error("failed to open stdout from plugin process")
+        })?;
+        let reader = BufReader::new(stdout);
+
+        let id_counter = AtomicU64::new(1);
+
+        // 1. Initialize handshake
+        let init_params = InitializeParams {
+            protocol_version: "1".to_string(),
+            ail_version: crate::version().to_string(),
+        };
+        let init_id = id_counter.fetch_add(1, Ordering::SeqCst);
+        let init_req = JsonRpcRequest::new(
+            init_id,
+            jsonrpc::methods::INITIALIZE,
+            Some(serde_json::to_value(&init_params).map_err(|e| {
+                AilError::plugin_protocol_error(format!("failed to serialize init params: {e}"))
+            })?),
+        );
+
+        send_request(&mut stdin, &init_req)?;
+        let (capabilities, mut lines) = read_initialize_response(reader, init_id)?;
+
+        debug!(
+            runner = %self.manifest.name,
+            streaming = capabilities.streaming,
+            session_resume = capabilities.session_resume,
+            "plugin initialized"
+        );
+
+        // 2. Send invoke request
+        let invoke_id = id_counter.fetch_add(1, Ordering::SeqCst);
+        let tool_policy_json = serialize_tool_policy(&options.tool_policy);
+        let invoke_params = InvokeParams {
+            prompt: prompt.to_string(),
+            session_id: options.resume_session_id.clone(),
+            model: options.model.clone(),
+            system_prompt: options.system_prompt.clone(),
+            tool_policy: tool_policy_json,
+        };
+        let invoke_req = JsonRpcRequest::new(
+            invoke_id,
+            jsonrpc::methods::INVOKE,
+            Some(serde_json::to_value(&invoke_params).map_err(|e| {
+                AilError::plugin_protocol_error(format!("failed to serialize invoke params: {e}"))
+            })?),
+        );
+
+        send_request(&mut stdin, &invoke_req)?;
+
+        // 3. Read streaming notifications and the final response
+        let result = read_invoke_response(
+            &mut lines,
+            invoke_id,
+            &tx,
+            &options,
+            &mut stdin,
+            &id_counter,
+        )?;
+
+        // 4. Send shutdown (best-effort)
+        let shutdown_id = id_counter.fetch_add(1, Ordering::SeqCst);
+        let shutdown_req = JsonRpcRequest::new(shutdown_id, jsonrpc::methods::SHUTDOWN, None);
+        let _ = send_request(&mut stdin, &shutdown_req);
+        drop(stdin);
+
+        // 5. Reap the subprocess
+        let outcome = subprocess.finish()?;
+        if outcome.was_cancelled {
+            return Err(AilError::runner_cancelled(
+                "plugin invocation was cancelled",
+            ));
+        }
+
+        let _ = tx.send(RunnerEvent::Completed(result.clone()));
+        Ok(result)
+    }
+}
+
+// ── Wire helpers ─────────────────────────────────────────────────────────────
+
+fn send_request(stdin: &mut impl Write, req: &JsonRpcRequest) -> Result<(), AilError> {
+    let line = serde_json::to_string(req).map_err(|e| {
+        AilError::plugin_protocol_error(format!("failed to serialize request: {e}"))
+    })?;
+    writeln!(stdin, "{}", line).map_err(|e| {
+        AilError::plugin_protocol_error(format!("failed to write to plugin stdin: {e}"))
+    })?;
+    stdin.flush().map_err(|e| {
+        AilError::plugin_protocol_error(format!("failed to flush plugin stdin: {e}"))
+    })?;
+    Ok(())
+}
+
+/// Read lines from stdout until we get the initialize response.
+fn read_initialize_response<R: BufRead>(
+    reader: R,
+    expected_id: u64,
+) -> Result<(PluginCapabilities, std::io::Lines<R>), AilError> {
+    let mut lines = reader.lines();
+
+    loop {
+        let line = match lines.next() {
+            Some(Ok(l)) => l,
+            Some(Err(e)) => {
+                return Err(AilError::plugin_protocol_error(format!(
+                    "failed to read from plugin stdout: {e}"
+                )));
+            }
+            None => {
+                return Err(AilError::plugin_protocol_error(
+                    "plugin closed stdout before sending initialize response",
+                ));
+            }
+        };
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let raw: RawJsonRpcMessage = serde_json::from_str(&line).map_err(|e| {
+            AilError::plugin_protocol_error(format!(
+                "invalid JSON-RPC from plugin: {e} (line: {line})"
+            ))
+        })?;
+
+        match raw.parse() {
+            ParsedMessage::Response(resp) => {
+                if resp.id != expected_id {
+                    warn!(
+                        expected = expected_id,
+                        got = resp.id,
+                        "unexpected response id during initialize"
+                    );
+                    continue;
+                }
+                if let Some(err) = resp.error {
+                    return Err(AilError::plugin_protocol_error(format!(
+                        "plugin initialize failed: {} (code {})",
+                        err.message, err.code
+                    )));
+                }
+                let result_value = resp.result.ok_or_else(|| {
+                    AilError::plugin_protocol_error("plugin initialize response has no result")
+                })?;
+                let init_result: InitializeResult =
+                    serde_json::from_value(result_value).map_err(|e| {
+                        AilError::plugin_protocol_error(format!("invalid initialize result: {e}"))
+                    })?;
+                return Ok((init_result.capabilities, lines));
+            }
+            ParsedMessage::Notification(n) => {
+                debug!(method = %n.method, "ignoring notification during initialize");
+                continue;
+            }
+        }
+    }
+}
+
+/// Read streaming notifications and the final invoke response.
+fn read_invoke_response<R: BufRead>(
+    lines: &mut std::io::Lines<R>,
+    expected_id: u64,
+    tx: &Sender<RunnerEvent>,
+    options: &InvokeOptions,
+    stdin: &mut impl Write,
+    id_counter: &AtomicU64,
+) -> Result<RunResult, AilError> {
+    loop {
+        let line = match lines.next() {
+            Some(Ok(l)) => l,
+            Some(Err(e)) => {
+                return Err(AilError::plugin_protocol_error(format!(
+                    "failed to read from plugin stdout: {e}"
+                )));
+            }
+            None => {
+                return Err(AilError::plugin_protocol_error(
+                    "plugin closed stdout before sending invoke response",
+                ));
+            }
+        };
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let raw: RawJsonRpcMessage = serde_json::from_str(&line).map_err(|e| {
+            AilError::plugin_protocol_error(format!(
+                "invalid JSON-RPC from plugin: {e} (line: {})",
+                truncate(&line, 200)
+            ))
+        })?;
+
+        match raw.parse() {
+            ParsedMessage::Response(resp) => {
+                if resp.id != expected_id {
+                    debug!(
+                        expected = expected_id,
+                        got = resp.id,
+                        "unexpected response id"
+                    );
+                    continue;
+                }
+                if let Some(err) = resp.error {
+                    return Err(AilError::runner_failed(format!(
+                        "plugin invoke failed: {} (code {})",
+                        err.message, err.code
+                    )));
+                }
+                let result_value = resp.result.ok_or_else(|| {
+                    AilError::plugin_protocol_error("plugin invoke response has no result")
+                })?;
+                let invoke_result: InvokeResult =
+                    serde_json::from_value(result_value).map_err(|e| {
+                        AilError::plugin_protocol_error(format!("invalid invoke result: {e}"))
+                    })?;
+                return Ok(RunResult {
+                    response: invoke_result.response,
+                    cost_usd: invoke_result.cost_usd,
+                    session_id: invoke_result.session_id,
+                    input_tokens: invoke_result.input_tokens,
+                    output_tokens: invoke_result.output_tokens,
+                    thinking: invoke_result.thinking,
+                    model: invoke_result.model,
+                    tool_events: invoke_result.tool_events,
+                });
+            }
+            ParsedMessage::Notification(n) => {
+                handle_notification(&n.method, n.params, tx, options, stdin, id_counter);
+            }
+        }
+    }
+}
+
+/// Dispatch a streaming notification to the appropriate RunnerEvent.
+fn handle_notification(
+    method: &str,
+    params: Option<serde_json::Value>,
+    tx: &Sender<RunnerEvent>,
+    options: &InvokeOptions,
+    stdin: &mut impl Write,
+    id_counter: &AtomicU64,
+) {
+    let params = params.unwrap_or(serde_json::Value::Null);
+
+    match method {
+        jsonrpc::notifications::STREAM_DELTA => {
+            if let Ok(p) = serde_json::from_value::<StreamDeltaParams>(params) {
+                let _ = tx.send(RunnerEvent::StreamDelta { text: p.text });
+            }
+        }
+        jsonrpc::notifications::STREAM_THINKING => {
+            if let Ok(p) = serde_json::from_value::<StreamThinkingParams>(params) {
+                let _ = tx.send(RunnerEvent::Thinking { text: p.text });
+            }
+        }
+        jsonrpc::notifications::STREAM_TOOL_USE => {
+            if let Ok(p) = serde_json::from_value::<StreamToolUseParams>(params) {
+                let _ = tx.send(RunnerEvent::ToolUse {
+                    tool_name: p.tool_name,
+                    tool_use_id: p.tool_use_id,
+                    input: p.input,
+                });
+            }
+        }
+        jsonrpc::notifications::STREAM_TOOL_RESULT => {
+            if let Ok(p) = serde_json::from_value::<StreamToolResultParams>(params) {
+                let _ = tx.send(RunnerEvent::ToolResult {
+                    tool_name: p.tool_name,
+                    tool_use_id: p.tool_use_id,
+                    content: p.content,
+                    is_error: p.is_error,
+                });
+            }
+        }
+        jsonrpc::notifications::STREAM_COST_UPDATE => {
+            if let Ok(p) = serde_json::from_value::<StreamCostUpdateParams>(params) {
+                let _ = tx.send(RunnerEvent::CostUpdate {
+                    cost_usd: p.cost_usd,
+                    input_tokens: p.input_tokens,
+                    output_tokens: p.output_tokens,
+                });
+            }
+        }
+        jsonrpc::notifications::STREAM_PERMISSION_REQUEST => {
+            if let Ok(p) = serde_json::from_value::<StreamPermissionRequestParams>(params) {
+                handle_permission_request(p, options, stdin, id_counter, tx);
+            }
+        }
+        other => {
+            debug!(
+                method = other,
+                "unknown notification from plugin — ignoring"
+            );
+        }
+    }
+}
+
+/// Handle a permission request from the plugin.
+fn handle_permission_request(
+    params: StreamPermissionRequestParams,
+    options: &InvokeOptions,
+    stdin: &mut impl Write,
+    id_counter: &AtomicU64,
+    tx: &Sender<RunnerEvent>,
+) {
+    let request = PermissionRequest {
+        display_name: params.display_name,
+        display_detail: params.display_detail,
+        tool_input: params.tool_input,
+    };
+
+    // If we have a permission responder, use it
+    let response = if let Some(ref responder) = options.permission_responder {
+        responder(request)
+    } else {
+        // No responder — emit event and default deny
+        let _ = tx.send(RunnerEvent::PermissionRequested(request));
+        PermissionResponse::Deny("no permission handler configured".to_string())
+    };
+
+    // Send the permission response back to the plugin
+    let (allow, reason) = match response {
+        PermissionResponse::Allow => (true, None),
+        PermissionResponse::Deny(r) => (false, Some(r)),
+    };
+
+    let resp_id = id_counter.fetch_add(1, Ordering::SeqCst);
+    let resp_params = PermissionRespondParams { allow, reason };
+    let req = JsonRpcRequest::new(
+        resp_id,
+        jsonrpc::methods::PERMISSION_RESPOND,
+        serde_json::to_value(&resp_params).ok(),
+    );
+    let _ = send_request(stdin, &req);
+}
+
+fn serialize_tool_policy(policy: &ToolPermissionPolicy) -> Option<serde_json::Value> {
+    match policy {
+        ToolPermissionPolicy::RunnerDefault => None,
+        ToolPermissionPolicy::NoTools => Some(serde_json::json!({"type": "no_tools"})),
+        ToolPermissionPolicy::Allowlist(tools) => {
+            Some(serde_json::json!({"type": "allowlist", "tools": tools}))
+        }
+        ToolPermissionPolicy::Denylist(tools) => {
+            Some(serde_json::json!({"type": "denylist", "tools": tools}))
+        }
+        ToolPermissionPolicy::Mixed { allow, deny } => {
+            Some(serde_json::json!({"type": "mixed", "allow": allow, "deny": deny}))
+        }
+    }
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        &s[..max]
+    }
+}

--- a/ail-core/src/runner/plugin/validation.rs
+++ b/ail-core/src/runner/plugin/validation.rs
@@ -49,15 +49,6 @@ pub fn validate(dto: ManifestDto, manifest_path: &Path) -> Result<PluginManifest
         ))
     })?;
 
-    let executable_str = dto.executable.filter(|s| !s.is_empty()).ok_or_else(|| {
-        AilError::plugin_manifest_invalid(format!(
-            "{}: 'executable' field is required",
-            manifest_path.display()
-        ))
-    })?;
-
-    let executable = resolve_executable(&executable_str, manifest_path)?;
-
     let protocol_version = dto
         .protocol_version
         .filter(|s| !s.is_empty())
@@ -70,6 +61,15 @@ pub fn validate(dto: ManifestDto, manifest_path: &Path) -> Result<PluginManifest
             protocol_version
         )));
     }
+
+    let executable_str = dto.executable.filter(|s| !s.is_empty()).ok_or_else(|| {
+        AilError::plugin_manifest_invalid(format!(
+            "{}: 'executable' field is required",
+            manifest_path.display()
+        ))
+    })?;
+
+    let executable = resolve_executable(&executable_str, manifest_path)?;
 
     Ok(PluginManifest {
         name,

--- a/ail-core/src/runner/plugin/validation.rs
+++ b/ail-core/src/runner/plugin/validation.rs
@@ -1,0 +1,282 @@
+//! DTO → Domain validation for runner plugin manifests.
+
+#![allow(clippy::result_large_err)]
+
+use std::path::{Path, PathBuf};
+
+use crate::error::AilError;
+
+use super::manifest::PluginManifest;
+use super::manifest_dto::ManifestDto;
+
+/// Validate a raw manifest DTO into a domain `PluginManifest`.
+///
+/// `manifest_path` is the path to the YAML/JSON file the DTO was read from.
+/// It is used for resolving relative executable paths and diagnostics.
+pub fn validate(dto: ManifestDto, manifest_path: &Path) -> Result<PluginManifest, AilError> {
+    let name = dto.name.filter(|s| !s.is_empty()).ok_or_else(|| {
+        AilError::plugin_manifest_invalid(format!(
+            "{}: 'name' field is required",
+            manifest_path.display()
+        ))
+    })?;
+
+    // Runner names must be alphanumeric + hyphens, and must not collide with built-ins.
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(AilError::plugin_manifest_invalid(format!(
+            "{}: runner name '{}' contains invalid characters (only alphanumeric, hyphens, underscores allowed)",
+            manifest_path.display(),
+            name
+        )));
+    }
+
+    let builtin_names = ["claude", "http", "ollama", "stub"];
+    if builtin_names.contains(&name.to_lowercase().as_str()) {
+        return Err(AilError::plugin_manifest_invalid(format!(
+            "{}: runner name '{}' conflicts with a built-in runner",
+            manifest_path.display(),
+            name
+        )));
+    }
+
+    let version = dto.version.filter(|s| !s.is_empty()).ok_or_else(|| {
+        AilError::plugin_manifest_invalid(format!(
+            "{}: 'version' field is required",
+            manifest_path.display()
+        ))
+    })?;
+
+    let executable_str = dto.executable.filter(|s| !s.is_empty()).ok_or_else(|| {
+        AilError::plugin_manifest_invalid(format!(
+            "{}: 'executable' field is required",
+            manifest_path.display()
+        ))
+    })?;
+
+    let executable = resolve_executable(&executable_str, manifest_path)?;
+
+    let protocol_version = dto
+        .protocol_version
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "1".to_string());
+
+    if protocol_version != "1" {
+        return Err(AilError::plugin_manifest_invalid(format!(
+            "{}: unsupported protocol_version '{}' (only '1' is supported)",
+            manifest_path.display(),
+            protocol_version
+        )));
+    }
+
+    Ok(PluginManifest {
+        name,
+        version,
+        executable,
+        protocol_version,
+        env: dto.env,
+        args: dto.args,
+        manifest_path: manifest_path.to_path_buf(),
+    })
+}
+
+/// Resolve the executable path from the manifest.
+///
+/// Resolution order:
+/// 1. If absolute path → use as-is (must exist)
+/// 2. If starts with `./` or `../` → relative to manifest directory (must exist)
+/// 3. Otherwise → bare name, looked up on PATH via `which`
+fn resolve_executable(raw: &str, manifest_path: &Path) -> Result<PathBuf, AilError> {
+    let path = Path::new(raw);
+
+    if path.is_absolute() {
+        if path.exists() {
+            return Ok(path.to_path_buf());
+        }
+        return Err(AilError::plugin_manifest_invalid(format!(
+            "{}: executable '{}' not found",
+            manifest_path.display(),
+            raw
+        )));
+    }
+
+    // Relative to manifest directory
+    if raw.starts_with("./") || raw.starts_with("../") {
+        if let Some(dir) = manifest_path.parent() {
+            let resolved = dir.join(path);
+            if resolved.exists() {
+                return Ok(resolved);
+            }
+            return Err(AilError::plugin_manifest_invalid(format!(
+                "{}: executable '{}' not found (resolved to '{}')",
+                manifest_path.display(),
+                raw,
+                resolved.display()
+            )));
+        }
+    }
+
+    // Bare name → look up on PATH
+    which_lookup(raw, manifest_path)
+}
+
+/// Look up a bare executable name on the system PATH.
+fn which_lookup(name: &str, manifest_path: &Path) -> Result<PathBuf, AilError> {
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(name);
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(AilError::plugin_manifest_invalid(format!(
+        "{}: executable '{}' not found on PATH",
+        manifest_path.display(),
+        name
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::io::Write;
+
+    fn make_dto(name: &str, executable: &str) -> ManifestDto {
+        ManifestDto {
+            name: Some(name.to_string()),
+            version: Some("1.0.0".to_string()),
+            executable: Some(executable.to_string()),
+            protocol_version: Some("1".to_string()),
+            env: HashMap::new(),
+            args: vec![],
+        }
+    }
+
+    #[test]
+    fn missing_name_is_error() {
+        let dto = ManifestDto {
+            name: None,
+            version: Some("1.0.0".to_string()),
+            executable: Some("/bin/true".to_string()),
+            protocol_version: Some("1".to_string()),
+            env: HashMap::new(),
+            args: vec![],
+        };
+        let err = validate(dto, Path::new("/tmp/test.yaml")).unwrap_err();
+        assert!(err.detail().contains("name"));
+    }
+
+    #[test]
+    fn empty_name_is_error() {
+        let dto = make_dto("", "/bin/true");
+        let err = validate(dto, Path::new("/tmp/test.yaml")).unwrap_err();
+        assert!(err.detail().contains("name"));
+    }
+
+    #[test]
+    fn builtin_name_is_rejected() {
+        let dto = make_dto("claude", "/bin/true");
+        let err = validate(dto, Path::new("/tmp/test.yaml")).unwrap_err();
+        assert!(err.detail().contains("built-in"));
+    }
+
+    #[test]
+    fn invalid_chars_in_name_rejected() {
+        let dto = make_dto("my runner!", "/bin/true");
+        let err = validate(dto, Path::new("/tmp/test.yaml")).unwrap_err();
+        assert!(err.detail().contains("invalid characters"));
+    }
+
+    #[test]
+    fn hyphen_and_underscore_allowed_in_name() {
+        let dto = make_dto("my-runner_v2", "/bin/true");
+        let result = validate(dto, Path::new("/tmp/test.yaml"));
+        // May fail on executable not found, but name validation should pass
+        if let Err(e) = &result {
+            assert!(
+                !e.detail().contains("invalid characters"),
+                "hyphens and underscores should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_executable_is_error() {
+        let dto = ManifestDto {
+            name: Some("test".to_string()),
+            version: Some("1.0.0".to_string()),
+            executable: None,
+            protocol_version: Some("1".to_string()),
+            env: HashMap::new(),
+            args: vec![],
+        };
+        let err = validate(dto, Path::new("/tmp/test.yaml")).unwrap_err();
+        assert!(err.detail().contains("executable"));
+    }
+
+    #[test]
+    fn unsupported_protocol_version_rejected() {
+        let dto = ManifestDto {
+            name: Some("test".to_string()),
+            version: Some("1.0.0".to_string()),
+            executable: Some("/bin/true".to_string()),
+            protocol_version: Some("99".to_string()),
+            env: HashMap::new(),
+            args: vec![],
+        };
+        let err = validate(dto, Path::new("/tmp/test.yaml")).unwrap_err();
+        assert!(err.detail().contains("protocol_version"));
+    }
+
+    #[test]
+    fn absolute_executable_that_exists_succeeds() {
+        let dto = make_dto("test-runner", "/bin/true");
+        let result = validate(dto, Path::new("/tmp/test.yaml"));
+        // /bin/true exists on Linux
+        if Path::new("/bin/true").exists() {
+            let manifest = result.unwrap();
+            assert_eq!(manifest.name, "test-runner");
+            assert_eq!(manifest.executable, PathBuf::from("/bin/true"));
+        }
+    }
+
+    #[test]
+    fn absolute_executable_that_does_not_exist_is_error() {
+        let dto = make_dto("test-runner", "/nonexistent/binary");
+        let err = validate(dto, Path::new("/tmp/test.yaml")).unwrap_err();
+        assert!(err.detail().contains("not found"));
+    }
+
+    #[test]
+    fn relative_executable_resolved_from_manifest_dir() {
+        // Create a temp executable
+        let dir = tempfile::tempdir().unwrap();
+        let exe_path = dir.path().join("my-runner");
+        let mut f = std::fs::File::create(&exe_path).unwrap();
+        f.write_all(b"#!/bin/sh\necho ok").unwrap();
+
+        let manifest_path = dir.path().join("runner.yaml");
+        let dto = make_dto("test-runner", "./my-runner");
+        let manifest = validate(dto, &manifest_path).unwrap();
+        assert_eq!(manifest.executable, exe_path);
+    }
+
+    #[test]
+    fn default_protocol_version_is_1() {
+        let dto = ManifestDto {
+            name: Some("test-runner".to_string()),
+            version: Some("1.0.0".to_string()),
+            executable: Some("/bin/true".to_string()),
+            protocol_version: None,
+            env: HashMap::new(),
+            args: vec![],
+        };
+        if Path::new("/bin/true").exists() {
+            let manifest = validate(dto, Path::new("/tmp/test.yaml")).unwrap();
+            assert_eq!(manifest.protocol_version, "1");
+        }
+    }
+}

--- a/ail-core/src/runner/subprocess.rs
+++ b/ail-core/src/runner/subprocess.rs
@@ -9,7 +9,7 @@
 #![allow(clippy::result_large_err)]
 
 use std::io::{BufReader, Read};
-use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
+use std::process::{Child, ChildStdin, ChildStdout, Command, ExitStatus, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
@@ -55,6 +55,7 @@ pub struct SubprocessOutcome {
 /// killed child exits non-zero.
 pub struct SubprocessSession {
     child: Arc<Mutex<Child>>,
+    stdin: Option<ChildStdin>,
     stdout: Option<BufReader<ChildStdout>>,
     stderr_handle: Option<JoinHandle<String>>,
     watchdog: Option<JoinHandle<()>>,
@@ -82,6 +83,7 @@ impl SubprocessSession {
             cmd.env(k, v);
         }
         let mut child = cmd
+            .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -90,6 +92,7 @@ impl SubprocessSession {
                 context: None,
             })?;
 
+        let stdin = child.stdin.take().expect("stdin was piped");
         let stdout = child.stdout.take().expect("stdout was piped");
         let stderr = child.stderr.take().expect("stderr was piped");
 
@@ -131,11 +134,21 @@ impl SubprocessSession {
 
         Ok(Self {
             child,
+            stdin: Some(stdin),
             stdout: Some(BufReader::new(stdout)),
             stderr_handle: Some(stderr_handle),
             watchdog,
             cancel_token,
         })
+    }
+
+    /// Take the child's stdin handle. May only be called once — subsequent calls return `None`.
+    ///
+    /// Used by runners that need to write to the child process (e.g. ProtocolRunner sends
+    /// JSON-RPC requests on stdin). Runners that only read stdout (e.g. ClaudeCliRunner) do
+    /// not need this — dropping the handle is fine.
+    pub fn take_stdin(&mut self) -> Option<ChildStdin> {
+        self.stdin.take()
     }
 
     /// Take the buffered stdout reader. May only be called once — subsequent calls return `None`.

--- a/ail-core/tests/spec/mod.rs
+++ b/ail-core/tests/spec/mod.rs
@@ -20,6 +20,8 @@ mod s12_step_conditions;
 mod s13_sqlite_provider;
 mod s17_error_handling;
 mod s18_materialize;
+mod s19_plugin_discovery;
+mod s19_plugin_protocol;
 mod s21_mvp;
 mod s23_structured_output;
 mod s35_ail_log_formatter;

--- a/ail-core/tests/spec/s19_plugin_discovery.rs
+++ b/ail-core/tests/spec/s19_plugin_discovery.rs
@@ -1,0 +1,221 @@
+//! Tests for runner plugin discovery (spec/runner/r11-plugin-discovery.md).
+
+use ail_core::runner::plugin::discovery::discover_plugins_in;
+use std::io::Write;
+use std::path::Path;
+
+fn write_file(dir: &Path, name: &str, content: &str) {
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+fn create_exe(dir: &Path, name: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(b"#!/bin/sh\necho ok").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    path
+}
+
+#[test]
+fn discover_empty_dir_returns_empty_registry() {
+    let dir = tempfile::tempdir().unwrap();
+    let reg = discover_plugins_in(dir.path());
+    assert!(reg.is_empty());
+}
+
+#[test]
+fn discover_nonexistent_dir_returns_empty_registry() {
+    let reg = discover_plugins_in(Path::new("/nonexistent/path/12345"));
+    assert!(reg.is_empty());
+}
+
+#[test]
+fn discover_valid_yaml_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = create_exe(dir.path(), "my-runner");
+    write_file(
+        dir.path(),
+        "my-runner.yaml",
+        &format!(
+            "name: my-runner\nversion: '1.0.0'\nexecutable: '{}'\nprotocol_version: '1'\n",
+            exe.display()
+        ),
+    );
+
+    let reg = discover_plugins_in(dir.path());
+    assert_eq!(reg.len(), 1);
+    let plugin = reg.get("my-runner").unwrap();
+    assert_eq!(plugin.name, "my-runner");
+    assert_eq!(plugin.version, "1.0.0");
+    assert_eq!(plugin.protocol_version, "1");
+}
+
+#[test]
+fn discover_valid_json_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = create_exe(dir.path(), "json-runner");
+    write_file(
+        dir.path(),
+        "json-runner.json",
+        &format!(
+            r#"{{"name":"json-runner","version":"0.2.0","executable":"{}","protocol_version":"1"}}"#,
+            exe.display()
+        ),
+    );
+
+    let reg = discover_plugins_in(dir.path());
+    assert_eq!(reg.len(), 1);
+    let plugin = reg.get("json-runner").unwrap();
+    assert_eq!(plugin.version, "0.2.0");
+}
+
+#[test]
+fn discover_skips_invalid_manifests() {
+    let dir = tempfile::tempdir().unwrap();
+    // Invalid: missing required fields
+    write_file(dir.path(), "bad.yaml", "foo: bar\n");
+    // Invalid: not even valid YAML
+    write_file(dir.path(), "worse.yaml", "{{{{not yaml\n");
+
+    let reg = discover_plugins_in(dir.path());
+    assert!(reg.is_empty());
+}
+
+#[test]
+fn discover_skips_non_manifest_extensions() {
+    let dir = tempfile::tempdir().unwrap();
+    write_file(dir.path(), "readme.md", "# not a manifest");
+    write_file(dir.path(), "notes.txt", "not a manifest either");
+
+    let reg = discover_plugins_in(dir.path());
+    assert!(reg.is_empty());
+}
+
+#[test]
+fn discover_rejects_builtin_name_collision() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = create_exe(dir.path(), "fake-claude");
+    write_file(
+        dir.path(),
+        "claude.yaml",
+        &format!(
+            "name: claude\nversion: '1.0.0'\nexecutable: '{}'\n",
+            exe.display()
+        ),
+    );
+
+    let reg = discover_plugins_in(dir.path());
+    assert!(reg.is_empty(), "built-in name 'claude' should be rejected");
+}
+
+#[test]
+fn discover_multiple_plugins() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe_a = create_exe(dir.path(), "runner-a");
+    let exe_b = create_exe(dir.path(), "runner-b");
+
+    write_file(
+        dir.path(),
+        "a.yaml",
+        &format!(
+            "name: runner-a\nversion: '1.0.0'\nexecutable: '{}'\n",
+            exe_a.display()
+        ),
+    );
+    write_file(
+        dir.path(),
+        "b.yaml",
+        &format!(
+            "name: runner-b\nversion: '2.0.0'\nexecutable: '{}'\n",
+            exe_b.display()
+        ),
+    );
+
+    let reg = discover_plugins_in(dir.path());
+    assert_eq!(reg.len(), 2);
+    assert!(reg.get("runner-a").is_some());
+    assert!(reg.get("runner-b").is_some());
+}
+
+#[test]
+fn discover_relative_executable_resolved_from_manifest_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    create_exe(dir.path(), "local-exe");
+    write_file(
+        dir.path(),
+        "local.yaml",
+        "name: local-runner\nversion: '1.0.0'\nexecutable: './local-exe'\n",
+    );
+
+    let reg = discover_plugins_in(dir.path());
+    assert_eq!(reg.len(), 1);
+    let plugin = reg.get("local-runner").unwrap();
+    assert_eq!(plugin.executable, dir.path().join("local-exe"));
+}
+
+#[test]
+fn discover_env_vars_preserved() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = create_exe(dir.path(), "env-runner");
+    write_file(
+        dir.path(),
+        "env.yaml",
+        &format!(
+            "name: env-runner\nversion: '1.0.0'\nexecutable: '{}'\nenv:\n  MY_KEY: my_value\n",
+            exe.display()
+        ),
+    );
+
+    let reg = discover_plugins_in(dir.path());
+    let plugin = reg.get("env-runner").unwrap();
+    assert_eq!(plugin.env.get("MY_KEY").unwrap(), "my_value");
+}
+
+#[test]
+fn factory_builds_plugin_runner() {
+    use ail_core::config::domain::ProviderConfig;
+    use ail_core::runner::factory::RunnerFactory;
+    use ail_core::runner::http::HttpSessionStore;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    let dir = tempfile::tempdir().unwrap();
+    let exe = create_exe(dir.path(), "test-plugin");
+    write_file(
+        dir.path(),
+        "test-plugin.yaml",
+        &format!(
+            "name: test-plugin\nversion: '1.0.0'\nexecutable: '{}'\n",
+            exe.display()
+        ),
+    );
+
+    let registry = discover_plugins_in(dir.path());
+    let store: HttpSessionStore = Arc::new(Mutex::new(HashMap::new()));
+    let provider = ProviderConfig::default();
+
+    // Should succeed — plugin found in registry
+    let result =
+        RunnerFactory::build_with_registry("test-plugin", false, &store, &provider, &registry);
+    assert!(result.is_ok(), "plugin runner should be found in registry");
+
+    // Should fail — unknown name not in registry
+    let result =
+        RunnerFactory::build_with_registry("nonexistent", false, &store, &provider, &registry);
+    match result {
+        Ok(_) => panic!("expected RUNNER_NOT_FOUND error"),
+        Err(err) => {
+            assert!(
+                err.detail().contains("test-plugin"),
+                "error message should list discovered plugins: {}",
+                err.detail()
+            );
+        }
+    }
+}

--- a/ail-core/tests/spec/s19_plugin_protocol.rs
+++ b/ail-core/tests/spec/s19_plugin_protocol.rs
@@ -1,0 +1,173 @@
+//! Tests for the AIL Runner Plugin Protocol (spec/runner/r10-plugin-protocol.md).
+//!
+//! Uses shell scripts as minimal protocol-compliant plugins to test the
+//! ProtocolRunner end-to-end.
+
+use ail_core::runner::plugin::discovery::discover_plugins_in;
+use ail_core::runner::plugin::ProtocolRunner;
+use ail_core::runner::{InvokeOptions, Runner};
+use std::io::Write;
+use std::path::Path;
+
+/// Create a shell script that implements the minimum viable plugin protocol.
+/// It reads JSON-RPC from stdin, responds to initialize and invoke, then shuts down.
+fn create_echo_plugin(dir: &Path) -> std::path::PathBuf {
+    let script = dir.join("echo-plugin");
+    let mut f = std::fs::File::create(&script).unwrap();
+    // This shell script uses a simple approach:
+    // - Read lines from stdin
+    // - Use basic string matching to identify methods
+    // - Respond with appropriate JSON-RPC
+    f.write_all(
+        br#"#!/bin/sh
+while IFS= read -r line; do
+    case "$line" in
+        *'"method":"initialize"'*)
+            id=$(echo "$line" | sed 's/.*"id":\([0-9]*\).*/\1/')
+            printf '{"jsonrpc":"2.0","id":%s,"result":{"name":"echo","version":"0.1.0","protocol_version":"1","capabilities":{"streaming":false,"session_resume":false,"tool_events":false,"permission_requests":false}}}\n' "$id"
+            ;;
+        *'"method":"invoke"'*)
+            id=$(echo "$line" | sed 's/.*"id":\([0-9]*\).*/\1/')
+            # Extract prompt - simplified extraction
+            prompt=$(echo "$line" | sed 's/.*"prompt":"\([^"]*\)".*/\1/')
+            printf '{"jsonrpc":"2.0","id":%s,"result":{"response":"Echo: %s","input_tokens":10,"output_tokens":5}}\n' "$id" "$prompt"
+            ;;
+        *'"method":"shutdown"'*)
+            id=$(echo "$line" | sed 's/.*"id":\([0-9]*\).*/\1/')
+            printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+            exit 0
+            ;;
+    esac
+done
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    script
+}
+
+/// Create a plugin that streams notifications before responding.
+fn create_streaming_plugin(dir: &Path) -> std::path::PathBuf {
+    let script = dir.join("stream-plugin");
+    let mut f = std::fs::File::create(&script).unwrap();
+    f.write_all(
+        br#"#!/bin/sh
+while IFS= read -r line; do
+    case "$line" in
+        *'"method":"initialize"'*)
+            id=$(echo "$line" | sed 's/.*"id":\([0-9]*\).*/\1/')
+            printf '{"jsonrpc":"2.0","id":%s,"result":{"name":"streamer","version":"0.1.0","protocol_version":"1","capabilities":{"streaming":true,"session_resume":false,"tool_events":false,"permission_requests":false}}}\n' "$id"
+            ;;
+        *'"method":"invoke"'*)
+            id=$(echo "$line" | sed 's/.*"id":\([0-9]*\).*/\1/')
+            # Emit streaming notifications
+            printf '{"jsonrpc":"2.0","method":"stream/delta","params":{"text":"Hello "}}\n'
+            printf '{"jsonrpc":"2.0","method":"stream/delta","params":{"text":"World"}}\n'
+            printf '{"jsonrpc":"2.0","method":"stream/cost_update","params":{"cost_usd":0.01,"input_tokens":5,"output_tokens":2}}\n'
+            # Then the final response
+            printf '{"jsonrpc":"2.0","id":%s,"result":{"response":"Hello World","cost_usd":0.01,"input_tokens":5,"output_tokens":2}}\n' "$id"
+            ;;
+        *'"method":"shutdown"'*)
+            id=$(echo "$line" | sed 's/.*"id":\([0-9]*\).*/\1/')
+            printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+            exit 0
+            ;;
+    esac
+done
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    script
+}
+
+fn write_manifest(dir: &Path, name: &str, exe: &Path) {
+    let manifest = dir.join(format!("{name}.yaml"));
+    let mut f = std::fs::File::create(&manifest).unwrap();
+    write!(
+        f,
+        "name: {name}\nversion: '1.0.0'\nexecutable: '{}'\nprotocol_version: '1'\n",
+        exe.display()
+    )
+    .unwrap();
+}
+
+#[test]
+fn echo_plugin_invoke_returns_response() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = create_echo_plugin(dir.path());
+    write_manifest(dir.path(), "echo", &exe);
+
+    let registry = discover_plugins_in(dir.path());
+    let manifest = registry.get("echo").unwrap();
+    let runner = ProtocolRunner::new(manifest.clone());
+
+    let result = runner
+        .invoke("hello world", InvokeOptions::default())
+        .unwrap();
+    assert_eq!(result.response, "Echo: hello world");
+    assert_eq!(result.input_tokens, 10);
+    assert_eq!(result.output_tokens, 5);
+}
+
+#[test]
+fn streaming_plugin_emits_events_then_response() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = create_streaming_plugin(dir.path());
+    write_manifest(dir.path(), "streamer", &exe);
+
+    let registry = discover_plugins_in(dir.path());
+    let manifest = registry.get("streamer").unwrap();
+    let runner = ProtocolRunner::new(manifest.clone());
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let result = runner
+        .invoke_streaming("test", InvokeOptions::default(), tx)
+        .unwrap();
+
+    assert_eq!(result.response, "Hello World");
+    assert_eq!(result.cost_usd, Some(0.01));
+
+    // Collect streaming events
+    let events: Vec<_> = rx.try_iter().collect();
+    // Should have at least the delta events, cost update, and completed
+    assert!(
+        events.len() >= 3,
+        "expected at least 3 events, got {}",
+        events.len()
+    );
+}
+
+#[test]
+fn plugin_runner_via_factory() {
+    use ail_core::config::domain::ProviderConfig;
+    use ail_core::runner::factory::RunnerFactory;
+    use ail_core::runner::http::HttpSessionStore;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    let dir = tempfile::tempdir().unwrap();
+    let exe = create_echo_plugin(dir.path());
+    write_manifest(dir.path(), "echo-test", &exe);
+
+    let registry = discover_plugins_in(dir.path());
+    let store: HttpSessionStore = Arc::new(Mutex::new(HashMap::new()));
+    let provider = ProviderConfig::default();
+
+    let runner =
+        RunnerFactory::build_with_registry("echo-test", false, &store, &provider, &registry)
+            .unwrap();
+
+    let result = runner
+        .invoke("factory test", InvokeOptions::default())
+        .unwrap();
+    assert_eq!(result.response, "Echo: factory test");
+}

--- a/ail/src/command.rs
+++ b/ail/src/command.rs
@@ -1,0 +1,41 @@
+//! Command trait — lifecycle contract for CLI commands.
+//!
+//! Every CLI command (validate, materialize, delete, once-text, once-json, chat, etc.)
+//! implements this trait. This gives:
+//!
+//! 1. **Clear contract** for "how do I add a new command?" — implement `Command`.
+//! 2. **Lifecycle guarantees** — `teardown()` always runs, even after errors.
+//! 3. **Testability** — commands can be tested without CLI parsing.
+//! 4. **Extensibility signal** — the trait is the seam for future external commands.
+//!
+//! # Async
+//!
+//! `execute()` is async because some commands (once-json, chat) need the tokio runtime.
+//! Sync commands simply return immediately without awaiting anything.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let mut cmd = ValidateCommand::new(..);
+//! cmd.validate()?;
+//! let outcome = cmd.execute().await;
+//! cmd.teardown();
+//! std::process::exit(outcome.exit_code());
+//! ```
+
+/// Outcome of a command execution.
+pub enum CommandOutcome {
+    /// Command completed successfully.
+    Success,
+    /// Command completed with a specific exit code.
+    ExitCode(i32),
+}
+
+impl CommandOutcome {
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::Success => 0,
+            Self::ExitCode(code) => *code,
+        }
+    }
+}

--- a/ail/src/delete.rs
+++ b/ail/src/delete.rs
@@ -1,28 +1,53 @@
 //! Handler for the `ail delete` subcommand.
 #![allow(clippy::result_large_err)]
 
-use ail_core::delete::delete_run;
-use ail_core::error::AilError;
+use crate::command::CommandOutcome;
 
-/// Execute the delete command.
-///
-/// Parameters are passed via the run_id and force/json flags.
-#[allow(clippy::result_large_err)]
-pub fn handle_delete(run_id: String, force: bool, json: bool) -> Result<(), AilError> {
-    delete_run(&run_id, force)?;
+pub struct DeleteCommand {
+    run_id: String,
+    force: bool,
+    json: bool,
+}
 
-    if json {
-        println!(
-            "{}",
-            serde_json::json!({
-                "deleted": true,
-                "run_id": run_id,
-                "message": format!("Deleted run {}", run_id)
-            })
-        );
-    } else {
-        println!("Deleted run {}", run_id);
+impl DeleteCommand {
+    pub fn new(run_id: String, force: bool, json: bool) -> Self {
+        Self {
+            run_id,
+            force,
+            json,
+        }
     }
 
-    Ok(())
+    pub fn execute(&self) -> CommandOutcome {
+        if let Err(e) = ail_core::delete::delete_run(&self.run_id, self.force) {
+            if self.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "deleted": false,
+                        "run_id": self.run_id,
+                        "error": e.detail(),
+                    })
+                );
+            } else {
+                eprintln!("{e}");
+            }
+            return CommandOutcome::ExitCode(1);
+        }
+
+        if self.json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "deleted": true,
+                    "run_id": self.run_id,
+                    "message": format!("Deleted run {}", self.run_id)
+                })
+            );
+        } else {
+            println!("Deleted run {}", self.run_id);
+        }
+
+        CommandOutcome::Success
+    }
 }

--- a/ail/src/main.rs
+++ b/ail/src/main.rs
@@ -3,6 +3,7 @@ mod ask_user_types;
 mod chat;
 mod check_permission_hook;
 mod cli;
+mod command;
 mod control_bridge;
 mod delete;
 mod log;
@@ -15,6 +16,7 @@ mod validate;
 use ail_core::runner::factory::RunnerFactory;
 use clap::Parser;
 use cli::{Cli, Commands, OutputFormat};
+use command::CommandOutcome;
 
 /// Discover and load a pipeline from an optional explicit path, falling back to
 /// automatic discovery and then passthrough mode. Exits with code 1 on load error.
@@ -37,6 +39,10 @@ fn init_tracing() {
         .json()
         .with_writer(std::io::stderr)
         .init();
+}
+
+fn exit_with(outcome: CommandOutcome) -> ! {
+    std::process::exit(outcome.exit_code())
 }
 
 #[tokio::main]
@@ -96,10 +102,8 @@ async fn main() {
                 force,
                 json,
             } => {
-                if let Err(e) = delete::handle_delete(run_id, force, json) {
-                    eprintln!("{e}");
-                    std::process::exit(1);
-                }
+                let cmd = delete::DeleteCommand::new(run_id, force, json);
+                exit_with(cmd.execute());
             }
             Commands::Logs {
                 session,
@@ -125,13 +129,15 @@ async fn main() {
             }
             Commands::Materialize { pipeline, out } => {
                 let p = load_pipeline(pipeline);
-                materialize::handle_materialize(p, out);
+                let cmd = materialize::MaterializeCommand::new(p, out);
+                exit_with(cmd.execute());
             }
             Commands::Validate {
                 pipeline,
                 output_format,
             } => {
-                validate::handle_validate(pipeline, output_format);
+                let cmd = validate::ValidateCommand::new(pipeline, output_format);
+                exit_with(cmd.execute());
             }
             Commands::Chat {
                 message,

--- a/ail/src/materialize.rs
+++ b/ail/src/materialize.rs
@@ -1,12 +1,29 @@
-pub fn handle_materialize(p: ail_core::config::domain::Pipeline, out: Option<std::path::PathBuf>) {
-    let output = ail_core::materialize::materialize(&p);
-    match out {
-        Some(out_path) => {
-            if let Err(e) = std::fs::write(&out_path, &output) {
-                eprintln!("Failed to write to {}: {e}", out_path.display());
-                std::process::exit(1);
+use crate::command::CommandOutcome;
+
+pub struct MaterializeCommand {
+    pipeline: ail_core::config::domain::Pipeline,
+    out: Option<std::path::PathBuf>,
+}
+
+impl MaterializeCommand {
+    pub fn new(
+        pipeline: ail_core::config::domain::Pipeline,
+        out: Option<std::path::PathBuf>,
+    ) -> Self {
+        Self { pipeline, out }
+    }
+
+    pub fn execute(&self) -> CommandOutcome {
+        let output = ail_core::materialize::materialize(&self.pipeline);
+        match &self.out {
+            Some(out_path) => {
+                if let Err(e) = std::fs::write(out_path, &output) {
+                    eprintln!("Failed to write to {}: {e}", out_path.display());
+                    return CommandOutcome::ExitCode(1);
+                }
             }
+            None => print!("{output}"),
         }
-        None => print!("{output}"),
+        CommandOutcome::Success
     }
 }

--- a/ail/src/validate.rs
+++ b/ail/src/validate.rs
@@ -1,53 +1,72 @@
 use crate::cli::OutputFormat;
+use crate::command::CommandOutcome;
 
-pub fn handle_validate(pipeline: Option<std::path::PathBuf>, output_format: OutputFormat) {
-    let path = match ail_core::config::discovery::discover(pipeline) {
-        Some(p) => p,
-        None => {
-            match output_format {
-                OutputFormat::Json => {
-                    println!(
-                        "{}",
-                        serde_json::json!({
-                            "valid": false,
-                            "errors": [{"message": "No pipeline file found.", "error_type": "ail:config/file-not-found"}]
-                        })
-                    );
-                }
-                OutputFormat::Text => {
-                    eprintln!("No pipeline file found.");
-                }
-            }
-            std::process::exit(1);
+pub struct ValidateCommand {
+    pipeline_path: Option<std::path::PathBuf>,
+    output_format: OutputFormat,
+}
+
+impl ValidateCommand {
+    pub fn new(pipeline_path: Option<std::path::PathBuf>, output_format: OutputFormat) -> Self {
+        Self {
+            pipeline_path,
+            output_format,
         }
-    };
-    match ail_core::config::load(&path) {
-        Ok(p) => match output_format {
-            OutputFormat::Json => {
-                println!(
-                    "{}",
-                    serde_json::json!({"valid": true, "step_count": p.steps.len()})
-                );
+    }
+
+    pub fn execute(&self) -> CommandOutcome {
+        let path = match ail_core::config::discovery::discover(self.pipeline_path.clone()) {
+            Some(p) => p,
+            None => {
+                match self.output_format {
+                    OutputFormat::Json => {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "valid": false,
+                                "errors": [{"message": "No pipeline file found.", "error_type": "ail:config/file-not-found"}]
+                            })
+                        );
+                    }
+                    OutputFormat::Text => {
+                        eprintln!("No pipeline file found.");
+                    }
+                }
+                return CommandOutcome::ExitCode(1);
             }
-            OutputFormat::Text => {
-                println!("Pipeline valid: {} step(s)", p.steps.len());
+        };
+        match ail_core::config::load(&path) {
+            Ok(p) => {
+                match self.output_format {
+                    OutputFormat::Json => {
+                        println!(
+                            "{}",
+                            serde_json::json!({"valid": true, "step_count": p.steps.len()})
+                        );
+                    }
+                    OutputFormat::Text => {
+                        println!("Pipeline valid: {} step(s)", p.steps.len());
+                    }
+                }
+                CommandOutcome::Success
             }
-        },
-        Err(e) => match output_format {
-            OutputFormat::Json => {
-                println!(
-                    "{}",
-                    serde_json::json!({
-                        "valid": false,
-                        "errors": [{"message": e.detail(), "error_type": e.error_type()}]
-                    })
-                );
-                std::process::exit(1);
+            Err(e) => {
+                match self.output_format {
+                    OutputFormat::Json => {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "valid": false,
+                                "errors": [{"message": e.detail(), "error_type": e.error_type()}]
+                            })
+                        );
+                    }
+                    OutputFormat::Text => {
+                        eprintln!("{e}");
+                    }
+                }
+                CommandOutcome::ExitCode(1)
             }
-            OutputFormat::Text => {
-                eprintln!("{e}");
-                std::process::exit(1);
-            }
-        },
+        }
     }
 }

--- a/spec/README.md
+++ b/spec/README.md
@@ -42,7 +42,7 @@ The AIL Pipeline Language Specification — for pipeline authors and implementer
 | [s16-error-handling.md](core/s16-error-handling.md) | §16 Error Handling | on_error: continue / pause_for_human / abort_pipeline / retry | deferred |
 | [s17-materialize.md](core/s17-materialize.md) | §17 materialize | CLI command; output format with origin comments | partial — single-file flatten + origin comments ✓; `FROM` chain traversal/`--expand-pipelines` not impl |
 | [s18-complete-examples.md](core/s18-complete-examples.md) | §18 Complete Examples | Full worked YAML — simplest, solo dev, org base, multi-speed | needs update for new step types |
-| [s19-runners-adapters.md](core/s19-runners-adapters.md) | §19 Runners & Adapters | Three-tier runner model; runner config; RunnerFactory; per-step `runner:` dispatch | reference — RunnerFactory (selection hierarchy, known names, `AIL_DEFAULT_RUNNER` env) and per-step dispatch ✓ |
+| [s19-runners-adapters.md](core/s19-runners-adapters.md) | §19 Runners & Adapters | Three-tier runner model; RunnerFactory; per-step dispatch; plugin runner system | **v0.2** — RunnerFactory, per-step dispatch, plugin discovery + JSON-RPC protocol ✓ |
 | [s20-mvp.md](core/s20-mvp.md) | §20 MVP v0.0.1 Scope | What is and isn't in scope for v0.0.1 | reference — v0.0.1 complete; alpha scope is next |
 | [s21-planned-extensions.md](core/s21-planned-extensions.md) | §21 Planned Extensions | Structured I/O, parallel steps, multi-provider quality comparison (D-020), self-modifying pipelines (D-019), MCP, plugins, observability | planned |
 | [s22-open-questions.md](core/s22-open-questions.md) | §22 Open Questions | Unresolved design questions (completion detection, hot reload, self-modifying pipeline approval/validation, etc.) | reference |
@@ -62,3 +62,5 @@ The AIL Runner Contract — for CLI tool authors and adapter writers.
 | [r03-targets.md](runner/r03-targets.md) | Known Runners, Custom Adapters, Open Questions | Roadmap runners; Runner trait for adapters; remaining open questions | partial — `http`/`ollama` implemented |
 | [r04-ail-log-format.md](runner/r04-ail-log-format.md) | r04. AIL Log Format Specification | Terminal-safe markdown+directives format; version header, thinking/tool-call/tool-result/stdio directives, turns, costs, errors | **alpha** |
 | [r05-http-runner.md](runner/r05-http-runner.md) | r05. HTTP Runner — Direct OpenAI-Compatible API | Direct API runner for Ollama and any OpenAI-compatible endpoint; session continuity, config, tool policy, error mapping | **v0.1** ✓ |
+| [r10-plugin-protocol.md](runner/r10-plugin-protocol.md) | r10. AIL Runner Plugin Protocol | JSON-RPC 2.0 over stdin/stdout; initialize/invoke/shutdown lifecycle; streaming notifications; permission flow | **alpha** |
+| [r11-plugin-discovery.md](runner/r11-plugin-discovery.md) | r11. Runner Plugin Discovery | Manifest format; `~/.ail/runners/` directory; executable resolution; runner name rules; factory integration | **alpha** |

--- a/spec/core/s19-runners-adapters.md
+++ b/spec/core/s19-runners-adapters.md
@@ -1,65 +1,33 @@
 ## 19. Runners & Adapters
 
-> **Implementation status:** The "Three Tiers of Runner Support" and "Custom Adapters" subsections below describe the long-arc vision for runner extensibility. The current implementation provides three built-in runners (`claude`, `http`/`ollama`, `stub`) selected via `RunnerFactory`. The "RunnerFactory and Per-Step Dispatch" subsection describes what is actually implemented.
-
-> **Note:** This section describes the conceptual model for how `ail` connects to underlying CLI tools. The detailed contract for runner compliance is defined in a separate document — `RUNNER-SPEC.md`. The interface described here should be considered directional, not final.
+> **Implementation status:** v0.2 — three built-in runners (`claude`, `http`/`ollama`, `stub`) plus a runtime plugin system for third-party runners via the AIL Runner Plugin Protocol (JSON-RPC 2.0 over stdin/stdout).
 
 ### What a Runner Is
 
-A runner is the underlying CLI agent that `ail` wraps. It receives the human's prompt, produces a response, and signals completion. `ail` orchestrates everything that happens after that signal fires.
+A runner is the underlying agent or LLM that `ail` wraps. It receives the human's prompt, produces a response, and signals completion. `ail` orchestrates everything that happens after that signal fires.
 
-The runner is deliberately outside the pipeline language. `SPEC.md` defines what pipelines do. The runner is what the pipeline acts upon.
+The runner is deliberately outside the pipeline language. This spec defines what pipelines do. The runner is what the pipeline acts upon.
 
 ### Three Tiers of Runner Support
 
-**Tier 1 — First-class runners**
-Built-in adapters shipped with `ail` and maintained by the core team. Tested against every `ail` release. The runner's behaviour, output format, completion signal, and error codes are fully understood and handled.
+**Tier 1 — Built-in runners**
+Runners shipped with `ail` and maintained by the core team. Tested against every release. Their behaviour, output format, and error codes are fully understood and handled.
 
-Initial first-class runner: **Claude CLI** (`claude`). The v0.0.1 proof of concept targets Claude exclusively.
+| Name | Type | Description |
+|---|---|---|
+| `claude` | `ClaudeCliRunner` | Shells out to the `claude` binary; supports streaming, session resume, tool permissions, headless bypass |
+| `http` / `ollama` | `HttpRunner` | Direct OpenAI-compatible HTTP API; supports session continuity (in-memory), configurable timeouts, system prompt control |
+| `stub` | `StubRunner` | Returns a fixed response; for tests and development |
 
-Roadmap for first-class support (not yet committed): Aider, OpenCode, Codex CLI, Gemini CLI, Qwen CLI, DeepSeek CLI, llama.cpp.
+**Tier 2 — Plugin runners (runtime-discoverable)**
+Any executable that implements the AIL Runner Plugin Protocol. Users install plugins by placing a manifest file in `~/.ail/runners/` alongside the plugin binary. No recompilation required.
 
-**Tier 2 — AIL-compliant runners**
-Any CLI tool that implements the AIL Runner Contract defined in `RUNNER-SPEC.md`. A compliant runner works with `ail`'s built-in generic adapter without requiring a custom implementation. The tool author reads `RUNNER-SPEC.md` and ships their CLI accordingly. `ail` makes no guarantees about compliant runners beyond what the contract specifies.
+See `spec/runner/r10-plugin-protocol.md` for the protocol specification and `spec/runner/r11-plugin-discovery.md` for manifest format and discovery rules.
 
-**Tier 3 — Custom adapters**
-Any CLI tool that does not implement the runner contract can be wrapped in a community-written or private adapter. Adapters implement the `Runner` trait defined in `ail`'s Rust core and are loaded at runtime as dynamic libraries. See `ARCHITECTURE.md` *(forthcoming)* for the trait interface and dynamic loading system.
-
-### Runner Configuration
-
-The active runner is declared in the pipeline file or in `~/.config/ail/config.yaml`:
-
-```yaml
-# In .ail.yaml
-runner:
-  id: claude
-  command: claude
-  args: ["--print"]         # invocation flags; runner-specific
-
-# Or reference a custom adapter
-runner:
-  id: my-custom-runner
-  adapter: ~/.ail/adapters/my-runner.so
-```
-
-If no runner is declared, `ail` defaults to the Claude CLI.
-
-### The AIL Runner Contract (Summary)
-
-The full contract is defined in `RUNNER-SPEC.md`. At a high level, a compliant runner must:
-
-- Accept a prompt via a flag or stdin in non-interactive mode
-- Write its response to stdout
-- Exit with code `0` on success, non-zero on error
-- Optionally declare supported capabilities (structured output, extended thinking, tool calls, session resumption) via a `--ail-capabilities` flag
-
-Runners that implement the optional capability declarations unlock richer `ail` features — structured step output, thinking traces, tool call inspection, and `resume: true` support. Runners that implement only the minimum contract work with Tier 1 text-based pipeline features.
-
-> **Note:** Session continuity behaviour — what "isolated" means per runner, and how session IDs are captured and passed for `resume: true` — is defined in `RUNNER-SPEC.md`, not here. The pipeline language declares intent; the runner contract defines mechanics.
+**Tier 3 — Custom Rust runners (compile-time)**
+Community or private runners implemented as Rust crates that implement the `Runner` trait directly. These require recompilation and adding a match arm in `RunnerFactory`. Use this tier when the JSON-RPC protocol is insufficient (e.g., for runners with complex subprocess lifecycle needs).
 
 ### RunnerFactory and Per-Step Dispatch
-
-> **Implementation status:** v0.1 — fully implemented in `ail-core/src/runner/factory.rs`.
 
 `RunnerFactory` (`ail_core::runner::factory`) is the canonical way to obtain a runner by name at runtime. It is used by the executor for per-step runner dispatch and by the binary entry points to build the default runner.
 
@@ -67,11 +35,22 @@ Runners that implement the optional capability declarations unlock richer `ail` 
 pub struct RunnerFactory;
 
 impl RunnerFactory {
-    /// Build a runner by explicit name.
-    pub fn build(runner_name: &str, headless: bool) -> Result<Box<dyn Runner + Send>, AilError>;
+    /// Build a runner by name, checking the plugin registry for unknown names.
+    pub fn build_with_registry(
+        runner_name: &str,
+        headless: bool,
+        http_store: &HttpSessionStore,
+        provider: &ProviderConfig,
+        registry: &PluginRegistry,
+    ) -> Result<Box<dyn Runner + Send>, AilError>;
 
-    /// Build the default runner, honouring the `AIL_DEFAULT_RUNNER` env var.
-    pub fn build_default(headless: bool) -> Result<Box<dyn Runner + Send>, AilError>;
+    /// Build without plugin support (backward-compatible).
+    pub fn build(
+        runner_name: &str,
+        headless: bool,
+        http_store: &HttpSessionStore,
+        provider: &ProviderConfig,
+    ) -> Result<Box<dyn Runner + Send>, AilError>;
 }
 ```
 
@@ -79,20 +58,28 @@ impl RunnerFactory {
 
 The effective runner for a step is determined in priority order (highest first):
 
-1. **Per-step `runner:` field** in the pipeline YAML — resolved by the executor via `RunnerFactory::build(name, true)`.
-2. **`AIL_DEFAULT_RUNNER` environment variable** — if set and non-empty, `build_default()` passes this to `build()`.
-3. **Hardcoded fallback: `"claude"`** — `ClaudeCliRunner` with `ClaudeCliRunnerConfig::default()`.
+1. **Per-step `runner:` field** in the pipeline YAML — resolved by the executor.
+2. **`AIL_DEFAULT_RUNNER` environment variable** — if set and non-empty.
+3. **Hardcoded fallback: `"claude"`**.
 
-#### Known Runner Names
+#### Runner Name Resolution
+
+When a runner name is requested, the factory resolves it in this order:
+
+1. **Built-in runners** — `claude`, `http`/`ollama`, `stub` (case-insensitive, trimmed).
+2. **Plugin registry** — discovered plugins from `~/.ail/runners/`.
+3. **Error** — `RUNNER_NOT_FOUND` with the list of all known runner names (built-in + plugins).
+
+#### Known Runner Names (Built-in)
 
 | Name | Case-sensitive | Resulting type | Notes |
 |---|---|---|---|
 | `claude` | No (trimmed, lowercased) | `ClaudeCliRunner` | Production runner; shells out to the `claude` binary |
-| `http` | No | `HttpRunner` | Direct OpenAI-compatible API; no tools; in-memory session continuity |
+| `http` | No | `HttpRunner` | Direct OpenAI-compatible API; configurable timeouts, session continuity |
 | `ollama` | No | `HttpRunner` | Alias for `http`; identical behaviour |
 | `stub` | No | `StubRunner` | Returns a fixed `"stub response"` string; for tests and development |
 
-Any unrecognised name returns `AilError { error_type: "ail:runner/not-found", ... }` and aborts the step.
+Plugin runner names are case-sensitive and must be alphanumeric with hyphens/underscores only.
 
 #### Per-Step runner: Field
 
@@ -102,33 +89,69 @@ Any `prompt:` step may declare a `runner:` field to override the default runner 
 pipeline:
   - id: review
     prompt: "Review the changes"
-    # no runner: — uses the injected default (AIL_DEFAULT_RUNNER or claude)
+    # no runner: — uses the default (AIL_DEFAULT_RUNNER or claude)
 
-  - id: audit
-    prompt: "Security audit"
-    runner: stub   # overrides for this step only
+  - id: quick-check
+    prompt: "Quick check"
+    runner: ollama   # uses the HTTP runner for this step
+
+  - id: codex-review
+    prompt: "Review with Codex"
+    runner: codex    # uses a plugin runner (if installed)
 ```
 
-Per-step runner overrides inherit the parent session's headless flag (`Session.headless`), so `--dangerously-skip-permissions` is passed (or not) consistently with the default runner invocation.
+Per-step runner overrides inherit the parent session's headless flag (`Session.headless`).
 
-#### Adding a New Runner
+### Plugin Runner System
 
+Users can extend ail with third-party runners without recompiling:
+
+1. **Install the plugin** — place a manifest file and executable in `~/.ail/runners/`.
+2. **Use in pipeline YAML** — set `runner: <plugin-name>` on any step.
+3. **ail discovers and launches it** — spawns the executable, communicates via JSON-RPC 2.0 over stdin/stdout.
+
+#### Manifest Example
+
+```yaml
+# ~/.ail/runners/codex.yaml
+name: codex
+version: "0.1.0"
+executable: codex-ail-runner
+protocol_version: "1"
+```
+
+#### Protocol Summary
+
+The AIL Runner Plugin Protocol uses JSON-RPC 2.0 over stdin/stdout:
+
+| Method | Direction | Purpose |
+|---|---|---|
+| `initialize` | ail → plugin | Handshake and capability negotiation |
+| `invoke` | ail → plugin | Send prompt, receive response |
+| `permission/respond` | ail → plugin | Respond to tool permission requests |
+| `shutdown` | ail → plugin | Graceful shutdown |
+| `stream/*` | plugin → ail | Streaming notifications (deltas, thinking, tool events, cost) |
+
+Full details: `spec/runner/r10-plugin-protocol.md` and `spec/runner/r11-plugin-discovery.md`.
+
+### Adding a New Runner
+
+**For plugin authors (no recompilation):**
+1. Create an executable that speaks the AIL Runner Plugin Protocol.
+2. Write a manifest YAML file declaring the runner name and executable path.
+3. Place both in `~/.ail/runners/`.
+
+**For Rust contributors (compile-time):**
 1. Implement the `Runner` trait in a new module under `ail-core/src/runner/`.
 2. Add a match arm in `RunnerFactory::build()` mapping the runner name to the new type.
 3. Export the module from `ail-core/src/runner/mod.rs`.
 
-#### Usage in the Binary
-
-```rust
-let runner = RunnerFactory::build_default(cli.headless)?;
-// runner is Box<dyn Runner + Send>
-```
-
-All entry points in `ail/src/main.rs` (`--once`, TUI, `chat`) construct runners exclusively through `RunnerFactory::build_default()`.
-
 ### Further Reading
 
-- `RUNNER-SPEC.md` — The AIL Runner Contract. Read this if you are a CLI tool author who wants first-class `ail` compatibility.
-- `ARCHITECTURE.md` *(forthcoming)* — The Rust trait interface and dynamic loading system. Read this if you are writing a custom runner adapter.
+- `spec/runner/r01-overview.md` — The AIL Runner Contract overview.
+- `spec/runner/r02-claude-cli.md` — Claude CLI reference implementation.
+- `spec/runner/r05-http-runner.md` — HTTP/Ollama runner specification.
+- `spec/runner/r10-plugin-protocol.md` — JSON-RPC plugin protocol specification.
+- `spec/runner/r11-plugin-discovery.md` — Plugin manifest format and discovery rules.
 
 ---

--- a/spec/runner/r10-plugin-protocol.md
+++ b/spec/runner/r10-plugin-protocol.md
@@ -1,0 +1,291 @@
+# r10. AIL Runner Plugin Protocol
+
+> **Status:** alpha — protocol version `1`
+
+---
+
+## Purpose
+
+This document defines the **AIL Runner Plugin Protocol** — a JSON-RPC 2.0 protocol over stdin/stdout that enables third-party runner extensions to work with ail without recompilation.
+
+A runner plugin is a standalone executable. ail spawns it as a subprocess, sends JSON-RPC requests on its stdin, and reads JSON-RPC responses and notifications from its stdout. This is the same transport pattern used by MCP (Model Context Protocol) and LSP (Language Server Protocol).
+
+---
+
+## Transport
+
+- **stdin (ail → plugin):** Newline-delimited JSON. Each line is a complete JSON-RPC 2.0 request or notification.
+- **stdout (plugin → ail):** Newline-delimited JSON. Each line is a complete JSON-RPC 2.0 response or notification.
+- **stderr:** Diagnostic output only. ail captures stderr for logging but does not parse it as protocol messages.
+- **Encoding:** UTF-8.
+- **Line terminator:** `\n` (LF). Plugins should accept `\r\n` but emit `\n`.
+
+---
+
+## JSON-RPC 2.0 Subset
+
+The protocol uses the JSON-RPC 2.0 specification with these conventions:
+
+- **Requests** have `jsonrpc`, `id`, `method`, and optional `params`.
+- **Responses** have `jsonrpc`, `id`, and either `result` or `error`.
+- **Notifications** have `jsonrpc` and `method` but no `id`. They are fire-and-forget.
+- **Batch requests** are not supported.
+
+---
+
+## Lifecycle
+
+```
+ail                              plugin
+ │                                  │
+ │── spawn ──────────────────────►  │
+ │                                  │
+ │── initialize ─────────────────►  │
+ │◄─ initialize response ────────  │
+ │                                  │
+ │── invoke ─────────────────────►  │
+ │◄─ stream/delta (notification) ─  │  (repeated)
+ │◄─ stream/thinking (notif.) ────  │  (optional)
+ │◄─ stream/tool_use (notif.) ────  │  (optional)
+ │◄─ stream/permission_request ───  │  (optional)
+ │── permission/respond ─────────►  │  (if permission requested)
+ │◄─ stream/tool_result (notif.) ─  │  (optional)
+ │◄─ stream/cost_update (notif.) ─  │  (optional)
+ │◄─ invoke response ────────────  │
+ │                                  │
+ │── shutdown ───────────────────►  │
+ │◄─ shutdown response ──────────  │
+ │                                  │
+ │── SIGTERM (if needed) ────────►  │
+```
+
+---
+
+## Methods
+
+### `initialize`
+
+Handshake. Must be the first request sent after spawning the plugin.
+
+**Request params:**
+
+| Field | Type | Description |
+|---|---|---|
+| `protocol_version` | string | Protocol version ail speaks (currently `"1"`) |
+| `ail_version` | string | ail version string (informational) |
+
+**Response result:**
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Runner's declared name (e.g. `"codex"`) |
+| `version` | string | Runner extension version |
+| `protocol_version` | string | Protocol version the runner speaks |
+| `capabilities` | object | Declared capabilities (see below) |
+
+**Capabilities object:**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `streaming` | bool | `false` | Runner emits streaming notifications during invoke |
+| `session_resume` | bool | `false` | Runner supports resuming sessions by ID |
+| `tool_events` | bool | `false` | Runner emits `stream/tool_use` and `stream/tool_result` |
+| `permission_requests` | bool | `false` | Runner sends `stream/permission_request` and awaits `permission/respond` |
+
+### `invoke`
+
+Send a prompt and receive a response. If the runner supports streaming, it emits notifications before the final response.
+
+**Request params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `prompt` | string | yes | The prompt text |
+| `session_id` | string | no | Session ID to resume (if `session_resume` capability) |
+| `model` | string | no | Model override for this invocation |
+| `system_prompt` | string | no | System prompt override |
+| `tool_policy` | object | no | Tool permission policy (see below) |
+
+**Tool policy object:**
+
+```json
+{ "type": "no_tools" }
+{ "type": "allowlist", "tools": ["Read", "Grep"] }
+{ "type": "denylist", "tools": ["Bash"] }
+{ "type": "mixed", "allow": ["Read"], "deny": ["Bash"] }
+```
+
+Omitted or `null` means runner default.
+
+**Response result:**
+
+| Field | Type | Description |
+|---|---|---|
+| `response` | string | The complete response text |
+| `cost_usd` | number? | Cost in USD (null if unavailable) |
+| `session_id` | string? | Session ID for future resumption |
+| `input_tokens` | number | Input token count (0 if unavailable) |
+| `output_tokens` | number | Output token count (0 if unavailable) |
+| `thinking` | string? | Concatenated thinking/reasoning text |
+| `model` | string? | Model name actually used |
+| `tool_events` | array | Ordered tool call/result events (empty if none) |
+
+### `permission/respond`
+
+Sent by ail in response to a `stream/permission_request` notification from the runner.
+
+**Request params:**
+
+| Field | Type | Description |
+|---|---|---|
+| `allow` | bool | Whether the tool call is allowed |
+| `reason` | string? | Reason for denial (when `allow` is false) |
+
+**Response:** Empty result `{}` on success.
+
+### `shutdown`
+
+Request graceful shutdown. The plugin should release resources and prepare to exit.
+
+**Request params:** None.
+
+**Response:** Empty result `{}`.
+
+After receiving the shutdown response, ail closes stdin. If the plugin does not exit within 5 seconds, ail sends SIGTERM. If still running after another 5 seconds, ail sends SIGKILL.
+
+---
+
+## Notifications (plugin → ail)
+
+All notifications are optional. A minimal plugin can skip all notifications and return only the invoke response.
+
+### `stream/delta`
+
+Incremental text output.
+
+```json
+{"jsonrpc":"2.0","method":"stream/delta","params":{"text":"Hello"}}
+```
+
+### `stream/thinking`
+
+Reasoning/thinking text (extended thinking).
+
+```json
+{"jsonrpc":"2.0","method":"stream/thinking","params":{"text":"Let me think..."}}
+```
+
+### `stream/tool_use`
+
+A tool call was initiated.
+
+```json
+{"jsonrpc":"2.0","method":"stream/tool_use","params":{"tool_name":"Bash","tool_use_id":"toolu_123","input":{"command":"ls"}}}
+```
+
+### `stream/tool_result`
+
+A tool call completed.
+
+```json
+{"jsonrpc":"2.0","method":"stream/tool_result","params":{"tool_name":"Bash","tool_use_id":"toolu_123","content":"file1.txt\nfile2.txt","is_error":false}}
+```
+
+### `stream/cost_update`
+
+Updated token counts and cost.
+
+```json
+{"jsonrpc":"2.0","method":"stream/cost_update","params":{"cost_usd":0.05,"input_tokens":1000,"output_tokens":500}}
+```
+
+### `stream/permission_request`
+
+The runner needs a tool permission decision before proceeding. ail must respond with a `permission/respond` request.
+
+```json
+{"jsonrpc":"2.0","method":"stream/permission_request","params":{"display_name":"Bash","display_detail":"rm -rf /tmp/test","tool_input":{"command":"rm -rf /tmp/test"}}}
+```
+
+The plugin **must block** until it receives the `permission/respond` request before continuing.
+
+---
+
+## Error Codes
+
+Standard JSON-RPC 2.0 error codes:
+
+| Code | Meaning |
+|---|---|
+| `-32700` | Parse error — invalid JSON |
+| `-32600` | Invalid request — not a valid JSON-RPC request |
+| `-32601` | Method not found |
+| `-32602` | Invalid params |
+| `-32603` | Internal error |
+
+Application-level errors (reserved range `-32000` to `-32099`):
+
+| Code | Meaning |
+|---|---|
+| `-32001` | Model not available |
+| `-32002` | Authentication failed |
+| `-32003` | Rate limited |
+| `-32004` | Context length exceeded |
+
+---
+
+## Cancellation
+
+When the user cancels an in-flight invocation (e.g. Ctrl+C), ail sends SIGTERM to the plugin process. The plugin should:
+
+1. Stop generating output
+2. Return a partial response if possible
+3. Exit cleanly
+
+If the plugin does not exit within 5 seconds of SIGTERM, ail sends SIGKILL.
+
+---
+
+## Minimum Viable Plugin
+
+A minimal plugin that echoes prompts:
+
+```python
+#!/usr/bin/env python3
+import json, sys
+
+def respond(id, result):
+    print(json.dumps({"jsonrpc": "2.0", "id": id, "result": result}), flush=True)
+
+for line in sys.stdin:
+    msg = json.loads(line)
+    method = msg.get("method")
+    id = msg.get("id")
+
+    if method == "initialize":
+        respond(id, {
+            "name": "echo",
+            "version": "0.1.0",
+            "protocol_version": "1",
+            "capabilities": {"streaming": False, "session_resume": False,
+                             "tool_events": False, "permission_requests": False}
+        })
+    elif method == "invoke":
+        prompt = msg["params"]["prompt"]
+        respond(id, {
+            "response": f"Echo: {prompt}",
+            "input_tokens": len(prompt.split()),
+            "output_tokens": len(prompt.split()) + 1,
+        })
+    elif method == "shutdown":
+        respond(id, {})
+        break
+```
+
+---
+
+## Versioning
+
+The `protocol_version` field enables forward compatibility. ail and the plugin exchange versions during `initialize`. If versions are incompatible, the plugin should return an error response.
+
+Protocol version `"1"` is the initial version defined in this document.

--- a/spec/runner/r11-plugin-discovery.md
+++ b/spec/runner/r11-plugin-discovery.md
@@ -1,0 +1,146 @@
+# r11. Runner Plugin Discovery
+
+> **Status:** alpha
+
+---
+
+## Purpose
+
+This document defines how ail discovers and loads runner plugins at startup. Plugins are standalone executables that speak the AIL Runner Plugin Protocol (see `r10-plugin-protocol.md`). Discovery is based on manifest files placed in a well-known directory.
+
+---
+
+## Discovery Directory
+
+Plugins are discovered from:
+
+```
+~/.ail/runners/
+```
+
+ail scans this directory for manifest files at startup. If the directory does not exist, discovery completes with zero plugins (no error).
+
+---
+
+## Manifest Format
+
+A manifest is a YAML or JSON file in the discovery directory. File extension must be `.yaml`, `.yml`, or `.json`.
+
+### Required Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Runner name used in pipeline YAML (`runner: <name>`). Must be alphanumeric, hyphens, and underscores only. Must not collide with built-in runner names. |
+| `version` | string | Version of the runner extension (informational) |
+| `executable` | string | Path to the runner executable (see resolution rules below) |
+
+### Optional Fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `protocol_version` | string | `"1"` | Protocol version the runner speaks |
+| `env` | map | `{}` | Environment variables to pass to the runner subprocess |
+| `args` | array | `[]` | Command-line arguments to pass to the runner executable |
+
+### Example (YAML)
+
+```yaml
+# ~/.ail/runners/codex.yaml
+name: codex
+version: "0.1.0"
+executable: codex-ail-runner
+protocol_version: "1"
+env:
+  CODEX_API_KEY: "${CODEX_API_KEY}"
+args:
+  - "--verbose"
+```
+
+### Example (JSON)
+
+```json
+{
+  "name": "codex",
+  "version": "0.1.0",
+  "executable": "/usr/local/bin/codex-ail-runner",
+  "protocol_version": "1"
+}
+```
+
+---
+
+## Executable Resolution
+
+The `executable` field is resolved in this order:
+
+1. **Absolute path** — used as-is. Must exist on disk.
+2. **Relative path** (starts with `./` or `../`) — resolved relative to the manifest file's directory. Must exist on disk.
+3. **Bare name** — looked up on the system `PATH`.
+
+If the executable cannot be found, the manifest is invalid and the plugin is skipped with a warning.
+
+---
+
+## Runner Name Rules
+
+- Must contain only ASCII alphanumeric characters, hyphens (`-`), and underscores (`_`).
+- Must not collide with built-in runner names: `claude`, `http`, `ollama`, `stub`.
+- Names are case-sensitive — `Codex` and `codex` are different names.
+- If two manifests declare the same name, first-seen wins and the duplicate is skipped with a warning.
+
+---
+
+## Discovery Behaviour
+
+1. ail reads all files in `~/.ail/runners/` with `.yaml`, `.yml`, or `.json` extensions.
+2. Each file is parsed and validated independently.
+3. Invalid manifests are logged as warnings and skipped — they do not prevent other plugins from loading.
+4. Duplicate runner names are logged as warnings — first-seen wins.
+5. The resulting plugin registry is passed to `RunnerFactory` for the lifetime of the process.
+
+Discovery happens once at process startup. Plugins cannot be hot-reloaded during a running session.
+
+---
+
+## Runner Selection Hierarchy
+
+When a step specifies `runner: <name>`, the resolution order is:
+
+1. **Built-in runners** — `claude`, `http`/`ollama`, `stub`
+2. **Plugin registry** — discovered plugins from `~/.ail/runners/`
+3. **Error** — `RUNNER_NOT_FOUND` with the list of known runner names
+
+Built-in runners always take precedence over plugins with the same name (though name collisions are rejected during discovery validation).
+
+---
+
+## Integration with RunnerFactory
+
+`RunnerFactory::build_with_registry()` accepts a `PluginRegistry` parameter:
+
+```rust
+RunnerFactory::build_with_registry(
+    "codex",           // runner name
+    false,             // headless
+    &http_store,       // HTTP session store
+    &provider,         // provider config
+    &plugin_registry,  // discovered plugins
+)
+```
+
+When the name doesn't match a built-in, the factory checks the registry and constructs a `ProtocolRunner` for the matching manifest.
+
+The original `RunnerFactory::build()` method (without registry) continues to work for backward compatibility — it uses an empty registry.
+
+---
+
+## Error Handling
+
+| Error Type | When |
+|---|---|
+| `ail:plugin/manifest-invalid` | Manifest fails validation (missing fields, bad name, executable not found, unsupported protocol version) |
+| `ail:plugin/spawn-failed` | Plugin executable could not be started |
+| `ail:plugin/protocol-error` | Plugin sent invalid JSON-RPC, unexpected response, or protocol violation |
+| `ail:plugin/timeout` | Plugin did not respond within the expected timeframe |
+
+Discovery errors (invalid manifests, missing directory) are warnings, not fatal errors. Pipeline execution can always proceed with built-in runners.


### PR DESCRIPTION
Add runtime-discoverable runner plugins via the AIL Runner Plugin Protocol
(JSON-RPC 2.0 over stdin/stdout). Users can install third-party runners by
placing a manifest + executable in ~/.ail/runners/ — no recompilation needed.

Workstream 1 — Runner Plugin System:
- Define JSON-RPC protocol spec (r10) and discovery spec (r11)
- Implement PluginRegistry, PluginManifest, ProtocolRunner
- JSON-RPC wire types (request/response/notification)
- Manifest DTO → domain validation following existing pattern
- Extend RunnerFactory with build_with_registry() for plugin lookup
- Add stdin piping to SubprocessSession for bidirectional communication
- Add PLUGIN_* error types to AilError
- Integration tests using shell-script protocol-compliant plugins

Workstream 2 — Command Trait:
- Add CommandOutcome type for structured exit handling
- Migrate validate, materialize, delete to struct-based commands
- Simplify main.rs dispatch to use command structs

Workstream 3 — Spec Updates:
- Rewrite spec/core/s19 to document actual plugin architecture
- Update spec/README.md with r10/r11 entries
- Update CLAUDE.md files with new modules and error types

https://claude.ai/code/session_01ECXFbV7dtQtVWpjvH4bM3A