### PR TITLE
refactor: decompose executor/helpers into per-concern modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ Unresolved variables **abort with a typed error** — never silently empty.
 - No `unwrap()`/`expect()` outside tests
 - No `println!`/`eprintln!` in `ail-core` — use `tracing::{info, warn, error}`
 - `dto.rs` derives `Deserialize`; `domain.rs` does not — conversion in `validation.rs`
-- `#[allow(clippy::result_large_err)]` required in every module that returns `Result<_, AilError>`. Apply at file scope (`#![allow(...)]`). Current files: `config/{mod,validation}.rs`, `template.rs`, `executor/{core,headless,controlled,helpers}.rs`, `runner/{mod,factory,http,subprocess,claude/mod,claude/permission}.rs`, `runner/plugin/{mod,validation,discovery,protocol_runner}.rs`, `delete.rs`, `fs_util.rs`, `logs.rs`, `formatter.rs`
+- `#[allow(clippy::result_large_err)]` required in every module that returns `Result<_, AilError>`. Apply at file scope (`#![allow(...)]`). Current files: `config/{mod,validation/mod,validation/step_body,validation/on_result,validation/system_prompt}.rs`, `template.rs`, `executor/{core,headless,controlled}.rs`, `executor/helpers/{invocation,runner_resolution,shell,system_prompt}.rs`, `executor/dispatch/{prompt,context,sub_pipeline}.rs`, `runner/{mod,factory,http,subprocess,claude/mod,claude/permission}.rs`, `runner/plugin/{mod,validation,discovery,protocol_runner}.rs`, `delete.rs`, `fs_util.rs`, `logs.rs`, `formatter.rs`
 - All errors use `AilError` with a stable `error_type` string constant from `error::error_types`
 - No co-authorship lines in git commits
 

--- a/ail-core/CLAUDE.md
+++ b/ail-core/CLAUDE.md
@@ -10,10 +10,27 @@ Consumed by `ail` (the binary) and future language-server / SDK targets.
 | `config/discovery.rs` | Walk the four-step file resolution order (SPEC §3.1) |
 | `config/dto.rs` | Serde-deserialised raw structs — derives `Deserialize` |
 | `config/domain.rs` | Validated domain types — no `Deserialize` derives |
-| `config/validation.rs` | `dto → domain` conversion with typed `AilError` on failure |
+| `config/validation/mod.rs` | `validate()` entry point, `cfg_err!` macro, `tools_to_policy` helper |
+| `config/validation/step_body.rs` | `parse_step_body()` — primary field count check + body construction |
+| `config/validation/on_result.rs` | `parse_result_branches()` — DTO → domain for result matchers and actions |
+| `config/validation/system_prompt.rs` | `parse_append_system_prompt()` — DTO → domain for system prompt entries |
 | `config/mod.rs` | `load(path)` public entry point |
 | `error.rs` | `AilError`, `ErrorContext`, `error_types` string constants |
-| `executor.rs` | `execute(&mut Session, &dyn Runner)` — SPEC §4.2 core invariant |
+| `executor/mod.rs` | `execute(&mut Session, &dyn Runner)` — SPEC §4.2 core invariant |
+| `executor/core.rs` | `StepObserver` trait, `NullObserver`, `execute_core()` — shared step-dispatch loop |
+| `executor/headless.rs` | `execute()` — headless mode entry point using `NullObserver` |
+| `executor/controlled.rs` | `execute_with_control()` — TUI-controlled mode with `ChannelObserver` |
+| `executor/events.rs` | `ExecuteOutcome`, `ExecutionControl`, `ExecutorEvent` |
+| `executor/helpers/mod.rs` | Re-exports all helper functions for the executor |
+| `executor/helpers/invocation.rs` | `run_invocation_step()` — host-managed invocation step lifecycle |
+| `executor/helpers/runner_resolution.rs` | `resolve_step_provider()`, `build_step_runner_box()`, `resolve_effective_runner_name()` |
+| `executor/helpers/shell.rs` | `run_shell_command()` — `/bin/sh -c` subprocess execution |
+| `executor/helpers/on_result.rs` | `evaluate_on_result()`, `build_tool_policy()` — on_result branch evaluation + tool policy |
+| `executor/helpers/system_prompt.rs` | `resolve_step_system_prompts()`, `resolve_prompt_file()` — system prompt resolution and file loading |
+| `executor/dispatch/mod.rs` | Re-exports step-type dispatch modules |
+| `executor/dispatch/prompt.rs` | Prompt step dispatch — template resolution, runner invocation, TurnEntry construction |
+| `executor/dispatch/context.rs` | Context shell step dispatch — shell execution and TurnEntry construction |
+| `executor/dispatch/sub_pipeline.rs` | Sub-pipeline dispatch — recursion, depth guard, child session creation |
 | `materialize.rs` | `materialize(&Pipeline) → String` — annotated YAML round-trip |
 | `runner/mod.rs` | `Runner` trait, `RunResult`, `InvokeOptions` |
 | `runner/subprocess.rs` | `SubprocessSession` — generic CLI subprocess lifecycle (spawn, stderr drain, cancel watchdog, reap); shared by all CLI-based runners |

--- a/ail-core/src/config/validation/mod.rs
+++ b/ail-core/src/config/validation/mod.rs
@@ -1,15 +1,16 @@
+//! DTO → domain validation for pipeline files.
+
 #![allow(clippy::result_large_err)]
+
+mod on_result;
+mod step_body;
+mod system_prompt;
 
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use super::domain::{
-    ActionKind, Condition, ContextSource, ExitCodeMatch, Pipeline, ProviderConfig, ResultAction,
-    ResultBranch, ResultMatcher, Step, StepBody, StepId, SystemPromptEntry, ToolPolicy,
-};
-use super::dto::{
-    AppendSystemPromptEntryDto, ExitCodeDto, OnResultBranchDto, PipelineFileDto, ToolsDto,
-};
+use super::domain::{Condition, Pipeline, ProviderConfig, Step, StepId, ToolPolicy};
+use super::dto::{PipelineFileDto, ToolsDto};
 use crate::error::AilError;
 
 macro_rules! cfg_err {
@@ -21,119 +22,15 @@ macro_rules! cfg_err {
     };
 }
 
