### PR TITLE
feat(#113): implement HITL modify_output action (§13.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ If nothing found → passthrough mode (safe zero-config default).
 | `{{ step.<id>.stdout }}` | stdout of a `shell:` context step |
 | `{{ step.<id>.stderr }}` | stderr of a `shell:` context step |
 | `{{ step.<id>.exit_code }}` | Exit code of a `shell:` context step (string) |
+| `{{ step.<id>.modified }}` | Human-modified output from a `modify_output` HITL gate (SPEC §13.2) |
 | `{{ last_response }}` | Most recent step response |
 | `{{ pipeline.run_id }}` | UUID for this run |
 | `{{ session.tool }}` | Runner name (e.g. `claude`) |
@@ -165,7 +166,7 @@ Unresolved variables **abort with a typed error** — never silently empty.
 
 - `--output-format stream-json` requires `--verbose` with `-p` — documented in `spec/runner/r02-claude-cli.md`
 - Must call `.env_remove("CLAUDECODE")` on the `Command` builder to avoid nested session guard
-- `pause_for_human` is a no-op in `--once` / headless mode (v0.2)
+- `pause_for_human` is a no-op in `--once` / headless mode; `modify_output` behavior is configurable via `on_headless` (skip/abort/use_default)
 - `skill:` and `pipeline:` step bodies abort with `PIPELINE_ABORTED` (stubs — v0.3+)
 - Interactive REPL deferred to v0.5
 - TUI removed in v0.2; all output goes to stdout/stderr

--- a/ail-core/CLAUDE.md
+++ b/ail-core/CLAUDE.md
@@ -66,7 +66,8 @@ pub enum StepBody  { Prompt(String), Skill(PathBuf), SubPipeline { path: String,
 // SubPipeline.path may contain {{ variable }} syntax — resolved at execution time (SPEC §11)
 // SubPipeline.prompt: when Some, overrides child session's invocation_prompt instead of using parent's last_response (SPEC §9.3)
 pub enum ContextSource { Shell(String) }
-pub enum ActionKind { PauseForHuman }
+pub enum ActionKind { PauseForHuman, ModifyOutput { headless_behavior: HitlHeadlessBehavior, default_value: Option<String> } }
+pub enum HitlHeadlessBehavior { Skip, Abort, UseDefault }
 pub struct ResultBranch { pub matcher: ResultMatcher, pub action: ResultAction }
 pub enum ResultMatcher { Contains(String), ExitCode(ExitCodeMatch), Always }
 pub enum ExitCodeMatch { Exact(i32), Any }

--- a/ail-core/src/config/domain.rs
+++ b/ail-core/src/config/domain.rs
@@ -173,6 +173,25 @@ pub enum ContextSource {
 #[derive(Debug, Clone)]
 pub enum ActionKind {
     PauseForHuman,
+    /// HITL modify gate (SPEC §13.2): presents step output to the human, who can edit it.
+    /// The modified text is stored in the turn log and available as `{{ step.<id>.modified }}`.
+    /// `headless_behavior` controls what happens when this action fires in headless/`--once` mode.
+    ModifyOutput {
+        headless_behavior: HitlHeadlessBehavior,
+        /// Optional default value used when `headless_behavior` is `UseDefault`.
+        default_value: Option<String>,
+    },
+}
+
+/// Behavior for HITL gates in headless/`--once` mode (SPEC §13.2).
+#[derive(Debug, Clone, PartialEq)]
+pub enum HitlHeadlessBehavior {
+    /// Skip the gate and continue the pipeline with the unmodified output (default).
+    Skip,
+    /// Abort the pipeline with a PIPELINE_ABORTED error.
+    Abort,
+    /// Use a configured default value as the modified output.
+    UseDefault,
 }
 
 /// One branch in an `on_result` multi-branch array (SPEC §5.4).

--- a/ail-core/src/config/dto.rs
+++ b/ail-core/src/config/dto.rs
@@ -32,8 +32,13 @@ pub struct StepDto {
     pub skill: Option<String>,
     pub pipeline: Option<String>,
     pub action: Option<String>,
-    /// Optional human-readable message shown in the HITL gate banner when `action: pause_for_human`.
+    /// Optional human-readable message shown in the HITL gate banner when `action: pause_for_human`
+    /// or `action: modify_output`.
     pub message: Option<String>,
+    /// Headless-mode behavior for HITL gates (`skip`, `abort`, `use_default`). Defaults to `skip`.
+    pub on_headless: Option<String>,
+    /// Default value used when `on_headless: use_default` and no human is available.
+    pub default_value: Option<String>,
     pub context: Option<ContextDto>,
     pub tools: Option<ToolsDto>,
     pub on_result: Option<Vec<OnResultBranchDto>>,

--- a/ail-core/src/config/validation/mod.rs
+++ b/ail-core/src/config/validation/mod.rs
@@ -181,6 +181,8 @@ mod tests {
             pipeline: None,
             action: None,
             message: None,
+            on_headless: None,
+            default_value: None,
             context: None,
             tools: None,
             on_result: None,
@@ -320,6 +322,8 @@ mod tests {
             pipeline: None,
             action: None,
             message: None,
+            on_headless: None,
+            default_value: None,
             context: None,
             tools: None,
             on_result: None,
@@ -344,6 +348,8 @@ mod tests {
             pipeline: None,
             action: None,
             message: None,
+            on_headless: None,
+            default_value: None,
             context: None,
             tools: None,
             on_result: None,
@@ -371,6 +377,8 @@ mod tests {
             pipeline: None,
             action: None,
             message: None,
+            on_headless: None,
+            default_value: None,
             context: None,
             tools: None,
             on_result: None,
@@ -403,6 +411,8 @@ mod tests {
             skill: None,
             action: None,
             message: None,
+            on_headless: None,
+            default_value: None,
             context: None,
             tools: None,
             on_result: None,
@@ -429,6 +439,8 @@ mod tests {
             skill: None,
             pipeline: None,
             message: Some("Waiting for approval".to_string()),
+            on_headless: None,
+            default_value: None,
             context: None,
             tools: None,
             on_result: None,
@@ -455,6 +467,8 @@ mod tests {
             skill: None,
             pipeline: None,
             message: None,
+            on_headless: None,
+            default_value: None,
             context: None,
             tools: None,
             on_result: None,
@@ -482,6 +496,8 @@ mod tests {
             pipeline: None,
             action: None,
             message: None,
+            on_headless: None,
+            default_value: None,
             tools: None,
             on_result: None,
             model: None,
@@ -508,6 +524,8 @@ mod tests {
             pipeline: None,
             action: None,
             message: None,
+            on_headless: None,
+            default_value: None,
             tools: None,
             on_result: None,
             model: None,
@@ -964,5 +982,90 @@ mod tests {
         let src = PathBuf::from("/custom/path.ail.yaml");
         let pipeline = validate(dto, src.clone()).expect("should succeed");
         assert_eq!(pipeline.source, Some(src));
+    }
+
+    // ── modify_output action ────────────────────────────────────────────────
+
+    #[test]
+    fn action_modify_output_round_trips_with_skip_default() {
+        let mut step = minimal_step("gate", "unused");
+        step.prompt = None;
+        step.action = Some("modify_output".to_string());
+        step.message = Some("Please review".to_string());
+        let dto = minimal_dto(vec![step]);
+        let pipeline = validate(dto, source()).expect("should succeed");
+        assert!(matches!(
+            pipeline.steps[0].body,
+            StepBody::Action(ActionKind::ModifyOutput {
+                headless_behavior: crate::config::domain::HitlHeadlessBehavior::Skip,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn action_modify_output_abort_headless_round_trips() {
+        let mut step = minimal_step("gate", "unused");
+        step.prompt = None;
+        step.action = Some("modify_output".to_string());
+        step.on_headless = Some("abort".to_string());
+        let dto = minimal_dto(vec![step]);
+        let pipeline = validate(dto, source()).expect("should succeed");
+        assert!(matches!(
+            pipeline.steps[0].body,
+            StepBody::Action(ActionKind::ModifyOutput {
+                headless_behavior: crate::config::domain::HitlHeadlessBehavior::Abort,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn action_modify_output_use_default_requires_default_value() {
+        let mut step = minimal_step("gate", "unused");
+        step.prompt = None;
+        step.action = Some("modify_output".to_string());
+        step.on_headless = Some("use_default".to_string());
+        // default_value is None → validation should fail
+        let dto = minimal_dto(vec![step]);
+        let err = validate(dto, source()).expect_err("should fail");
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(err.detail().contains("default_value"));
+    }
+
+    #[test]
+    fn action_modify_output_use_default_with_value_round_trips() {
+        let mut step = minimal_step("gate", "unused");
+        step.prompt = None;
+        step.action = Some("modify_output".to_string());
+        step.on_headless = Some("use_default".to_string());
+        step.default_value = Some("fallback text".to_string());
+        let dto = minimal_dto(vec![step]);
+        let pipeline = validate(dto, source()).expect("should succeed");
+        if let StepBody::Action(ActionKind::ModifyOutput {
+            headless_behavior,
+            default_value,
+        }) = &pipeline.steps[0].body
+        {
+            assert_eq!(
+                *headless_behavior,
+                crate::config::domain::HitlHeadlessBehavior::UseDefault
+            );
+            assert_eq!(default_value.as_deref(), Some("fallback text"));
+        } else {
+            panic!("expected ModifyOutput step body");
+        }
+    }
+
+    #[test]
+    fn action_modify_output_unknown_on_headless_returns_error() {
+        let mut step = minimal_step("gate", "unused");
+        step.prompt = None;
+        step.action = Some("modify_output".to_string());
+        step.on_headless = Some("magic".to_string());
+        let dto = minimal_dto(vec![step]);
+        let err = validate(dto, source()).expect_err("should fail");
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(err.detail().contains("magic"));
     }
 }

--- a/ail-core/src/config/validation/step_body.rs
+++ b/ail-core/src/config/validation/step_body.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::result_large_err)]
 
-use crate::config::domain::{ActionKind, ContextSource, StepBody};
+use crate::config::domain::{ActionKind, ContextSource, HitlHeadlessBehavior, StepBody};
 use crate::config::dto::StepDto;
 use crate::error::AilError;
 
@@ -50,6 +50,30 @@ pub(in crate::config) fn parse_step_body(
     } else if let Some(ref action) = step_dto.action {
         match action.as_str() {
             "pause_for_human" => Ok(StepBody::Action(ActionKind::PauseForHuman)),
+            "modify_output" => {
+                let headless_behavior = match step_dto.on_headless.as_deref() {
+                    None | Some("skip") => HitlHeadlessBehavior::Skip,
+                    Some("abort") => HitlHeadlessBehavior::Abort,
+                    Some("use_default") => {
+                        if step_dto.default_value.is_none() {
+                            return Err(cfg_err!(
+                                "Step '{id_str}' uses on_headless: use_default but no default_value is provided"
+                            ));
+                        }
+                        HitlHeadlessBehavior::UseDefault
+                    }
+                    Some(other) => {
+                        return Err(cfg_err!(
+                            "Step '{id_str}' specifies unknown on_headless value '{other}'; \
+                             supported values are 'skip', 'abort', 'use_default'"
+                        ))
+                    }
+                };
+                Ok(StepBody::Action(ActionKind::ModifyOutput {
+                    headless_behavior,
+                    default_value: step_dto.default_value.clone(),
+                }))
+            }
             other => Err(cfg_err!(
                 "Step '{id_str}' specifies unknown action '{other}'"
             )),

--- a/ail-core/src/executor/controlled.rs
+++ b/ail-core/src/executor/controlled.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::result_large_err)]
 
+use crate::config::domain::HitlHeadlessBehavior;
 use crate::error::AilError;
 use crate::runner::{InvokeOptions, RunResult, Runner, RunnerEvent};
 use crate::session::Session;
@@ -159,6 +160,33 @@ impl<'a> StepObserver for ChannelObserver<'a> {
             response: None,
             model: None,
         });
+    }
+
+    fn handle_modify_output(
+        &mut self,
+        step_id: &str,
+        message: Option<&str>,
+        last_response: Option<&str>,
+        _headless_behavior: &HitlHeadlessBehavior,
+        _default_value: Option<&str>,
+    ) -> Result<Option<String>, AilError> {
+        tracing::info!(step_id = %step_id, "modify_output gate — waiting for HITL response");
+        let _ = self.event_tx.send(ExecutorEvent::HitlModifyReached {
+            step_id: step_id.to_string(),
+            message: message.map(str::to_string),
+            last_response: last_response.map(str::to_string),
+        });
+        let modified = self.hitl_rx.recv().unwrap_or_default();
+        tracing::info!(step_id = %step_id, "modify_output HITL gate unblocked — resuming");
+        let _ = self.event_tx.send(ExecutorEvent::StepCompleted {
+            step_id: step_id.to_string(),
+            cost_usd: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            response: None,
+            model: None,
+        });
+        Ok(Some(modified))
     }
 
     fn on_pipeline_done(&mut self, outcome: &ExecuteOutcome) {
@@ -737,6 +765,124 @@ mod tests {
                 prompt.contains(&run_id),
                 "Expected run_id in resolved_prompt, got: {prompt}"
             );
+        }
+    }
+
+    // ── Test 14: modify_output gate in controlled mode ──────────────────────
+
+    #[test]
+    fn modify_output_sends_hitl_modify_reached_and_stores_modified_text() {
+        use crate::config::domain::{ActionKind, HitlHeadlessBehavior};
+
+        let generate = prompt_step("generate", "Generate content");
+        let gate = Step {
+            id: StepId("review_gate".to_string()),
+            body: StepBody::Action(ActionKind::ModifyOutput {
+                headless_behavior: HitlHeadlessBehavior::Skip,
+                default_value: None,
+            }),
+            message: Some("Review and edit the output".to_string()),
+            tools: None,
+            on_result: None,
+            model: None,
+            runner: None,
+            condition: None,
+            append_system_prompt: None,
+            system_prompt: None,
+            resume: false,
+        };
+
+        let mut session = make_session(vec![generate, gate]);
+        let runner = StubRunner::new("generated content");
+        let control = make_control();
+        let disabled = HashSet::new();
+        let (tx, rx) = mpsc::channel::<ExecutorEvent>();
+        let (hitl_tx, hitl_rx) = mpsc::channel::<String>();
+
+        // Simulate human editing the output.
+        hitl_tx.send("human-edited content".to_string()).unwrap();
+
+        let result =
+            super::execute_with_control(&mut session, &runner, &control, &disabled, tx, hitl_rx);
+
+        assert!(result.is_ok());
+
+        let events = collect_events(rx);
+        // Should have HitlModifyReached event
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                ExecutorEvent::HitlModifyReached { step_id, .. } if step_id == "review_gate"
+            )),
+            "Expected HitlModifyReached event, got: {events:?}"
+        );
+
+        // The modified text should be stored in the turn log.
+        let entries = session.turn_log.entries();
+        assert_eq!(entries.len(), 2); // generate + review_gate
+        assert_eq!(entries[1].step_id, "review_gate");
+        assert_eq!(entries[1].modified.as_deref(), Some("human-edited content"));
+    }
+
+    // ── Test 15: HitlModifyReached event includes last_response ─────────────
+
+    #[test]
+    fn modify_output_event_includes_last_response() {
+        use crate::config::domain::{ActionKind, HitlHeadlessBehavior};
+
+        let generate = prompt_step("gen", "Generate");
+        let gate = Step {
+            id: StepId("gate".to_string()),
+            body: StepBody::Action(ActionKind::ModifyOutput {
+                headless_behavior: HitlHeadlessBehavior::Skip,
+                default_value: None,
+            }),
+            message: Some("Edit this".to_string()),
+            tools: None,
+            on_result: None,
+            model: None,
+            runner: None,
+            condition: None,
+            append_system_prompt: None,
+            system_prompt: None,
+            resume: false,
+        };
+
+        let mut session = make_session(vec![generate, gate]);
+        let runner = StubRunner::new("original output");
+        let control = make_control();
+        let disabled = HashSet::new();
+        let (tx, rx) = mpsc::channel::<ExecutorEvent>();
+        let (hitl_tx, hitl_rx) = mpsc::channel::<String>();
+
+        hitl_tx.send("edited".to_string()).unwrap();
+
+        let result =
+            super::execute_with_control(&mut session, &runner, &control, &disabled, tx, hitl_rx);
+
+        assert!(result.is_ok());
+
+        let events = collect_events(rx);
+        let modify_event = events.iter().find(|e| {
+            matches!(
+                e,
+                ExecutorEvent::HitlModifyReached { step_id, .. } if step_id == "gate"
+            )
+        });
+        assert!(modify_event.is_some(), "Expected HitlModifyReached");
+
+        if let Some(ExecutorEvent::HitlModifyReached {
+            last_response,
+            message,
+            ..
+        }) = modify_event
+        {
+            assert_eq!(
+                last_response.as_deref(),
+                Some("original output"),
+                "last_response should be the previous step's output"
+            );
+            assert_eq!(message.as_deref(), Some("Edit this"));
         }
     }
 }

--- a/ail-core/src/executor/core.rs
+++ b/ail-core/src/executor/core.rs
@@ -10,6 +10,7 @@
 use crate::config::domain::{ActionKind, Condition, ContextSource, ResultAction, StepBody};
 use crate::error::AilError;
 use crate::runner::{InvokeOptions, RunResult, Runner};
+use crate::session::turn_log::TurnEntry;
 use crate::session::Session;
 
 use super::dispatch;
@@ -82,6 +83,18 @@ pub(super) trait StepObserver {
     /// the HITL channel, then emit `StepCompleted`. Headless: no-op (step is skipped, no entry).
     fn handle_pause_for_human(&mut self, step_id: &str, message: Option<&str>);
 
+    /// Handle a `modify_output` HITL gate (SPEC §13.2). Controlled: emit `HitlModifyReached`,
+    /// block on the HITL channel, return the human's modified text. Headless: behavior depends
+    /// on `headless_behavior` (skip/abort/use_default).
+    fn handle_modify_output(
+        &mut self,
+        step_id: &str,
+        message: Option<&str>,
+        last_response: Option<&str>,
+        headless_behavior: &crate::config::domain::HitlHeadlessBehavior,
+        default_value: Option<&str>,
+    ) -> Result<Option<String>, AilError>;
+
     /// Pipeline completed (normal or via `break`). Controlled: emit `PipelineCompleted`.
     /// Headless: no-op.
     fn on_pipeline_done(&mut self, outcome: &ExecuteOutcome);
@@ -136,6 +149,46 @@ impl StepObserver for NullObserver {
 
     fn handle_pause_for_human(&mut self, step_id: &str, _: Option<&str>) {
         tracing::info!(step_id = %step_id, "pause_for_human — no-op in headless mode");
+    }
+
+    fn handle_modify_output(
+        &mut self,
+        step_id: &str,
+        _message: Option<&str>,
+        _last_response: Option<&str>,
+        headless_behavior: &crate::config::domain::HitlHeadlessBehavior,
+        default_value: Option<&str>,
+    ) -> Result<Option<String>, AilError> {
+        use crate::config::domain::HitlHeadlessBehavior;
+        match headless_behavior {
+            HitlHeadlessBehavior::Skip => {
+                tracing::warn!(
+                    step_id = %step_id,
+                    "modify_output gate skipped in headless mode — pipeline continues; \
+                     use controlled mode (--output-format json) for interactive HITL gates"
+                );
+                Ok(None)
+            }
+            HitlHeadlessBehavior::Abort => {
+                tracing::warn!(step_id = %step_id, "modify_output gate fired abort in headless mode");
+                Err(AilError::PipelineAborted {
+                    detail: format!(
+                        "Step '{step_id}' is a modify_output gate with on_headless: abort — \
+                         pipeline cannot continue without human input"
+                    ),
+                    context: None,
+                })
+            }
+            HitlHeadlessBehavior::UseDefault => {
+                let value = default_value.unwrap_or("").to_string();
+                tracing::info!(
+                    step_id = %step_id,
+                    default_len = value.len(),
+                    "modify_output gate using default_value in headless mode"
+                );
+                Ok(Some(value))
+            }
+        }
     }
 
     fn on_pipeline_done(&mut self, _: &ExecuteOutcome) {}
@@ -208,6 +261,31 @@ pub(super) fn execute_core<O: StepObserver>(
             continue;
         }
 
+        // modify_output HITL gate — may produce a TurnEntry with modified text, or skip.
+        if let StepBody::Action(ActionKind::ModifyOutput {
+            ref headless_behavior,
+            ref default_value,
+        }) = &step.body
+        {
+            let last_resp = session.turn_log.last_response().map(|s| s.to_string());
+            let modified = observer.handle_modify_output(
+                &step_id,
+                step.message.as_deref(),
+                last_resp.as_deref(),
+                headless_behavior,
+                default_value.as_deref(),
+            )?;
+            if let Some(modified_text) = modified {
+                let msg = step
+                    .message
+                    .clone()
+                    .unwrap_or_else(|| "modify_output".to_string());
+                let entry = TurnEntry::from_modify(&step_id, msg, modified_text);
+                session.turn_log.append(entry);
+            }
+            continue;
+        }
+
         // Non-Prompt steps emit StepStarted before dispatch; Prompt steps emit after resolution.
         if !matches!(step.body, StepBody::Prompt(_)) {
             observer.on_non_prompt_started(&step_id, step_index, total_steps);
@@ -232,6 +310,10 @@ pub(super) fn execute_core<O: StepObserver>(
 
             StepBody::Action(ActionKind::PauseForHuman) => {
                 unreachable!("PauseForHuman handled above before the match")
+            }
+
+            StepBody::Action(ActionKind::ModifyOutput { .. }) => {
+                unreachable!("ModifyOutput handled above before the match")
             }
 
             StepBody::SubPipeline {

--- a/ail-core/src/executor/dispatch/sub_pipeline.rs
+++ b/ail-core/src/executor/dispatch/sub_pipeline.rs
@@ -141,5 +141,6 @@ pub(in crate::executor) fn execute_sub_pipeline(
         exit_code: None,
         thinking: None,
         tool_events: vec![],
+        modified: None,
     })
 }

--- a/ail-core/src/executor/events.rs
+++ b/ail-core/src/executor/events.rs
@@ -96,6 +96,17 @@ pub enum ExecutorEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         message: Option<String>,
     },
+    /// A `modify_output` HITL gate was reached (SPEC §13.2).
+    /// The executor blocks until `hitl_rx` receives the modified text.
+    HitlModifyReached {
+        step_id: String,
+        /// Optional operator-facing message from the step's `message:` YAML field.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+        /// The last step response presented to the human for modification.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        last_response: Option<String>,
+    },
     /// A streaming event from the runner, nested under `event` so the inner `type` field is
     /// preserved in the NDJSON output. Using a named field avoids the internally-tagged
     /// newtype-of-tagged-enum serialization conflict that would overwrite the inner `type`.

--- a/ail-core/src/executor/headless.rs
+++ b/ail-core/src/executor/headless.rs
@@ -541,4 +541,111 @@ mod tests {
         assert!(matches!(result.unwrap(), ExecuteOutcome::Completed));
         assert_eq!(session.turn_log.entries().len(), 2);
     }
+
+    // ── modify_output HITL gate tests (headless mode, SPEC §13.2) ───────────
+
+    fn modify_step(
+        id: &str,
+        behavior: crate::config::domain::HitlHeadlessBehavior,
+        default_value: Option<&str>,
+    ) -> Step {
+        Step {
+            id: StepId(id.to_string()),
+            body: StepBody::Action(crate::config::domain::ActionKind::ModifyOutput {
+                headless_behavior: behavior,
+                default_value: default_value.map(str::to_string),
+            }),
+            message: Some("Review and edit".to_string()),
+            tools: None,
+            on_result: None,
+            model: None,
+            runner: None,
+            condition: None,
+            append_system_prompt: None,
+            system_prompt: None,
+            resume: false,
+        }
+    }
+
+    /// SPEC §13.2 — modify_output with on_headless: skip is a no-op; pipeline continues.
+    #[test]
+    fn modify_output_skip_is_noop_in_headless_mode() {
+        let gate = modify_step(
+            "gate",
+            crate::config::domain::HitlHeadlessBehavior::Skip,
+            None,
+        );
+        let after = prompt_step("after", "continue");
+        let mut session = make_session(vec![gate, after]);
+        let runner = StubRunner::new("ok");
+        let result = execute(&mut session, &runner);
+
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), ExecuteOutcome::Completed));
+        // Only the prompt step produces an entry; the skipped gate produces no entry.
+        let entries = session.turn_log.entries();
+        assert_eq!(entries.len(), 1, "skipped modify gate produces no entry");
+        assert_eq!(entries[0].step_id, "after");
+    }
+
+    /// SPEC §13.2 — modify_output with on_headless: abort terminates the pipeline.
+    #[test]
+    fn modify_output_abort_terminates_pipeline_in_headless_mode() {
+        let gate = modify_step(
+            "gate",
+            crate::config::domain::HitlHeadlessBehavior::Abort,
+            None,
+        );
+        let after = prompt_step("after", "never reached");
+        let mut session = make_session(vec![gate, after]);
+        let runner = StubRunner::new("ok");
+        let result = execute(&mut session, &runner);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.error_type(), error_types::PIPELINE_ABORTED);
+        assert!(err.detail().contains("gate"));
+    }
+
+    /// SPEC §13.2 — modify_output with on_headless: use_default stores the default value.
+    #[test]
+    fn modify_output_use_default_stores_default_value_in_headless_mode() {
+        let gate = modify_step(
+            "gate",
+            crate::config::domain::HitlHeadlessBehavior::UseDefault,
+            Some("fallback text"),
+        );
+        let after = prompt_step("after", "continue");
+        let mut session = make_session(vec![gate, after]);
+        let runner = StubRunner::new("ok");
+        let result = execute(&mut session, &runner);
+
+        assert!(result.is_ok());
+        let entries = session.turn_log.entries();
+        // Both the modify gate (with entry) and the prompt step produce entries.
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].step_id, "gate");
+        assert_eq!(entries[0].modified.as_deref(), Some("fallback text"));
+        assert_eq!(entries[1].step_id, "after");
+    }
+
+    /// SPEC §13.2 — modified output is available as {{ step.<id>.modified }} template variable.
+    #[test]
+    fn modify_output_use_default_accessible_via_template() {
+        let gate = modify_step(
+            "review_gate",
+            crate::config::domain::HitlHeadlessBehavior::UseDefault,
+            Some("edited content"),
+        );
+        let after = prompt_step("finalize", "Result: {{ step.review_gate.modified }}");
+        let mut session = make_session(vec![gate, after]);
+        let runner = StubRunner::new("ok");
+        let result = execute(&mut session, &runner);
+
+        assert!(result.is_ok());
+        let entries = session.turn_log.entries();
+        assert_eq!(entries.len(), 2);
+        // The finalize step's prompt should contain the resolved modified output.
+        assert_eq!(entries[1].prompt, "Result: edited content");
+    }
 }

--- a/ail-core/src/executor/mod.rs
+++ b/ail-core/src/executor/mod.rs
@@ -208,4 +208,35 @@ mod tests {
         assert_eq!(json["outcome"], "break");
         assert_eq!(json["step_id"], "s1");
     }
+
+    #[test]
+    fn executor_event_serializes_hitl_modify_reached() {
+        let event = ExecutorEvent::HitlModifyReached {
+            step_id: "review_gate".into(),
+            message: Some("Edit the output".into()),
+            last_response: Some("generated text".into()),
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&event).unwrap()).unwrap();
+        assert_eq!(json["type"], "hitl_modify_reached");
+        assert_eq!(json["step_id"], "review_gate");
+        assert_eq!(json["message"], "Edit the output");
+        assert_eq!(json["last_response"], "generated text");
+    }
+
+    #[test]
+    fn executor_event_serializes_hitl_modify_reached_without_optional_fields() {
+        let event = ExecutorEvent::HitlModifyReached {
+            step_id: "gate".into(),
+            message: None,
+            last_response: None,
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&event).unwrap()).unwrap();
+        assert_eq!(json["type"], "hitl_modify_reached");
+        assert_eq!(json["step_id"], "gate");
+        // Optional fields should be absent.
+        assert!(json.get("message").is_none());
+        assert!(json.get("last_response").is_none());
+    }
 }

--- a/ail-core/src/materialize.rs
+++ b/ail-core/src/materialize.rs
@@ -47,6 +47,24 @@ pub fn materialize(pipeline: &Pipeline) -> String {
             StepBody::Action(ActionKind::PauseForHuman) => {
                 out.push_str("    action: pause_for_human\n");
             }
+            StepBody::Action(ActionKind::ModifyOutput {
+                ref headless_behavior,
+                ref default_value,
+            }) => {
+                out.push_str("    action: modify_output\n");
+                match headless_behavior {
+                    crate::config::domain::HitlHeadlessBehavior::Skip => {}
+                    crate::config::domain::HitlHeadlessBehavior::Abort => {
+                        out.push_str("    on_headless: abort\n");
+                    }
+                    crate::config::domain::HitlHeadlessBehavior::UseDefault => {
+                        out.push_str("    on_headless: use_default\n");
+                        if let Some(dv) = default_value {
+                            out.push_str(&format!("    default_value: \"{}\"\n", yaml_quote(dv)));
+                        }
+                    }
+                }
+            }
             StepBody::Context(ContextSource::Shell(cmd)) => {
                 out.push_str(&format!(
                     "    context:\n      shell: \"{}\"\n",

--- a/ail-core/src/session/turn_log.rs
+++ b/ail-core/src/session/turn_log.rs
@@ -31,6 +31,9 @@ pub struct TurnEntry {
     /// Ordered list of tool call and tool result events captured during this step.
     /// Empty for context:shell steps, sub-pipeline steps, and action steps.
     pub tool_events: Vec<ToolEvent>,
+    /// Human-modified output from a HITL `modify_output` gate (SPEC §13.2).
+    /// `None` for steps that are not modify gates or when no modification was made.
+    pub modified: Option<String>,
 }
 
 /// Written as the first entry for a run. Carries pipeline_source and project_hash so the SQLite provider
@@ -70,6 +73,7 @@ impl TurnEntry {
             exit_code: None,
             thinking: result.thinking,
             tool_events: result.tool_events,
+            modified: None,
         }
     }
 
@@ -95,6 +99,31 @@ impl TurnEntry {
             exit_code: Some(exit_code),
             thinking: None,
             tool_events: vec![],
+            modified: None,
+        }
+    }
+
+    /// Construct a TurnEntry for a `modify_output` HITL gate (SPEC §13.2).
+    pub fn from_modify(
+        step_id: impl Into<String>,
+        message: String,
+        modified_output: String,
+    ) -> Self {
+        TurnEntry {
+            step_id: step_id.into(),
+            prompt: message,
+            response: None,
+            timestamp: SystemTime::now(),
+            cost_usd: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            runner_session_id: None,
+            stdout: None,
+            stderr: None,
+            exit_code: None,
+            thinking: None,
+            tool_events: vec![],
+            modified: Some(modified_output),
         }
     }
 }
@@ -290,6 +319,14 @@ impl TurnLog {
             .map(|e| e.tool_events.as_slice())
     }
 
+    /// Human-modified output for a `modify_output` HITL gate step (SPEC §13.2).
+    pub fn modified_for_step(&self, id: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find(|e| e.step_id == id)
+            .and_then(|e| e.modified.as_deref())
+    }
+
     pub fn entries(&self) -> &[TurnEntry] {
         &self.entries
     }
@@ -317,6 +354,7 @@ mod tests {
             exit_code: None,
             thinking: None,
             tool_events: Vec::<ToolEvent>::new(),
+            modified: None,
         }
     }
 

--- a/ail-core/src/template.rs
+++ b/ail-core/src/template.rs
@@ -100,6 +100,15 @@ fn resolve_variable(variable: &str, session: &Session) -> Result<String, AilErro
                             .ok_or_else(|| {
                                 unresolved(format!("No exit_code recorded for step '{step_id}'"))
                             }),
+                        "modified" => session
+                            .turn_log
+                            .modified_for_step(step_id)
+                            .map(|s| s.to_string())
+                            .ok_or_else(|| {
+                                unresolved(format!(
+                                    "No modified output recorded for step '{step_id}'"
+                                ))
+                            }),
                         "tool_calls" => {
                             let events = session
                                 .turn_log

--- a/ail-core/tests/fixtures/modify_output.ail.yaml
+++ b/ail-core/tests/fixtures/modify_output.ail.yaml
@@ -1,0 +1,9 @@
+version: "0.0.1"
+pipeline:
+  - id: generate
+    prompt: "Generate a document"
+  - id: review_gate
+    action: modify_output
+    message: "Review and edit the generated document before continuing."
+  - id: finalize
+    prompt: "Finalize: {{ step.review_gate.modified }}"

--- a/ail-core/tests/spec/s04_execution_model.rs
+++ b/ail-core/tests/spec/s04_execution_model.rs
@@ -76,6 +76,7 @@ mod session {
             exit_code: None,
             thinking: None,
             tool_events: vec![],
+            modified: None,
         }
     }
 

--- a/ail-core/tests/spec/s04_log_provider.rs
+++ b/ail-core/tests/spec/s04_log_provider.rs
@@ -21,6 +21,7 @@ mod log_provider_tests {
             exit_code: None,
             thinking: None,
             tool_events: vec![],
+            modified: None,
         }
     }
 

--- a/ail-core/tests/spec/s09_sub_pipeline.rs
+++ b/ail-core/tests/spec/s09_sub_pipeline.rs
@@ -460,6 +460,7 @@ fn sub_pipeline_step_prompt_override_is_passed_to_child() {
         exit_code: None,
         thinking: None,
         tool_events: vec![],
+        modified: None,
     });
 
     let runner = EchoStubRunner::new();

--- a/ail-core/tests/spec/s11_template_variables.rs
+++ b/ail-core/tests/spec/s11_template_variables.rs
@@ -27,6 +27,7 @@ fn append_response(session: &mut Session, step_id: &str, response: &str) {
         exit_code: None,
         thinking: None,
         tool_events: vec![],
+        modified: None,
     });
 }
 
@@ -45,6 +46,7 @@ fn append_context(session: &mut Session, step_id: &str, stdout: &str, stderr: &s
         exit_code: Some(code),
         thinking: None,
         tool_events: vec![],
+        modified: None,
     });
 }
 