+// Make the macro available to sub-modules.
+pub(in crate::config) use cfg_err;
+
 fn tools_to_policy(t: ToolsDto) -> ToolPolicy {
     ToolPolicy {
         disabled: t.disabled,
         allow: t.allow,
         deny: t.deny,
     }
-}
-
-fn parse_result_branches(
-    step_id: &str,
-    branches: Vec<OnResultBranchDto>,
-) -> Result<Vec<ResultBranch>, AilError> {
-    branches
-        .into_iter()
-        .enumerate()
-        .map(|(i, branch)| {
-            let matcher_count = [
-                branch.contains.is_some(),
-                branch.exit_code.is_some(),
-                branch.always.is_some(),
-            ]
-            .iter()
-            .filter(|&&b| b)
-            .count();
-
-            if matcher_count != 1 {
-                return Err(cfg_err!(
-                    "Step '{step_id}' on_result branch {i} must have exactly one matcher \
-                     (contains, exit_code, always); found {matcher_count}"
-                ));
-            }
-
-            let action_str = branch.action.ok_or_else(|| {
-                cfg_err!("Step '{step_id}' on_result branch {i} must declare an 'action'")
-            })?;
-
-            let action = if let Some(path) = action_str.strip_prefix("pipeline:").map(str::trim) {
-                if path.is_empty() {
-                    return Err(cfg_err!(
-                        "Step '{step_id}' on_result branch {i} action 'pipeline:' requires a path"
-                    ));
-                }
-                ResultAction::Pipeline {
-                    path: path.to_string(),
-                    prompt: branch.prompt,
-                }
-            } else {
-                match action_str.as_str() {
-                    "continue" => ResultAction::Continue,
-                    "break" => ResultAction::Break,
-                    "abort_pipeline" => ResultAction::AbortPipeline,
-                    "pause_for_human" => ResultAction::PauseForHuman,
-                    other => {
-                        return Err(cfg_err!(
-                        "Step '{step_id}' on_result branch {i} specifies unknown action '{other}'"
-                    ))
-                    }
-                }
-            };
-
-            let matcher = if let Some(text) = branch.contains {
-                ResultMatcher::Contains(text)
-            } else if let Some(exit_code_dto) = branch.exit_code {
-                let exit_code_match = match exit_code_dto {
-                    ExitCodeDto::Integer(n) => ExitCodeMatch::Exact(n),
-                    ExitCodeDto::Keyword(k) if k == "any" => ExitCodeMatch::Any,
-                    ExitCodeDto::Keyword(k) => {
-                        return Err(cfg_err!(
-                            "Step '{step_id}' on_result branch {i} exit_code must be an integer \
-                             or 'any', got '{k}'"
-                        ))
-                    }
-                };
-                ResultMatcher::ExitCode(exit_code_match)
-            } else {
-                ResultMatcher::Always
-            };
-
-            Ok(ResultBranch { matcher, action })
-        })
-        .collect()
-}
-
-fn parse_append_system_prompt(
-    step_id: &str,
-    entries: Vec<AppendSystemPromptEntryDto>,
-) -> Result<Vec<SystemPromptEntry>, AilError> {
-    entries
-        .into_iter()
-        .enumerate()
-        .map(|(i, entry)| match entry {
-            AppendSystemPromptEntryDto::Text(s) => Ok(SystemPromptEntry::Text(s)),
-            AppendSystemPromptEntryDto::Structured(s) => {
-                let set_count = [s.text.is_some(), s.file.is_some(), s.shell.is_some()]
-                    .iter()
-                    .filter(|&&b| b)
-                    .count();
-                if set_count != 1 {
-                    return Err(cfg_err!(
-                        "Step '{step_id}' append_system_prompt entry {i} must have exactly one \
-                         key (text, file, or shell); found {set_count}"
-                    ));
-                }
-                if let Some(text) = s.text {
-                    Ok(SystemPromptEntry::Text(text))
-                } else if let Some(file) = s.file {
-                    Ok(SystemPromptEntry::File(std::path::PathBuf::from(file)))
-                } else {
-                    Ok(SystemPromptEntry::Shell(s.shell.expect("set_count == 1")))
-                }
-            }
-        })
-        .collect()
 }
 
 pub fn validate(dto: PipelineFileDto, source: PathBuf) -> Result<Pipeline, AilError> {
@@ -203,71 +100,18 @@ pub fn validate(dto: PipelineFileDto, source: PathBuf) -> Result<Pipeline, AilEr
     for step_dto in step_dtos {
         let id_str = step_dto
             .id
+            .clone()
             .ok_or_else(|| cfg_err!("Every step must declare an 'id' field"))?;
 
         if !seen_ids.insert(id_str.clone()) {
             return Err(cfg_err!("Step id '{id_str}' appears more than once"));
         }
 
-        // When pipeline: is set, prompt: is treated as the child invocation override,
-        // not a primary field — so don't count it in the primary field selector.
-        let primary_count = [
-            step_dto.prompt.is_some() && step_dto.pipeline.is_none(),
-            step_dto.skill.is_some(),
-            step_dto.pipeline.is_some(),
-            step_dto.action.is_some(),
-            step_dto.context.is_some(),
-        ]
-        .iter()
-        .filter(|&&b| b)
-        .count();
-
-        if primary_count != 1 {
-            return Err(cfg_err!(
-                "Step '{id_str}' must have exactly one primary field \
-                 (prompt, skill, pipeline, action, or context); found {primary_count}"
-            ));
-        }
-
-        // pipeline: is checked before prompt: so that pipeline+prompt correctly creates a
-        // SubPipeline step with prompt as the child invocation override (SPEC §9.3).
-        let body = if let Some(pipeline_path) = step_dto.pipeline {
-            StepBody::SubPipeline {
-                path: pipeline_path,
-                prompt: step_dto.prompt,
-            }
-        } else if let Some(prompt) = step_dto.prompt {
-            StepBody::Prompt(prompt)
-        } else if let Some(_skill) = step_dto.skill {
-            return Err(cfg_err!(
-                "Step '{id_str}' uses 'skill:' which is not yet implemented (planned for v0.2+). \
-                 Use a 'pipeline:' step to compose pipelines instead."
-            ));
-        } else if let Some(action) = step_dto.action {
-            match action.as_str() {
-                "pause_for_human" => StepBody::Action(ActionKind::PauseForHuman),
-                other => {
-                    return Err(cfg_err!(
-                        "Step '{id_str}' specifies unknown action '{other}'"
-                    ))
-                }
-            }
-        } else if let Some(context_dto) = step_dto.context {
-            match context_dto.shell {
-                Some(cmd) => StepBody::Context(ContextSource::Shell(cmd)),
-                None => {
-                    return Err(cfg_err!(
-                        "Step '{id_str}' declares context: but no source (shell:, mcp:) is present"
-                    ))
-                }
-            }
-        } else {
-            unreachable!("primary_count == 1 enforced above")
-        };
+        let body = step_body::parse_step_body(&step_dto, &id_str)?;
 
         let on_result = step_dto
             .on_result
-            .map(|branches| parse_result_branches(&id_str, branches))
+            .map(|branches| on_result::parse_result_branches(&id_str, branches))
             .transpose()?;
 
         let condition = match step_dto.condition.as_deref() {
@@ -283,7 +127,7 @@ pub fn validate(dto: PipelineFileDto, source: PathBuf) -> Result<Pipeline, AilEr
 
         let append_system_prompt = step_dto
             .append_system_prompt
-            .map(|entries| parse_append_system_prompt(&id_str, entries))
+            .map(|entries| system_prompt::parse_append_system_prompt(&id_str, entries))
             .transpose()?;
 
         steps.push(Step {
@@ -315,6 +159,10 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+    use crate::config::domain::{
+        ActionKind, Condition, ContextSource, ExitCodeMatch, ResultAction, ResultMatcher, StepBody,
+        SystemPromptEntry,
+    };
     use crate::config::dto::{
         AppendSystemPromptEntryDto, AppendSystemPromptStructuredDto, ContextDto, DefaultsDto,
         ExitCodeDto, OnResultBranchDto, PipelineFileDto, ProviderDto, StepDto, ToolsDto,

--- a/ail-core/src/config/validation/on_result.rs
+++ b/ail-core/src/config/validation/on_result.rs
@@ -1,0 +1,84 @@
+//! on_result branch parsing — DTO to domain conversion for result matchers and actions.
+
+#![allow(clippy::result_large_err)]
+
+use crate::config::domain::{ExitCodeMatch, ResultAction, ResultBranch, ResultMatcher};
+use crate::config::dto::ExitCodeDto;
+use crate::error::AilError;
+
+use super::cfg_err;
+
+pub(in crate::config) fn parse_result_branches(
+    step_id: &str,
+    branches: Vec<crate::config::dto::OnResultBranchDto>,
+) -> Result<Vec<ResultBranch>, AilError> {
+    branches
+        .into_iter()
+        .enumerate()
+        .map(|(i, branch)| {
+            let matcher_count = [
+                branch.contains.is_some(),
+                branch.exit_code.is_some(),
+                branch.always.is_some(),
+            ]
+            .iter()
+            .filter(|&&b| b)
+            .count();
+
+            if matcher_count != 1 {
+                return Err(cfg_err!(
+                    "Step '{step_id}' on_result branch {i} must have exactly one matcher \
+                     (contains, exit_code, always); found {matcher_count}"
+                ));
+            }
+
+            let action_str = branch.action.ok_or_else(|| {
+                cfg_err!("Step '{step_id}' on_result branch {i} must declare an 'action'")
+            })?;
+
+            let action = if let Some(path) = action_str.strip_prefix("pipeline:").map(str::trim) {
+                if path.is_empty() {
+                    return Err(cfg_err!(
+                        "Step '{step_id}' on_result branch {i} action 'pipeline:' requires a path"
+                    ));
+                }
+                ResultAction::Pipeline {
+                    path: path.to_string(),
+                    prompt: branch.prompt,
+                }
+            } else {
+                match action_str.as_str() {
+                    "continue" => ResultAction::Continue,
+                    "break" => ResultAction::Break,
+                    "abort_pipeline" => ResultAction::AbortPipeline,
+                    "pause_for_human" => ResultAction::PauseForHuman,
+                    other => {
+                        return Err(cfg_err!(
+                        "Step '{step_id}' on_result branch {i} specifies unknown action '{other}'"
+                    ))
+                    }
+                }
+            };
+
+            let matcher = if let Some(text) = branch.contains {
+                ResultMatcher::Contains(text)
+            } else if let Some(exit_code_dto) = branch.exit_code {
+                let exit_code_match = match exit_code_dto {
+                    ExitCodeDto::Integer(n) => ExitCodeMatch::Exact(n),
+                    ExitCodeDto::Keyword(k) if k == "any" => ExitCodeMatch::Any,
+                    ExitCodeDto::Keyword(k) => {
+                        return Err(cfg_err!(
+                            "Step '{step_id}' on_result branch {i} exit_code must be an integer \
+                             or 'any', got '{k}'"
+                        ))
+                    }
+                };
+                ResultMatcher::ExitCode(exit_code_match)
+            } else {
+                ResultMatcher::Always
+            };
+
+            Ok(ResultBranch { matcher, action })
+        })
+        .collect()
+}

--- a/ail-core/src/config/validation/step_body.rs
+++ b/ail-core/src/config/validation/step_body.rs
@@ -1,0 +1,67 @@
+//! Step body parsing — primary field selection and body construction.
+
+#![allow(clippy::result_large_err)]
+
+use crate::config::domain::{ActionKind, ContextSource, StepBody};
+use crate::config::dto::StepDto;
+use crate::error::AilError;
+
+use super::cfg_err;
+
+/// Parse the step body from a DTO, enforcing exactly one primary field.
+pub(in crate::config) fn parse_step_body(
+    step_dto: &StepDto,
+    id_str: &str,
+) -> Result<StepBody, AilError> {
+    // When pipeline: is set, prompt: is treated as the child invocation override,
+    // not a primary field — so don't count it in the primary field selector.
+    let primary_count = [
+        step_dto.prompt.is_some() && step_dto.pipeline.is_none(),
+        step_dto.skill.is_some(),
+        step_dto.pipeline.is_some(),
+        step_dto.action.is_some(),
+        step_dto.context.is_some(),
+    ]
+    .iter()
+    .filter(|&&b| b)
+    .count();
+
+    if primary_count != 1 {
+        return Err(cfg_err!(
+            "Step '{id_str}' must have exactly one primary field \
+             (prompt, skill, pipeline, action, or context); found {primary_count}"
+        ));
+    }
+
+    // pipeline: is checked before prompt: so that pipeline+prompt correctly creates a
+    // SubPipeline step with prompt as the child invocation override (SPEC §9.3).
+    if let Some(ref pipeline_path) = step_dto.pipeline {
+        Ok(StepBody::SubPipeline {
+            path: pipeline_path.clone(),
+            prompt: step_dto.prompt.clone(),
+        })
+    } else if let Some(ref prompt) = step_dto.prompt {
+        Ok(StepBody::Prompt(prompt.clone()))
+    } else if step_dto.skill.is_some() {
+        Err(cfg_err!(
+            "Step '{id_str}' uses 'skill:' which is not yet implemented (planned for v0.2+). \
+             Use a 'pipeline:' step to compose pipelines instead."
+        ))
+    } else if let Some(ref action) = step_dto.action {
+        match action.as_str() {
+            "pause_for_human" => Ok(StepBody::Action(ActionKind::PauseForHuman)),
+            other => Err(cfg_err!(
+                "Step '{id_str}' specifies unknown action '{other}'"
+            )),
+        }
+    } else if let Some(ref context_dto) = step_dto.context {
+        match context_dto.shell {
+            Some(ref cmd) => Ok(StepBody::Context(ContextSource::Shell(cmd.clone()))),
+            None => Err(cfg_err!(
+                "Step '{id_str}' declares context: but no source (shell:, mcp:) is present"
+            )),
+        }
+    } else {
+        unreachable!("primary_count == 1 enforced above")
+    }
+}

--- a/ail-core/src/config/validation/system_prompt.rs
+++ b/ail-core/src/config/validation/system_prompt.rs
@@ -1,0 +1,41 @@
+//! append_system_prompt parsing — DTO to domain conversion for system prompt entries.
+
+#![allow(clippy::result_large_err)]
+
+use crate::config::domain::SystemPromptEntry;
+use crate::config::dto::AppendSystemPromptEntryDto;
+use crate::error::AilError;
+
+use super::cfg_err;
+
+pub(in crate::config) fn parse_append_system_prompt(
+    step_id: &str,
+    entries: Vec<AppendSystemPromptEntryDto>,
+) -> Result<Vec<SystemPromptEntry>, AilError> {
+    entries
+        .into_iter()
+        .enumerate()
+        .map(|(i, entry)| match entry {
+            AppendSystemPromptEntryDto::Text(s) => Ok(SystemPromptEntry::Text(s)),
+            AppendSystemPromptEntryDto::Structured(s) => {
+                let set_count = [s.text.is_some(), s.file.is_some(), s.shell.is_some()]
+                    .iter()
+                    .filter(|&&b| b)
+                    .count();
+                if set_count != 1 {
+                    return Err(cfg_err!(
+                        "Step '{step_id}' append_system_prompt entry {i} must have exactly one \
+                         key (text, file, or shell); found {set_count}"
+                    ));
+                }
+                if let Some(text) = s.text {
+                    Ok(SystemPromptEntry::Text(text))
+                } else if let Some(file) = s.file {
+                    Ok(SystemPromptEntry::File(std::path::PathBuf::from(file)))
+                } else {
+                    Ok(SystemPromptEntry::Shell(s.shell.expect("set_count == 1")))
+                }
+            }
+        })
+        .collect()
+}

--- a/ail-core/src/executor/core.rs
+++ b/ail-core/src/executor/core.rs
@@ -7,21 +7,14 @@
 
 #![allow(clippy::result_large_err)]
 
-use std::time::SystemTime;
-
-use crate::config::domain::{
-    ActionKind, Condition, ContextSource, ResultAction, StepBody, MAX_SUB_PIPELINE_DEPTH,
-};
+use crate::config::domain::{ActionKind, Condition, ContextSource, ResultAction, StepBody};
 use crate::error::AilError;
 use crate::runner::{InvokeOptions, RunResult, Runner};
-use crate::session::{Session, TurnEntry};
-use crate::template;
+use crate::session::Session;
 
+use super::dispatch;
 use super::events::ExecuteOutcome;
-use super::helpers::{
-    build_step_runner_box, build_tool_policy, evaluate_on_result, resolve_effective_runner_name,
-    resolve_prompt_file, resolve_step_provider, resolve_step_system_prompts, run_shell_command,
-};
+use super::helpers::evaluate_on_result;
 
 // ── Observer trait ────────────────────────────────────────────────────────────
 
@@ -159,112 +152,6 @@ impl StepObserver for NullObserver {
     }
 }
 
-// ── Sub-pipeline execution ────────────────────────────────────────────────────
-
-/// Load and execute a sub-pipeline, returning a `TurnEntry` for the calling step.
-///
-/// The `path_template` may contain `{{ variable }}` syntax (SPEC §11); it is resolved
-/// against `session` before the file is loaded. The sub-pipeline runs in isolation:
-/// a fresh `Session` is created with the parent's `last_response` as its invocation prompt.
-/// The child's final step response becomes the returned entry's `response` field.
-///
-/// `depth` guards against infinite recursion; exceeding `MAX_SUB_PIPELINE_DEPTH` aborts.
-///
-/// **Note:** sub-pipelines always execute in headless mode, even when the parent pipeline
-/// is running in controlled mode. Sub-pipeline streaming events and HITL gates are not
-/// propagated to the parent's TUI. This is a known limitation (v0.2).
-pub(super) fn execute_sub_pipeline(
-    path_template: &str,
-    prompt_override: Option<&str>,
-    step_id: &str,
-    session: &mut Session,
-    runner: &dyn Runner,
-    depth: usize,
-    base_dir: Option<&std::path::Path>,
-) -> Result<TurnEntry, AilError> {
-    if depth >= MAX_SUB_PIPELINE_DEPTH {
-        return Err(AilError::PipelineAborted {
-            detail: format!(
-                "Step '{step_id}' would exceed the maximum sub-pipeline nesting depth \
-                 of {MAX_SUB_PIPELINE_DEPTH}"
-            ),
-            context: Some(crate::error::ErrorContext::for_step(
-                &session.run_id,
-                step_id,
-            )),
-        });
-    }
-
-    // Resolve template variables in the path (SPEC §11).
-    let resolved_path = template::resolve(path_template, session)
-        .map_err(|e| e.with_step_context(&session.run_id, step_id))?;
-
-    // Resolve ./relative and ../relative paths against the parent pipeline's directory (SPEC §9).
-    let path_buf = if let (true, Some(base)) = (
-        resolved_path.starts_with("./") || resolved_path.starts_with("../"),
-        base_dir,
-    ) {
-        base.join(&resolved_path)
-    } else {
-        std::path::PathBuf::from(&resolved_path)
-    };
-
-    let sub_pipeline = crate::config::load(path_buf.as_path())
-        .map_err(|e| e.with_step_context(&session.run_id, step_id))?;
-
-    // The sub-pipeline's invocation prompt: use the explicit override when provided
-    // (template-resolved against the parent session), otherwise fall back to the
-    // parent's most recent response (SPEC §9).
-    let invocation_prompt = if let Some(override_template) = prompt_override {
-        template::resolve(override_template, session)
-            .map_err(|e| e.with_step_context(&session.run_id, step_id))?
-    } else {
-        session
-            .turn_log
-            .last_response()
-            .unwrap_or(&session.invocation_prompt)
-            .to_string()
-    };
-
-    let mut child_session = crate::session::Session::new(sub_pipeline, invocation_prompt);
-    child_session.cli_provider = session.cli_provider.clone();
-
-    tracing::info!(
-        run_id = %session.run_id,
-        step_id = %step_id,
-        sub_pipeline = %resolved_path,
-        depth,
-        "executing sub-pipeline"
-    );
-
-    execute_core(&mut child_session, runner, &mut NullObserver, depth + 1)?;
-
-    let response = child_session
-        .turn_log
-        .last_response()
-        .unwrap_or("")
-        .to_string();
-
-    Ok(TurnEntry {
-        step_id: step_id.to_string(),
-        prompt: resolved_path,
-        response: Some(response),
-        timestamp: SystemTime::now(),
-        cost_usd: None,
-        input_tokens: 0,
-        output_tokens: 0,
-        runner_session_id: child_session
-            .turn_log
-            .last_runner_session_id()
-            .map(str::to_string),
-        stdout: None,
-        stderr: None,
-        exit_code: None,
-        thinking: None,
-        tool_events: vec![],
-    })
-}
-
 // ── Core loop ─────────────────────────────────────────────────────────────────
 
 /// Inner execution loop shared by headless and controlled modes.
@@ -327,88 +214,20 @@ pub(super) fn execute_core<O: StepObserver>(
         }
 
         let entry = match &step.body {
-            StepBody::Prompt(template_text) => {
-                let template_text = resolve_prompt_file(template_text, &step_id, pipeline_base_dir)
-                    .inspect_err(|e| observer.on_step_failed(&step_id, e.detail()))?;
-                let resolved = template::resolve(&template_text, session)
-                    .map_err(|e| e.with_step_context(&session.run_id, &step_id))
-                    .inspect_err(|e| observer.on_step_failed(&step_id, e.detail()))?;
-
-                observer.on_prompt_ready(&step_id, step_index, total_steps, &resolved);
-
-                let resume_id = if step.resume {
-                    session
-                        .turn_log
-                        .last_runner_session_id()
-                        .map(|s| s.to_string())
-                } else {
-                    None
-                };
-                session.turn_log.record_step_started(&step_id, &resolved);
-
-                let (resolved_system_prompt, resolved_append_system_prompt) =
-                    resolve_step_system_prompts(step, session, &step_id, pipeline_base_dir)
-                        .inspect_err(|e| observer.on_step_failed(&step_id, e.detail()))?;
-
-                let resolved_provider = resolve_step_provider(session, step);
-                let effective_tools = step
-                    .tools
-                    .as_ref()
-                    .or(session.pipeline.default_tools.as_ref());
-                // Update session.runner_name so {{ session.tool }} reflects the active runner.
-                session.runner_name = resolve_effective_runner_name(step);
-                let step_runner_box = build_step_runner_box(
-                    step,
-                    session.headless,
-                    &session.http_session_store,
-                    &resolved_provider,
-                )
-                .inspect_err(|e| observer.on_step_failed(&step_id, e.detail()))?;
-                let effective_runner: &dyn Runner = step_runner_box
-                    .as_deref()
-                    .map(|b| b as &dyn Runner)
-                    .unwrap_or(runner);
-
-                let extensions = effective_runner.build_extensions(&resolved_provider);
-                let mut options = InvokeOptions {
-                    resume_session_id: resume_id,
-                    tool_policy: build_tool_policy(effective_tools),
-                    model: resolved_provider.model,
-                    extensions,
-                    permission_responder: None,
-                    cancel_token: None,
-                    system_prompt: resolved_system_prompt,
-                    append_system_prompt: resolved_append_system_prompt,
-                };
-                observer.augment_options(&mut options);
-
-                let result = observer
-                    .invoke(effective_runner, &resolved, options)
-                    .inspect_err(|e| observer.on_step_failed(&step_id, e.detail()))?;
-
-                tracing::info!(
-                    run_id = %session.run_id,
-                    step_id = %step_id,
-                    cost_usd = ?result.cost_usd,
-                    "step complete"
-                );
-                observer.on_prompt_completed(&step_id, &result);
-
-                TurnEntry::from_prompt(step_id.clone(), resolved, result)
-            }
+            StepBody::Prompt(template_text) => dispatch::prompt::execute(
+                template_text,
+                step,
+                session,
+                runner,
+                &step_id,
+                step_index,
+                total_steps,
+                pipeline_base_dir,
+                observer,
+            )?,
 
             StepBody::Context(ContextSource::Shell(cmd)) => {
-                session.turn_log.record_step_started(&step_id, cmd);
-                let (stdout, stderr, exit_code) = run_shell_command(&session.run_id, &step_id, cmd)
-                    .inspect_err(|e| observer.on_step_failed(&step_id, e.detail()))?;
-                tracing::info!(
-                    run_id = %session.run_id,
-                    step_id = %step_id,
-                    exit_code,
-                    "context shell step complete"
-                );
-                observer.on_non_prompt_completed(&step_id);
-                TurnEntry::from_context(step_id.clone(), cmd.clone(), stdout, stderr, exit_code)
+                dispatch::context::execute_shell(cmd, session, &step_id, observer)?
             }
 
             StepBody::Action(ActionKind::PauseForHuman) => {
@@ -418,23 +237,16 @@ pub(super) fn execute_core<O: StepObserver>(
             StepBody::SubPipeline {
                 path: path_template,
                 prompt,
-            } => {
-                session
-                    .turn_log
-                    .record_step_started(&step_id, path_template);
-                let entry = execute_sub_pipeline(
-                    path_template,
-                    prompt.as_deref(),
-                    &step_id,
-                    session,
-                    runner,
-                    depth,
-                    pipeline_base_dir,
-                )
-                .inspect_err(|e| observer.on_step_failed(&step_id, e.detail()))?;
-                observer.on_non_prompt_completed(&step_id);
-                entry
-            }
+            } => dispatch::sub_pipeline::execute(
+                path_template,
+                prompt.as_deref(),
+                &step_id,
+                session,
+                runner,
+                depth,
+                pipeline_base_dir,
+                observer,
+            )?,
 
             StepBody::Skill(_) => {
                 let err = AilError::PipelineAborted {
@@ -493,7 +305,7 @@ pub(super) fn execute_core<O: StepObserver>(
                         // addressable as `{{ step.<id>__on_result.response }}` without
                         // shadowing the parent step's own turn log entry (SPEC §11).
                         let on_result_step_id = format!("{step_id}__on_result");
-                        let sub_entry = execute_sub_pipeline(
+                        let sub_entry = dispatch::sub_pipeline::execute_sub_pipeline(
                             path,
                             prompt.as_deref(),
                             &on_result_step_id,

--- a/ail-core/src/executor/dispatch/context.rs
+++ b/ail-core/src/executor/dispatch/context.rs
@@ -1,0 +1,35 @@
+//! Context shell step dispatch — shell subprocess execution and TurnEntry construction.
+
+#![allow(clippy::result_large_err)]
+
+use crate::error::AilError;
+use crate::session::{Session, TurnEntry};
+
+use crate::executor::core::StepObserver;
+use crate::executor::helpers::run_shell_command;
+
+/// Execute a shell context step: run the command and return a TurnEntry.
+pub(in crate::executor) fn execute_shell<O: StepObserver>(
+    cmd: &str,
+    session: &mut Session,
+    step_id: &str,
+    observer: &mut O,
+) -> Result<TurnEntry, AilError> {
+    session.turn_log.record_step_started(step_id, cmd);
+    let (stdout, stderr, exit_code) = run_shell_command(&session.run_id, step_id, cmd)
+        .inspect_err(|e| observer.on_step_failed(step_id, e.detail()))?;
+    tracing::info!(
+        run_id = %session.run_id,
+        step_id = %step_id,
+        exit_code,
+        "context shell step complete"
+    );
+    observer.on_non_prompt_completed(step_id);
+    Ok(TurnEntry::from_context(
+        step_id.to_string(),
+        cmd.to_string(),
+        stdout,
+        stderr,
+        exit_code,
+    ))
+}

--- a/ail-core/src/executor/dispatch/mod.rs
+++ b/ail-core/src/executor/dispatch/mod.rs
@@ -1,0 +1,5 @@
+//! Step-type-specific dispatch logic extracted from the core execution loop.
+
+pub(super) mod context;
+pub(super) mod prompt;
+pub(super) mod sub_pipeline;

--- a/ail-core/src/executor/dispatch/prompt.rs
+++ b/ail-core/src/executor/dispatch/prompt.rs
@@ -1,0 +1,102 @@
+//! Prompt step dispatch — template resolution, runner invocation, TurnEntry construction.
+
+#![allow(clippy::result_large_err)]
+
+use crate::error::AilError;
+use crate::runner::{InvokeOptions, Runner};
+use crate::session::{Session, TurnEntry};
+use crate::template;
+
+use crate::executor::core::StepObserver;
+use crate::executor::helpers::{
+    build_step_runner_box, build_tool_policy, resolve_effective_runner_name, resolve_prompt_file,
+    resolve_step_provider, resolve_step_system_prompts,
+};
+
+use crate::config::domain::Step;
+
+/// Execute a prompt step: resolve template, build runner, invoke, return TurnEntry.
+#[allow(clippy::too_many_arguments)]
+pub(in crate::executor) fn execute<O: StepObserver>(
+    template_text: &str,
+    step: &Step,
+    session: &mut Session,
+    runner: &dyn Runner,
+    step_id: &str,
+    step_index: usize,
+    total_steps: usize,
+    pipeline_base_dir: Option<&std::path::Path>,
+    observer: &mut O,
+) -> Result<TurnEntry, AilError> {
+    let template_text = resolve_prompt_file(template_text, step_id, pipeline_base_dir)
+        .inspect_err(|e| observer.on_step_failed(step_id, e.detail()))?;
+    let resolved = template::resolve(&template_text, session)
+        .map_err(|e| e.with_step_context(&session.run_id, step_id))
+        .inspect_err(|e| observer.on_step_failed(step_id, e.detail()))?;
+
+    observer.on_prompt_ready(step_id, step_index, total_steps, &resolved);
+
+    let resume_id = if step.resume {
+        session
+            .turn_log
+            .last_runner_session_id()
+            .map(|s| s.to_string())
+    } else {
+        None
+    };
+    session.turn_log.record_step_started(step_id, &resolved);
+
+    let (resolved_system_prompt, resolved_append_system_prompt) =
+        resolve_step_system_prompts(step, session, step_id, pipeline_base_dir)
+            .inspect_err(|e| observer.on_step_failed(step_id, e.detail()))?;
+
+    let resolved_provider = resolve_step_provider(session, step);
+    let effective_tools = step
+        .tools
+        .as_ref()
+        .or(session.pipeline.default_tools.as_ref());
+    // Update session.runner_name so {{ session.tool }} reflects the active runner.
+    session.runner_name = resolve_effective_runner_name(step);
+    let step_runner_box = build_step_runner_box(
+        step,
+        session.headless,
+        &session.http_session_store,
+        &resolved_provider,
+    )
+    .inspect_err(|e| observer.on_step_failed(step_id, e.detail()))?;
+    let effective_runner: &dyn Runner = step_runner_box
+        .as_deref()
+        .map(|b| b as &dyn Runner)
+        .unwrap_or(runner);
+
+    let extensions = effective_runner.build_extensions(&resolved_provider);
+    let mut options = InvokeOptions {
+        resume_session_id: resume_id,
+        tool_policy: build_tool_policy(effective_tools),
+        model: resolved_provider.model,
+        extensions,
+        permission_responder: None,
+        cancel_token: None,
+        system_prompt: resolved_system_prompt,
+        append_system_prompt: resolved_append_system_prompt,
+    };
+    observer.augment_options(&mut options);
+
+    let result = observer
+        .invoke(effective_runner, &resolved, options)
+        .inspect_err(|e| observer.on_step_failed(step_id, e.detail()))?;
+
+    tracing::info!(
+        run_id = %session.run_id,
+        step_id = %step_id,
+        cost_usd = ?result.cost_usd,
+        "step complete"
+    );
+    observer.on_prompt_completed(step_id, &result);
+
+    Ok(TurnEntry::from_prompt(
+        step_id.to_string(),
+        resolved,
+        result,
+    ))
+}

--- a/ail-core/src/executor/dispatch/sub_pipeline.rs
+++ b/ail-core/src/executor/dispatch/sub_pipeline.rs
@@ -1,0 +1,145 @@
+//! Sub-pipeline dispatch — recursion, depth guard, child session creation.
+
+#![allow(clippy::result_large_err)]
+
+use std::time::SystemTime;
+
+use crate::config::domain::MAX_SUB_PIPELINE_DEPTH;
+use crate::error::AilError;
+use crate::runner::Runner;
+use crate::session::{Session, TurnEntry};
+use crate::template;
+
+use crate::executor::core::{execute_core, NullObserver, StepObserver};
+
+/// Load and execute a sub-pipeline, returning a `TurnEntry` for the calling step.
+///
+/// The `path_template` may contain `{{ variable }}` syntax (SPEC §11); it is resolved
+/// against `session` before the file is loaded. The sub-pipeline runs in isolation:
+/// a fresh `Session` is created with the parent's `last_response` as its invocation prompt.
+/// The child's final step response becomes the returned entry's `response` field.
+///
+/// `depth` guards against infinite recursion; exceeding `MAX_SUB_PIPELINE_DEPTH` aborts.
+///
+/// **Note:** sub-pipelines always execute in headless mode, even when the parent pipeline
+/// is running in controlled mode. Sub-pipeline streaming events and HITL gates are not
+/// propagated to the parent's TUI. This is a known limitation (v0.2).
+#[allow(clippy::too_many_arguments)]
+pub(in crate::executor) fn execute<O: StepObserver>(
+    path_template: &str,
+    prompt_override: Option<&str>,
+    step_id: &str,
+    session: &mut Session,
+    runner: &dyn Runner,
+    depth: usize,
+    base_dir: Option<&std::path::Path>,
+    observer: &mut O,
+) -> Result<TurnEntry, AilError> {
+    session.turn_log.record_step_started(step_id, path_template);
+    let entry = execute_sub_pipeline(
+        path_template,
+        prompt_override,
+        step_id,
+        session,
+        runner,
+        depth,
+        base_dir,
+    )
+    .inspect_err(|e| observer.on_step_failed(step_id, e.detail()))?;
+    observer.on_non_prompt_completed(step_id);
+    Ok(entry)
+}
+
+/// Inner sub-pipeline execution logic. Also used by the on_result pipeline action
+/// in `core.rs`.
+pub(in crate::executor) fn execute_sub_pipeline(
+    path_template: &str,
+    prompt_override: Option<&str>,
+    step_id: &str,
+    session: &mut Session,
+    runner: &dyn Runner,
+    depth: usize,
+    base_dir: Option<&std::path::Path>,
+) -> Result<TurnEntry, AilError> {
+    if depth >= MAX_SUB_PIPELINE_DEPTH {
+        return Err(AilError::PipelineAborted {
+            detail: format!(
+                "Step '{step_id}' would exceed the maximum sub-pipeline nesting depth \
+                 of {MAX_SUB_PIPELINE_DEPTH}"
+            ),
+            context: Some(crate::error::ErrorContext::for_step(
+                &session.run_id,
+                step_id,
+            )),
+        });
+    }
+
+    // Resolve template variables in the path (SPEC §11).
+    let resolved_path = template::resolve(path_template, session)
+        .map_err(|e| e.with_step_context(&session.run_id, step_id))?;
+
+    // Resolve ./relative and ../relative paths against the parent pipeline's directory (SPEC §9).
+    let path_buf = if let (true, Some(base)) = (
+        resolved_path.starts_with("./") || resolved_path.starts_with("../"),
+        base_dir,
+    ) {
+        base.join(&resolved_path)
+    } else {
+        std::path::PathBuf::from(&resolved_path)
+    };
+
+    let sub_pipeline = crate::config::load(path_buf.as_path())
+        .map_err(|e| e.with_step_context(&session.run_id, step_id))?;
+
+    // The sub-pipeline's invocation prompt: use the explicit override when provided
+    // (template-resolved against the parent session), otherwise fall back to the
+    // parent's most recent response (SPEC §9).
+    let invocation_prompt = if let Some(override_template) = prompt_override {
+        template::resolve(override_template, session)
+            .map_err(|e| e.with_step_context(&session.run_id, step_id))?
+    } else {
+        session
+            .turn_log
+            .last_response()
+            .unwrap_or(&session.invocation_prompt)
+            .to_string()
+    };
+
+    let mut child_session = crate::session::Session::new(sub_pipeline, invocation_prompt);
+    child_session.cli_provider = session.cli_provider.clone();
+
+    tracing::info!(
+        run_id = %session.run_id,
+        step_id = %step_id,
+        sub_pipeline = %resolved_path,
+        depth,
+        "executing sub-pipeline"
+    );
+
+    execute_core(&mut child_session, runner, &mut NullObserver, depth + 1)?;
+
+    let response = child_session
+        .turn_log
+        .last_response()
+        .unwrap_or("")
+        .to_string();
+
+    Ok(TurnEntry {
+        step_id: step_id.to_string(),
+        prompt: resolved_path,
+        response: Some(response),
+        timestamp: SystemTime::now(),
+        cost_usd: None,
+        input_tokens: 0,
+        output_tokens: 0,
+        runner_session_id: child_session
+            .turn_log
+            .last_runner_session_id()
+            .map(str::to_string),
+        stdout: None,
+        stderr: None,
+        exit_code: None,
+        thinking: None,
+        tool_events: vec![],
+    })
+}

--- a/ail-core/src/executor/helpers/invocation.rs
+++ b/ail-core/src/executor/helpers/invocation.rs
@@ -1,0 +1,33 @@
+//! Invocation-step lifecycle — running the host-managed invocation step.
+
+#![allow(clippy::result_large_err)]
+
+use crate::error::AilError;
+use crate::runner::{InvokeOptions, RunResult, Runner};
+use crate::session::{Session, TurnEntry};
+
+/// Run the host-managed invocation step when the pipeline does not declare its own.
+///
+/// Calls `runner.invoke()`, appends a `TurnEntry` for `"invocation"`, and returns
+/// the `RunResult` so callers can use it for output or event emission.
+///
+/// **Callers must first check `session.has_invocation_step()`** — this function
+/// unconditionally runs the runner and logs the result. It does not recheck.
+pub fn run_invocation_step(
+    session: &mut Session,
+    runner: &dyn Runner,
+    prompt: &str,
+    options: InvokeOptions,
+) -> Result<RunResult, AilError> {
+    session.turn_log.record_step_started("invocation", prompt);
+    let result = runner
+        .invoke(prompt, options)
+        .map_err(|e| e.with_step_context(&session.run_id, "invocation"))?;
+    let result_clone = result.clone();
+    session.turn_log.append(TurnEntry::from_prompt(
+        "invocation",
+        prompt.to_string(),
+        result,
+    ));
+    Ok(result_clone)
+}

--- a/ail-core/src/executor/helpers/mod.rs
+++ b/ail-core/src/executor/helpers/mod.rs
@@ -1,0 +1,18 @@
+//! Shared helper functions used by both the headless and controlled execution paths.
+
+mod invocation;
+mod on_result;
+mod runner_resolution;
+mod shell;
+mod system_prompt;
+
+// Public re-export (used by executor/mod.rs)
+pub use invocation::run_invocation_step;
+
+// Crate-internal re-exports (used by core.rs and dispatch modules)
+pub(super) use on_result::{build_tool_policy, evaluate_on_result};
+pub(super) use runner_resolution::{
+    build_step_runner_box, resolve_effective_runner_name, resolve_step_provider,
+};
+pub(super) use shell::run_shell_command;
+pub(super) use system_prompt::{resolve_prompt_file, resolve_step_system_prompts};

--- a/ail-core/src/executor/helpers/on_result.rs
+++ b/ail-core/src/executor/helpers/on_result.rs
@@ -1,0 +1,123 @@
+//! on_result branch evaluation and tool policy construction.
+
+use crate::config::domain::{ExitCodeMatch, ResultAction, ResultMatcher};
+use crate::runner::ToolPermissionPolicy;
+use crate::session::TurnEntry;
+
+/// Evaluate `on_result` branches against the most recent `TurnEntry`.
+/// Returns the action of the first matching branch, or `None` if no branch matches.
+pub(in crate::executor) fn evaluate_on_result(
+    branches: &[crate::config::domain::ResultBranch],
+    entry: &TurnEntry,
+) -> Option<ResultAction> {
+    for branch in branches {
+        let matched = match &branch.matcher {
+            ResultMatcher::Contains(text) => {
+                let haystack = entry
+                    .response
+                    .as_deref()
+                    .or(entry.stdout.as_deref())
+                    .unwrap_or("");
+                let haystack_lower = haystack.to_lowercase();
+                haystack_lower.contains(&text.to_lowercase())
+            }
+            ResultMatcher::ExitCode(ExitCodeMatch::Exact(n)) => entry.exit_code == Some(*n),
+            ResultMatcher::ExitCode(ExitCodeMatch::Any) => {
+                // `any` matches any non-zero exit code — does NOT match 0.
+                matches!(entry.exit_code, Some(c) if c != 0)
+            }
+            ResultMatcher::Always => true,
+        };
+
+        if matched {
+            return Some(branch.action.clone());
+        }
+    }
+    None
+}
+
+/// Build a `ToolPermissionPolicy` from an optional `ToolPolicy` domain value.
+pub(in crate::executor) fn build_tool_policy(
+    tools: Option<&crate::config::domain::ToolPolicy>,
+) -> ToolPermissionPolicy {
+    match tools {
+        Some(t) if t.disabled => ToolPermissionPolicy::NoTools,
+        Some(t) if !t.allow.is_empty() && !t.deny.is_empty() => ToolPermissionPolicy::Mixed {
+            allow: t.allow.clone(),
+            deny: t.deny.clone(),
+        },
+        Some(t) if !t.allow.is_empty() => ToolPermissionPolicy::Allowlist(t.allow.clone()),
+        Some(t) if !t.deny.is_empty() => ToolPermissionPolicy::Denylist(t.deny.clone()),
+        _ => ToolPermissionPolicy::RunnerDefault,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::domain::ToolPolicy;
+    use crate::runner::ToolPermissionPolicy;
+
+    // ── build_tool_policy ────────────────────────────────────────────────────
+
+    fn make_policy(disabled: bool, allow: Vec<&str>, deny: Vec<&str>) -> ToolPolicy {
+        ToolPolicy {
+            disabled,
+            allow: allow.iter().map(|s| s.to_string()).collect(),
+            deny: deny.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn build_tool_policy_none_returns_runner_default() {
+        assert!(matches!(
+            build_tool_policy(None),
+            ToolPermissionPolicy::RunnerDefault
+        ));
+    }
+
+    #[test]
+    fn build_tool_policy_disabled_returns_no_tools() {
+        let policy = make_policy(true, vec![], vec![]);
+        assert!(matches!(
+            build_tool_policy(Some(&policy)),
+            ToolPermissionPolicy::NoTools
+        ));
+    }
+
+    #[test]
+    fn build_tool_policy_allow_and_deny_returns_mixed() {
+        let policy = make_policy(false, vec!["Bash"], vec!["Write"]);
+        assert!(matches!(
+            build_tool_policy(Some(&policy)),
+            ToolPermissionPolicy::Mixed { .. }
+        ));
+    }
+
+    #[test]
+    fn build_tool_policy_allow_only_returns_allowlist() {
+        let policy = make_policy(false, vec!["Read", "Bash"], vec![]);
+        assert!(matches!(
+            build_tool_policy(Some(&policy)),
+            ToolPermissionPolicy::Allowlist(_)
+        ));
+    }
+
+    #[test]
+    fn build_tool_policy_deny_only_returns_denylist() {
+        let policy = make_policy(false, vec![], vec!["Bash"]);
+        assert!(matches!(
+            build_tool_policy(Some(&policy)),
+            ToolPermissionPolicy::Denylist(_)
+        ));
+    }
+
+    #[test]
+    fn build_tool_policy_empty_returns_runner_default() {
+        let policy = make_policy(false, vec![], vec![]);
+        assert!(matches!(
+            build_tool_policy(Some(&policy)),
+            ToolPermissionPolicy::RunnerDefault
+        ));
+    }
+}

--- a/ail-core/src/executor/helpers/runner_resolution.rs
+++ b/ail-core/src/executor/helpers/runner_resolution.rs
@@ -1,0 +1,58 @@
+//! Runner selection and construction — resolving per-step runner overrides.
+
+#![allow(clippy::result_large_err)]
+
+use crate::config::domain::{ProviderConfig, Step};
+use crate::error::AilError;
+use crate::runner::factory::RunnerFactory;
+use crate::runner::http::HttpSessionStore;
+use crate::runner::Runner;
+use crate::session::Session;
+
+/// Resolve the effective provider config for a step by merging pipeline defaults,
+/// step-level model override, and CLI provider flags.
+pub(in crate::executor) fn resolve_step_provider(session: &Session, step: &Step) -> ProviderConfig {
+    session
+        .pipeline
+        .defaults
+        .clone()
+        .merge(ProviderConfig {
+            model: step.model.clone(),
+            ..Default::default()
+        })
+        .merge(session.cli_provider.clone())
+}
+
+/// Build a per-step runner override box if `step.runner` is set (SPEC §19).
+///
+/// `headless` is propagated from `Session.headless` so per-step `runner: claude` overrides
+/// honour the same `--dangerously-skip-permissions` flag as the default runner.
+pub(in crate::executor) fn build_step_runner_box(
+    step: &Step,
+    headless: bool,
+    http_store: &HttpSessionStore,
+    provider: &ProviderConfig,
+) -> Result<Option<Box<dyn Runner + Send>>, AilError> {
+    match step.runner {
+        Some(ref name) => Ok(Some(RunnerFactory::build(
+            name, headless, http_store, provider,
+        )?)),
+        None => Ok(None),
+    }
+}
+
+/// Resolve the effective runner name for a step without constructing the runner.
+///
+/// Mirrors the `RunnerFactory` selection hierarchy:
+/// 1. Per-step `runner:` field
+/// 2. `AIL_DEFAULT_RUNNER` environment variable
+/// 3. `"claude"` fallback
+///
+/// Used to update `session.runner_name` so `{{ session.tool }}` reflects the actual runner.
+pub(in crate::executor) fn resolve_effective_runner_name(step: &Step) -> String {
+    if let Some(ref name) = step.runner {
+        name.clone()
+    } else {
+        std::env::var("AIL_DEFAULT_RUNNER").unwrap_or_else(|_| "claude".to_string())
+    }
+}

--- a/ail-core/src/executor/helpers/shell.rs
+++ b/ail-core/src/executor/helpers/shell.rs
@@ -1,0 +1,36 @@
+//! Shell subprocess execution for context steps.
+
+#![allow(clippy::result_large_err)]
+
+use std::process::{Command, Stdio};
+
+use crate::error::AilError;
+
+/// Spawn `/bin/sh -c cmd` and return `(stdout, stderr, exit_code)`.
+pub(in crate::executor) fn run_shell_command(
+    run_id: &str,
+    step_id: &str,
+    cmd: &str,
+) -> Result<(String, String, i32), AilError> {
+    let child = Command::new("/bin/sh")
+        .args(["-c", cmd])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| AilError::RunnerInvocationFailed {
+            detail: format!("Could not run shell command for step '{step_id}': {e}"),
+            context: Some(crate::error::ErrorContext::for_step(run_id, step_id)),
+        })?;
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| AilError::RunnerInvocationFailed {
+            detail: format!("Step '{step_id}': {e}"),
+            context: Some(crate::error::ErrorContext::for_step(run_id, step_id)),
+        })?;
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    Ok((stdout, stderr, exit_code))
+}

--- a/ail-core/src/executor/helpers/system_prompt.rs
+++ b/ail-core/src/executor/helpers/system_prompt.rs
@@ -1,176 +1,20 @@
-//! Shared helper functions used by both the headless and controlled execution paths.
+//! System prompt resolution and file loading for pipeline steps.
 
 #![allow(clippy::result_large_err)]
 
-use std::process::{Command, Stdio};
-
-use crate::config::domain::{
-    ExitCodeMatch, ProviderConfig, ResultAction, ResultMatcher, Step, SystemPromptEntry,
-};
+use crate::config::domain::{Step, SystemPromptEntry};
 use crate::error::AilError;
-use crate::runner::factory::RunnerFactory;
-use crate::runner::http::HttpSessionStore;
-use crate::runner::{InvokeOptions, RunResult, Runner, ToolPermissionPolicy};
-use crate::session::{Session, TurnEntry};
+use crate::session::Session;
 use crate::template;
 
-/// Run the host-managed invocation step when the pipeline does not declare its own.
-///
-/// Calls `runner.invoke()`, appends a `TurnEntry` for `"invocation"`, and returns
-/// the `RunResult` so callers can use it for output or event emission.
-///
-/// **Callers must first check `session.has_invocation_step()`** — this function
-/// unconditionally runs the runner and logs the result. It does not recheck.
-pub fn run_invocation_step(
-    session: &mut Session,
-    runner: &dyn Runner,
-    prompt: &str,
-    options: InvokeOptions,
-) -> Result<RunResult, AilError> {
-    session.turn_log.record_step_started("invocation", prompt);
-    let result = runner
-        .invoke(prompt, options)
-        .map_err(|e| e.with_step_context(&session.run_id, "invocation"))?;
-    let result_clone = result.clone();
-    session.turn_log.append(TurnEntry::from_prompt(
-        "invocation",
-        prompt.to_string(),
-        result,
-    ));
-    Ok(result_clone)
-}
-
-/// Resolve the effective provider config for a step by merging pipeline defaults,
-/// step-level model override, and CLI provider flags.
-pub(super) fn resolve_step_provider(session: &Session, step: &Step) -> ProviderConfig {
-    session
-        .pipeline
-        .defaults
-        .clone()
-        .merge(ProviderConfig {
-            model: step.model.clone(),
-            ..Default::default()
-        })
-        .merge(session.cli_provider.clone())
-}
-
-/// Build a per-step runner override box if `step.runner` is set (SPEC §19).
-///
-/// `headless` is propagated from `Session.headless` so per-step `runner: claude` overrides
-/// honour the same `--dangerously-skip-permissions` flag as the default runner.
-pub(super) fn build_step_runner_box(
-    step: &Step,
-    headless: bool,
-    http_store: &HttpSessionStore,
-    provider: &ProviderConfig,
-) -> Result<Option<Box<dyn Runner + Send>>, AilError> {
-    match step.runner {
-        Some(ref name) => Ok(Some(RunnerFactory::build(
-            name, headless, http_store, provider,
-        )?)),
-        None => Ok(None),
-    }
-}
-
-/// Resolve the effective runner name for a step without constructing the runner.
-///
-/// Mirrors the `RunnerFactory` selection hierarchy:
-/// 1. Per-step `runner:` field
-/// 2. `AIL_DEFAULT_RUNNER` environment variable
-/// 3. `"claude"` fallback
-///
-/// Used to update `session.runner_name` so `{{ session.tool }}` reflects the actual runner.
-pub(super) fn resolve_effective_runner_name(step: &Step) -> String {
-    if let Some(ref name) = step.runner {
-        name.clone()
-    } else {
-        std::env::var("AIL_DEFAULT_RUNNER").unwrap_or_else(|_| "claude".to_string())
-    }
-}
-
-/// Spawn `/bin/sh -c cmd` and return `(stdout, stderr, exit_code)`.
-pub(super) fn run_shell_command(
-    run_id: &str,
-    step_id: &str,
-    cmd: &str,
-) -> Result<(String, String, i32), AilError> {
-    let child = Command::new("/bin/sh")
-        .args(["-c", cmd])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| AilError::RunnerInvocationFailed {
-            detail: format!("Could not run shell command for step '{step_id}': {e}"),
-            context: Some(crate::error::ErrorContext::for_step(run_id, step_id)),
-        })?;
-
-    let output = child
-        .wait_with_output()
-        .map_err(|e| AilError::RunnerInvocationFailed {
-            detail: format!("Step '{step_id}': {e}"),
-            context: Some(crate::error::ErrorContext::for_step(run_id, step_id)),
-        })?;
-
-    let exit_code = output.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    Ok((stdout, stderr, exit_code))
-}
-
-/// Evaluate `on_result` branches against the most recent `TurnEntry`.
-/// Returns the action of the first matching branch, or `None` if no branch matches.
-pub(super) fn evaluate_on_result(
-    branches: &[crate::config::domain::ResultBranch],
-    entry: &TurnEntry,
-) -> Option<ResultAction> {
-    for branch in branches {
-        let matched = match &branch.matcher {
-            ResultMatcher::Contains(text) => {
-                let haystack = entry
-                    .response
-                    .as_deref()
-                    .or(entry.stdout.as_deref())
-                    .unwrap_or("");
-                let haystack_lower = haystack.to_lowercase();
-                haystack_lower.contains(&text.to_lowercase())
-            }
-            ResultMatcher::ExitCode(ExitCodeMatch::Exact(n)) => entry.exit_code == Some(*n),
-            ResultMatcher::ExitCode(ExitCodeMatch::Any) => {
-                // `any` matches any non-zero exit code — does NOT match 0.
-                matches!(entry.exit_code, Some(c) if c != 0)
-            }
-            ResultMatcher::Always => true,
-        };
-
-        if matched {
-            return Some(branch.action.clone());
-        }
-    }
-    None
-}
-
-/// Build a `ToolPermissionPolicy` from an optional `ToolPolicy` domain value.
-pub(super) fn build_tool_policy(
-    tools: Option<&crate::config::domain::ToolPolicy>,
-) -> ToolPermissionPolicy {
-    match tools {
-        Some(t) if t.disabled => ToolPermissionPolicy::NoTools,
-        Some(t) if !t.allow.is_empty() && !t.deny.is_empty() => ToolPermissionPolicy::Mixed {
-            allow: t.allow.clone(),
-            deny: t.deny.clone(),
-        },
-        Some(t) if !t.allow.is_empty() => ToolPermissionPolicy::Allowlist(t.allow.clone()),
-        Some(t) if !t.deny.is_empty() => ToolPermissionPolicy::Denylist(t.deny.clone()),
-        _ => ToolPermissionPolicy::RunnerDefault,
-    }
-}
+use super::shell::run_shell_command;
 
 /// Resolve `system_prompt` and all `append_system_prompt` entries for a step.
 ///
 /// Returns `(resolved_system_prompt, resolved_append_entries)` on success.
 /// On error, returns an `AilError` with step context already populated — the caller
 /// may wrap with event emission before propagating.
-pub(super) fn resolve_step_system_prompts(
+pub(in crate::executor) fn resolve_step_system_prompts(
     step: &Step,
     session: &Session,
     step_id: &str,
@@ -223,7 +67,7 @@ pub(super) fn resolve_step_system_prompts(
 ///
 /// `base_dir` is the directory of the pipeline file that owns this step. Per SPEC §5.2,
 /// `./` and `../` paths are resolved relative to the pipeline file, not the process CWD.
-pub(super) fn resolve_prompt_file(
+pub(in crate::executor) fn resolve_prompt_file(
     prompt_text: &str,
     step_id: &str,
     base_dir: Option<&std::path::Path>,
@@ -267,73 +111,9 @@ pub(super) fn resolve_prompt_file(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::domain::{Pipeline, Step, StepBody, StepId, SystemPromptEntry, ToolPolicy};
-    use crate::runner::ToolPermissionPolicy;
+    use crate::config::domain::{Pipeline, Step, StepBody, StepId, SystemPromptEntry};
     use crate::session::log_provider::NullProvider;
     use crate::session::Session;
-
-    // ── build_tool_policy ────────────────────────────────────────────────────
-
-    fn make_policy(disabled: bool, allow: Vec<&str>, deny: Vec<&str>) -> ToolPolicy {
-        ToolPolicy {
-            disabled,
-            allow: allow.iter().map(|s| s.to_string()).collect(),
-            deny: deny.iter().map(|s| s.to_string()).collect(),
-        }
-    }
-
-    #[test]
-    fn build_tool_policy_none_returns_runner_default() {
-        assert!(matches!(
-            build_tool_policy(None),
-            ToolPermissionPolicy::RunnerDefault
-        ));
-    }
-
-    #[test]
-    fn build_tool_policy_disabled_returns_no_tools() {
-        let policy = make_policy(true, vec![], vec![]);
-        assert!(matches!(
-            build_tool_policy(Some(&policy)),
-            ToolPermissionPolicy::NoTools
-        ));
-    }
-
-    #[test]
-    fn build_tool_policy_allow_and_deny_returns_mixed() {
-        let policy = make_policy(false, vec!["Bash"], vec!["Write"]);
-        assert!(matches!(
-            build_tool_policy(Some(&policy)),
-            ToolPermissionPolicy::Mixed { .. }
-        ));
-    }
-
-    #[test]
-    fn build_tool_policy_allow_only_returns_allowlist() {
-        let policy = make_policy(false, vec!["Read", "Bash"], vec![]);
-        assert!(matches!(
-            build_tool_policy(Some(&policy)),
-            ToolPermissionPolicy::Allowlist(_)
-        ));
-    }
-
-    #[test]
-    fn build_tool_policy_deny_only_returns_denylist() {
-        let policy = make_policy(false, vec![], vec!["Bash"]);
-        assert!(matches!(
-            build_tool_policy(Some(&policy)),
-            ToolPermissionPolicy::Denylist(_)
-        ));
-    }
-
-    #[test]
-    fn build_tool_policy_empty_returns_runner_default() {
-        let policy = make_policy(false, vec![], vec![]);
-        assert!(matches!(
-            build_tool_policy(Some(&policy)),
-            ToolPermissionPolicy::RunnerDefault
-        ));
-    }
 
     // ── resolve_prompt_file ──────────────────────────────────────────────────
 

--- a/ail-core/src/executor/mod.rs
+++ b/ail-core/src/executor/mod.rs
@@ -6,6 +6,7 @@
 
 mod controlled;
 mod core;
+mod dispatch;
 mod events;
 mod headless;
 mod helpers;


### PR DESCRIPTION
Split the monolithic helpers.rs (516 lines) into a module directory:
- helpers/invocation.rs: run_invocation_step lifecycle
- helpers/runner_resolution.rs: provider config and runner construction
- helpers/shell.rs: shell subprocess execution
- helpers/on_result.rs: on_result branch evaluation + tool policy
- helpers/system_prompt.rs: system prompt resolution and file loading
- helpers/mod.rs: re-exports preserving existing visibility

No behavior changes. All existing tests pass unchanged.

https://claude.ai/code/session_01QZJpbWkTdZYYgQoTCEtv7Q