@@ -488,6 +490,7 @@ fn step_tool_calls_serialises_events_as_json() {
         exit_code: None,
         thinking: None,
         tool_events: vec![event],
+        modified: None,
     });
 
     let result = resolve("{{ step.run_check.tool_calls }}", &session).unwrap();
@@ -497,6 +500,43 @@ fn step_tool_calls_serialises_events_as_json() {
     assert_eq!(arr.len(), 1);
     assert_eq!(arr[0]["tool_name"], "Bash");
     assert_eq!(arr[0]["event_type"], "tool_call");
+}
+
+// ── 13. {{ step.<id>.modified }} (SPEC §13.2) ──────────────────────────
+
+#[test]
+fn step_modified_resolves_to_modified_output() {
+    let mut session = make_session();
+    let entry = TurnEntry::from_modify(
+        "review_gate",
+        "Please review".to_string(),
+        "edited text".to_string(),
+    );
+    session.turn_log.append(entry);
+
+    let result = resolve("{{ step.review_gate.modified }}", &session).unwrap();
+    assert_eq!(result, "edited text");
+}
+
+#[test]
+fn step_modified_missing_returns_error() {
+    let session = make_session();
+    let result = resolve("{{ step.no_gate.modified }}", &session);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.error_type(),
+        ail_core::error::error_types::TEMPLATE_UNRESOLVED
+    );
+}
+
+#[test]
+fn step_modified_none_when_not_a_modify_step_returns_error() {
+    let mut session = make_session();
+    // Append a regular prompt entry (modified is None).
+    append_response(&mut session, "regular", "some response");
+    let result = resolve("{{ step.regular.modified }}", &session);
+    assert!(result.is_err());
 }
 
 #[test]

--- a/spec/core/s04-execution-model.md
+++ b/spec/core/s04-execution-model.md
@@ -183,6 +183,7 @@ Every state change is emitted as one of the following variants. In JSON mode, ea
 | `StepSkipped` | `"step_skipped"` | When a step is in the `disabled_steps` set |
 | `StepFailed` | `"step_failed"` | When a step errors (includes `error` string detail) |
 | `HitlGateReached` | `"hitl_gate_reached"` | When a `pause_for_human` step is reached; executor blocks until `hitl_rx` receives a value |
+| `HitlModifyReached` | `"hitl_modify_reached"` | When a `modify_output` step is reached (§13.2); includes `last_response` for the human to edit; blocks until `hitl_rx` receives the modified text |
 | `RunnerEvent` | `"runner_event"` | Wraps a streaming `RunnerEvent` (thinking, stream delta, tool call, etc.) as `"event"` field |
 | `PipelineCompleted` | `"pipeline_completed"` | When all steps complete; `"outcome"` field is `"completed"` or `"break"` |
 | `PipelineError` | `"pipeline_error"` | When the pipeline aborts due to an error; includes `"error"` and `"error_type"` |
@@ -210,6 +211,12 @@ The inner `"event"` object uses the `RunnerEvent` JSON schema (e.g., `"type": "t
 {"type": "hitl_gate_reached", "step_id": "review_gate", "message": "Please review before continuing."}
 ```
 The `"message"` field is omitted when not declared in the step YAML.
+
+**`HitlModifyReached` payload (§13.2):**
+```json
+{"type": "hitl_modify_reached", "step_id": "review_gate", "message": "Edit the output.", "last_response": "Generated document text..."}
+```
+`"message"` and `"last_response"` are omitted when not available. The consumer sends a `hitl_response` message with the edited text to unblock the executor.
 
 #### Function Signature
 

--- a/spec/core/s11-template-variables.md
+++ b/spec/core/s11-template-variables.md
@@ -16,6 +16,7 @@ Prompt strings, file-based prompts, and `pipeline:` paths may reference runtime 
 | `{{ step.<id>.stderr }}` | Standard error of a `shell:` context step. |
 | `{{ step.<id>.exit_code }}` | Exit code of a `shell:` context step, as a string. |
 | `{{ step.<id>.tool_calls }}` | Tool call and result events from a specific named `prompt:` step, serialised as a JSON array. Empty array for context/action/sub-pipeline steps. |
+| `{{ step.<id>.modified }}` | Human-modified output from a `modify_output` HITL gate step (§13.2). Only available for steps with `action: modify_output` that produced a turn entry (i.e., the gate was not skipped). |
 | `{{ session.tool }}` | The runner name resolved for the currently executing step (e.g. `claude`, `ollama`). Reflects per-step `runner:` overrides — updated at the start of each Prompt step. |
 | `{{ session.cwd }}` | The current working directory of the session. |
 | `{{ pipeline.run_id }}` | Unique ID for this pipeline execution. |

--- a/spec/core/s13-hitl-gates.md
+++ b/spec/core/s13-hitl-gates.md
@@ -1,10 +1,12 @@
 ## 13. Human-in-the-Loop (HITL) Gates
 
-> **Implementation status:** Partial. `pause_for_human` action is implemented in `execute_with_control()` (the controlled executor used by TUI and `--output-format json` mode): it blocks execution and emits a `HitlGateReached` event. In simple `execute()` mode (`--once` text output), `pause_for_human` is a no-op. "Allow for session" is implemented in both `--once --output-format json` and `ail chat` (NDJSON) modes via the `allow_for_session` field in the `permission_response` stdin message (§23.7). The allowlist persists for the lifetime of the run/chat session — in chat mode it carries across turns. The "Modify" response for tool permissions is deferred to v0.2.
+> **Implementation status:** `pause_for_human` action is implemented in `execute_with_control()` (the controlled executor used by TUI and `--output-format json` mode): it blocks execution and emits a `HitlGateReached` event. In simple `execute()` mode (`--once` text output), `pause_for_human` is a no-op. `modify_output` action (§13.2) is fully implemented: in controlled mode it emits `HitlModifyReached`, blocks for human input, and stores the modified text; in headless mode behavior is configurable via `on_headless` (skip/abort/use_default). "Allow for session" is implemented in both `--once --output-format json` and `ail chat` (NDJSON) modes via the `allow_for_session` field in the `permission_response` stdin message (§23.7). The allowlist persists for the lifetime of the run/chat session — in chat mode it carries across turns. The "Modify" response for tool permissions is deferred to v0.3.
 
 HITL gates are intentional checkpoints, not error states.
 
-### 13.1 Explicit HITL Step
+### 13.1 Explicit HITL Steps
+
+#### `pause_for_human`
 
 ```yaml
 - id: approve_before_deploy
@@ -13,6 +15,32 @@ HITL gates are intentional checkpoints, not error states.
   timeout_seconds: 3600
   on_timeout: abort_pipeline
 ```
+
+#### `modify_output`
+
+Presents the most recent step output to the human for editing. The human-modified text is stored in the turn log and available to subsequent steps via `{{ step.<id>.modified }}`.
+
+```yaml
+- id: generate
+  prompt: "Generate a document"
+- id: review_gate
+  action: modify_output
+  message: "Review and edit the generated document before continuing."
+  on_headless: skip          # skip | abort | use_default (default: skip)
+  # default_value: "..."     # required when on_headless: use_default
+- id: finalize
+  prompt: "Finalize: {{ step.review_gate.modified }}"
+```
+
+**`on_headless`** controls behavior in headless/`--once` text mode:
+
+| Value | Effect |
+|---|---|
+| `skip` (default) | Gate is skipped; no entry recorded; pipeline continues. |
+| `abort` | Pipeline aborts with `PIPELINE_ABORTED`. |
+| `use_default` | Uses `default_value` as the modified output; entry recorded. |
+
+When `on_headless: use_default` is specified, `default_value` is required — validation rejects the pipeline if it is missing.
 
 ### 13.2 HITL Responses
 
@@ -72,11 +100,16 @@ Preferred over explicit gates — interrupts only when something genuinely requi
 
 For automated runs (CI, the autonomous agent use case, Docker sandbox), HITL prompts are not viable. Pass `--dangerously-skip-permissions` to the Claude CLI invocation to bypass all tool permission checks. This is only appropriate in a fully trusted, sandboxed environment. `ail` will expose this as a session-level flag — not a pipeline YAML option — to prevent it from being accidentally committed to a shared pipeline file.
 
-**`--once --output-format json` mode and `ail chat` (NDJSON) mode:** Full interactive HITL is available. Both the invocation step and all pipeline steps use a `permission_responder` wired to the stdin control protocol (§23.7). Consumers receive `permission_requested` events on stdout and respond via `permission_response` messages on stdin. `pause_for_human` steps and `on_result: pause_for_human` branches both block the executor and emit `hitl_gate_reached` events, unblocked by `hitl_response` messages on stdin. "Allow for session" (`allow_for_session: true`) adds the tool's `display_name` to an in-memory allowlist shared across turns in chat mode; subsequent permission requests for the same tool are auto-approved silently and no `permission_requested` event is emitted for them.
+**`--once --output-format json` mode and `ail chat` (NDJSON) mode:** Full interactive HITL is available. Both the invocation step and all pipeline steps use a `permission_responder` wired to the stdin control protocol (§23.7). Consumers receive `permission_requested` events on stdout and respond via `permission_response` messages on stdin. `pause_for_human` steps and `on_result: pause_for_human` branches both block the executor and emit `hitl_gate_reached` events, unblocked by `hitl_response` messages on stdin. `modify_output` steps emit `hitl_modify_reached` events (which include the `last_response` for the human to edit) and are similarly unblocked by `hitl_response` messages — the response text becomes the modified output. "Allow for session" (`allow_for_session: true`) adds the tool's `display_name` to an in-memory allowlist shared across turns in chat mode; subsequent permission requests for the same tool are auto-approved silently and no `permission_requested` event is emitted for them.
 
 **`--once` text mode:** The `--once --output-format text` flow does not set a `permission_responder` and does not spawn a stdin reader thread. Interactive permission HITL is not available. Tools in text mode require either `--headless` (bypass all permissions) or `tools: allow:` in the pipeline YAML (pre-approve specific tools).
 
 When `pause_for_human` fires in headless / text mode (either as an explicit step or via `on_result: pause_for_human`), the executor emits a `WARN`-level log message identifying the step and any configured message, then **continues the pipeline**. No HITL gate is raised and no input is awaited. This is visible on stderr (as a structured JSON log entry) when the binary's tracing subscriber is active. Use `--output-format json` mode for interactive HITL gates.
+
+When `modify_output` fires in headless / text mode, the behavior depends on the step's `on_headless` field:
+- **`skip`** (default): the gate is skipped with a `WARN`-level log message; no turn entry is recorded; the pipeline continues. The `{{ step.<id>.modified }}` variable will not be available — subsequent steps that reference it will fail with `TEMPLATE_UNRESOLVED`.
+- **`abort`**: the pipeline terminates with a `PIPELINE_ABORTED` error.
+- **`use_default`**: the `default_value` is used as the modified output; a turn entry is recorded; `{{ step.<id>.modified }}` resolves to the default value.
 
 **Interactive questions in Claude's text output:** When the model's response contains a question (e.g., "Do you want option 1, 2, or 3?"), this is the step's completed response — not a HITL event. In `-p` mode (single-turn), there is no follow-up turn within a step. The question text is available to subsequent steps as `{{ step.<id>.response }}`. Pipelines that need human review of model output should use explicit `pause_for_human` gates.
 


### PR DESCRIPTION
## Summary

Implements the HITL `modify_output` action (issue #113, SPEC §13.2) — a human-in-the-loop gate that presents step output for editing before the pipeline continues.

- **`action: modify_output`** step type with configurable headless behavior
- **`HitlHeadlessBehavior`** enum: `skip` (log and continue), `abort` (pipeline aborted), `use_default` (use provided default value)
- **Controlled mode**: emits `HitlModifyReached` event with `last_response`, blocks on `hitl_rx` for human input
- **Headless mode**: respects `on_headless` setting — skip/abort/use_default
- **`{{ step.<id>.modified }}`** template variable for accessing modified output in subsequent steps
- **Turn log**: `modified: Option<String>` field on `TurnEntry`, `from_modify()` constructor, `modified_for_step()` accessor

**Spec correction:** Previous spec stated "The 'Modify' response for tool permissions is deferred to v0.2." — `modify_output` step action is now implemented; tool permission modification remains deferred (now v0.3).

## Test plan

- [x] 5 validation tests (round-trip for skip/abort/use_default, error cases)
- [x] 4 headless executor tests (skip no-op, abort terminates, use_default stores value, template access)
- [x] 2 controlled executor tests (event emission, modified text storage)
- [x] 3 template variable tests (`{{ step.<id>.modified }}` resolution and error cases)
- [x] 2 event serialization tests
- [x] 1 test fixture (`modify_output.ail.yaml`)
- [x] `cargo build` clean
- [x] `cargo nextest run` — all tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #113

https://claude.ai/code/session_01Q2f8ZpmyjywfKhbmGcxSRW