### PR TITLE
feat: add do_while types and parse-time validation (§27)

### DIFF
--- a/ail-core/src/config/domain.rs
+++ b/ail-core/src/config/domain.rs
@@ -16,6 +16,10 @@ pub enum SystemPromptEntry {
 /// when pipelines call each other in a cycle.
 pub const MAX_SUB_PIPELINE_DEPTH: usize = 16;
 
+/// Maximum nesting depth for loop constructs (`do_while`, `for_each`).
+/// Prevents runaway resource consumption from deeply nested loops (SPEC §27).
+pub const MAX_LOOP_DEPTH: usize = 8;
+
 /// Provider and model configuration resolved from pipeline defaults, per-step overrides,
 /// or CLI flags. All fields are optional — unset fields fall back to runner/environment defaults.
 #[derive(Debug, Clone, Default)]
@@ -245,6 +249,17 @@ pub enum StepBody {
     // in validation. If the value does not match a named pipeline key, it remains
     // as `SubPipeline` (file-based sub-pipeline reference).
     Context(ContextSource),
+    /// Bounded repeat-until loop (SPEC §27). Inner steps execute repeatedly until
+    /// `exit_when` evaluates to true or `max_iterations` is reached.
+    DoWhile {
+        /// Maximum number of iterations (≥ 1, required, no default).
+        max_iterations: u64,
+        /// Condition expression evaluated after each complete iteration.
+        /// Uses the same expression syntax as `condition:` (SPEC §12.2).
+        exit_when: ConditionExpr,
+        /// Inner steps executed each iteration.
+        steps: Vec<Step>,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/ail-core/src/config/dto.rs
+++ b/ail-core/src/config/dto.rs
@@ -90,8 +90,8 @@ pub struct StepDto {
     // ── Reserved v0.3 fields ─────────────────────────────────────────────────
     // Accepted by serde so users get a clear validation error instead of
     // "unknown field". Rejected at validation time until implemented.
-    /// Reserved: bounded repeat-until loop (SPEC §27). Rejected at validation time.
-    pub do_while: Option<serde_json::Value>,
+    /// Bounded repeat-until loop (SPEC §27).
+    pub do_while: Option<DoWhileDto>,
     /// Reserved: collection iteration (SPEC §28). Rejected at validation time.
     pub for_each: Option<serde_json::Value>,
     /// Reserved: JSON Schema for step output validation (SPEC §26). Rejected at validation time.
@@ -116,6 +116,17 @@ pub enum ChainStepDto {
 #[derive(Debug, Default, Deserialize)]
 pub struct ContextDto {
     pub shell: Option<String>,
+}
+
+/// DTO for `do_while:` bounded repeat-until loop (SPEC §27).
+#[derive(Debug, Default, Deserialize)]
+pub struct DoWhileDto {
+    /// Maximum number of iterations (required, must be ≥ 1).
+    pub max_iterations: Option<u64>,
+    /// Condition expression evaluated after each iteration; loop exits when true.
+    pub exit_when: Option<String>,
+    /// Inner steps executed each iteration.
+    pub steps: Option<Vec<StepDto>>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/ail-core/src/config/validation/mod.rs
+++ b/ail-core/src/config/validation/mod.rs
@@ -46,7 +46,10 @@ fn tools_to_policy(t: ToolsDto) -> ToolPolicy {
 ///   `"{{ step.test.exit_code }} == 0"`
 ///   `"{{ step.review.response }} contains 'LGTM'"`
 ///   `"{{ step.build.exit_code }} != 0"`
-fn parse_condition_expression(raw: &str, step_id: &str) -> Result<Condition, AilError> {
+pub(in crate::config) fn parse_condition_expression(
+    raw: &str,
+    step_id: &str,
+) -> Result<Condition, AilError> {
     // Operator tokens in order of specificity (multi-word first to avoid partial matches).
     let operators: &[(&str, ConditionOp)] = &[
         ("starts_with", ConditionOp::StartsWith),
@@ -166,11 +169,14 @@ fn strip_quotes(s: &str) -> &str {
 /// Validate a list of step DTOs into domain `Step`s.
 /// `context_label` is used in error messages to indicate where these steps come from
 /// (e.g. "pipeline" or "named pipeline 'security_gates'").
-fn validate_steps(step_dtos: Vec<StepDto>, context_label: &str) -> Result<Vec<Step>, AilError> {
+pub(in crate::config) fn validate_steps(
+    step_dtos: Vec<StepDto>,
+    context_label: &str,
+) -> Result<Vec<Step>, AilError> {
     let mut seen_ids: HashSet<String> = HashSet::new();
     let mut steps: Vec<Step> = Vec::with_capacity(step_dtos.len());
 
-    for step_dto in step_dtos {
+    for mut step_dto in step_dtos {
         // Reject leftover hook operation fields — these are consumed during FROM
         // inheritance resolution and should never reach validation. If they do,
         // the pipeline either lacks FROM or the merge logic has a bug.
@@ -215,7 +221,7 @@ fn validate_steps(step_dtos: Vec<StepDto>, context_label: &str) -> Result<Vec<St
             ));
         }
 
-        let body = step_body::parse_step_body(&step_dto, &id_str)?;
+        let body = step_body::parse_step_body(&mut step_dto, &id_str)?;
 
         let on_result = step_dto
             .on_result
@@ -416,8 +422,8 @@ fn parse_chain_step(
                 then: vec![],
             })
         }
-        ChainStepDto::Full(step_dto) => {
-            let body = step_body::parse_step_body(&step_dto, &auto_id)?;
+        ChainStepDto::Full(mut step_dto) => {
+            let body = step_body::parse_step_body(&mut step_dto, &auto_id)?;
 
             let on_result_branches = step_dto
                 .on_result

--- a/ail-core/src/config/validation/step_body.rs
+++ b/ail-core/src/config/validation/step_body.rs
@@ -6,16 +6,19 @@ use crate::config::domain::{ActionKind, ContextSource, HitlHeadlessBehavior, Ste
 use crate::config::dto::StepDto;
 use crate::error::AilError;
 
-use super::cfg_err;
+use super::{cfg_err, parse_condition_expression, validate_steps};
 
 /// Parse the step body from a DTO, enforcing exactly one primary field.
+///
+/// Takes `&mut StepDto` because composite step bodies (e.g. `do_while:`) need to
+/// take ownership of nested step lists via `.take()` — cloning is not possible
+/// since `StepDto` does not derive `Clone`.
 pub(in crate::config) fn parse_step_body(
-    step_dto: &StepDto,
+    step_dto: &mut StepDto,
     id_str: &str,
 ) -> Result<StepBody, AilError> {
     // Reject reserved v0.3 fields that are accepted by serde but not yet implemented.
     for (field_name, is_set) in [
-        ("do_while", step_dto.do_while.is_some()),
         ("for_each", step_dto.for_each.is_some()),
         ("output_schema", step_dto.output_schema.is_some()),
         ("input_schema", step_dto.input_schema.is_some()),
@@ -36,6 +39,7 @@ pub(in crate::config) fn parse_step_body(
         step_dto.pipeline.is_some(),
         step_dto.action.is_some(),
         step_dto.context.is_some(),
+        step_dto.do_while.is_some(),
     ]
     .iter()
     .filter(|&&b| b)
@@ -44,7 +48,7 @@ pub(in crate::config) fn parse_step_body(
     if primary_count != 1 {
         return Err(cfg_err!(
             "Step '{id_str}' must have exactly one primary field \
-             (prompt, skill, pipeline, action, or context); found {primary_count}"
+             (prompt, skill, pipeline, action, context, or do_while); found {primary_count}"
         ));
     }
 
@@ -104,7 +108,76 @@ pub(in crate::config) fn parse_step_body(
                 "Step '{id_str}' declares context: but no source (shell:, mcp:) is present"
             )),
         }
+    } else if step_dto.do_while.is_some() {
+        parse_do_while_body(step_dto.do_while.take().unwrap(), id_str)
     } else {
         unreachable!("primary_count == 1 enforced above")
     }
+}
+
+/// Parse a `do_while:` step body, validating all required fields (SPEC §27).
+///
+/// Takes ownership of the `DoWhileDto` because the inner `steps` list
+/// is passed by value to `validate_steps`.
+fn parse_do_while_body(
+    dw: crate::config::dto::DoWhileDto,
+    id_str: &str,
+) -> Result<StepBody, AilError> {
+    let max_iterations = dw.max_iterations.ok_or_else(|| {
+        cfg_err!(
+            "Step '{id_str}' declares do_while: but 'max_iterations' is missing; \
+             max_iterations is required to prevent unbounded loops (SPEC §27)"
+        )
+    })?;
+
+    if max_iterations < 1 {
+        return Err(cfg_err!(
+            "Step '{id_str}' specifies do_while.max_iterations: 0; \
+             max_iterations must be at least 1"
+        ));
+    }
+
+    let exit_when_raw = dw.exit_when.as_deref().ok_or_else(|| {
+        cfg_err!(
+            "Step '{id_str}' declares do_while: but 'exit_when' is missing; \
+             exit_when is required (SPEC §27)"
+        )
+    })?;
+
+    // Reuse the condition expression parser from §12.2.
+    let exit_when_condition = parse_condition_expression(exit_when_raw, id_str)?;
+    // parse_condition_expression returns Condition::Expression for valid expressions.
+    // Extract the inner ConditionExpr.
+    let exit_when = match exit_when_condition {
+        crate::config::domain::Condition::Expression(expr) => expr,
+        _ => {
+            return Err(cfg_err!(
+                "Step '{id_str}' do_while.exit_when must be a condition expression \
+                 (e.g. '{{{{ step.<id>.exit_code }}}} == 0'), not 'always' or 'never'"
+            ))
+        }
+    };
+
+    let step_dtos = dw.steps.ok_or_else(|| {
+        cfg_err!(
+            "Step '{id_str}' declares do_while: but 'steps' is missing; \
+             at least one inner step is required (SPEC §27)"
+        )
+    })?;
+
+    if step_dtos.is_empty() {
+        return Err(cfg_err!(
+            "Step '{id_str}' declares do_while: with an empty 'steps' array; \
+             at least one inner step is required (SPEC §27)"
+        ));
+    }
+
+    let context_label = format!("do_while step '{id_str}'");
+    let inner_steps = validate_steps(step_dtos, &context_label)?;
+
+    Ok(StepBody::DoWhile {
+        max_iterations,
+        exit_when,
+        steps: inner_steps,
+    })
 }

--- a/ail-core/src/executor/core.rs
+++ b/ail-core/src/executor/core.rs
@@ -358,6 +358,16 @@ fn execute_single_step<O: StepObserver>(
                 pipeline_base_dir,
                 observer,
             ),
+
+            StepBody::DoWhile { .. } => {
+                return Err(AilError::ConfigValidationFailed {
+                    detail: format!(
+                        "Step '{step_id}' uses do_while: which is parsed but executor \
+                         support is not yet implemented"
+                    ),
+                    context: None,
+                });
+            }
         };
 
         match result {

--- a/ail-core/src/materialize.rs
+++ b/ail-core/src/materialize.rs
@@ -1,11 +1,23 @@
 use crate::config::domain::{
-    ActionKind, ContextSource, ExitCodeMatch, OnError, Pipeline, ResultAction, ResultMatcher, Step,
-    StepBody,
+    ActionKind, ConditionExpr, ConditionOp, ContextSource, ExitCodeMatch, OnError, Pipeline,
+    ResultAction, ResultMatcher, Step, StepBody,
 };
 
 /// Escape a string for use inside a YAML double-quoted scalar.
 fn yaml_quote(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Format a `ConditionExpr` back to its string representation.
+fn format_condition_expr(expr: &ConditionExpr) -> String {
+    let op_str = match expr.op {
+        ConditionOp::Eq => "==",
+        ConditionOp::Ne => "!=",
+        ConditionOp::Contains => "contains",
+        ConditionOp::StartsWith => "starts_with",
+        ConditionOp::EndsWith => "ends_with",
+    };
+    format!("{} {} {}", expr.lhs, op_str, expr.rhs)
 }
 
 /// One-line summary of a chain step body for materialize comments.
@@ -26,6 +38,16 @@ fn chain_step_summary(body: &StepBody) -> String {
         StepBody::Action(ActionKind::ModifyOutput { .. }) => "action: modify_output".to_string(),
         StepBody::Context(ContextSource::Shell(cmd)) => {
             format!("context: shell: \"{}\"", yaml_quote(cmd))
+        }
+        StepBody::DoWhile {
+            max_iterations,
+            steps,
+            ..
+        } => {
+            format!(
+                "do_while: (max_iterations: {max_iterations}, {} inner steps)",
+                steps.len()
+            )
         }
     }
 }
@@ -123,6 +145,22 @@ pub fn materialize(pipeline: &Pipeline) -> String {
                     "    context:\n      shell: \"{}\"\n",
                     yaml_quote(cmd)
                 ));
+            }
+            StepBody::DoWhile {
+                max_iterations,
+                ref exit_when,
+                ref steps,
+            } => {
+                out.push_str("    do_while:\n");
+                out.push_str(&format!("      max_iterations: {max_iterations}\n"));
+                out.push_str(&format!(
+                    "      exit_when: \"{}\"\n",
+                    yaml_quote(&format_condition_expr(exit_when))
+                ));
+                out.push_str("      steps:\n");
+                for inner in steps {
+                    serialize_step(&mut out, inner, "        ", None);
+                }
             }
         }
 
@@ -243,6 +281,25 @@ fn serialize_step(out: &mut String, step: &Step, indent: &str, origin_comment: O
                 "{field_indent}context:\n{field_indent}  shell: \"{}\"\n",
                 yaml_quote(cmd)
             ));
+        }
+        StepBody::DoWhile {
+            max_iterations,
+            ref exit_when,
+            ref steps,
+        } => {
+            out.push_str(&format!("{field_indent}do_while:\n"));
+            out.push_str(&format!(
+                "{field_indent}  max_iterations: {max_iterations}\n"
+            ));
+            out.push_str(&format!(
+                "{field_indent}  exit_when: \"{}\"\n",
+                yaml_quote(&format_condition_expr(exit_when))
+            ));
+            out.push_str(&format!("{field_indent}  steps:\n"));
+            let inner_indent = format!("{field_indent}    ");
+            for inner in steps {
+                serialize_step(out, inner, &inner_indent, None);
+            }
         }
     }
 

--- a/ail-core/tests/spec/s27_do_while.rs
+++ b/ail-core/tests/spec/s27_do_while.rs
@@ -1,13 +1,12 @@
-/// SPEC §27 — do_while is a reserved field rejected at parse time
-/// until implementation is complete.
+/// SPEC §27 — do_while: bounded repeat-until loop validation tests.
 
-mod reserved_field_rejection {
+mod parse_valid {
     use ail_core::config;
-    use ail_core::error::error_types;
+    use ail_core::config::domain::{ConditionOp, StepBody};
 
-    /// §27 — do_while is rejected with a clear "reserved" error.
+    /// §27 — valid do_while config parses successfully.
     #[test]
-    fn do_while_rejected_as_reserved() {
+    fn valid_do_while_parses() {
         let yaml = r#"
 version: "0.1"
 pipeline:
@@ -18,23 +17,374 @@ pipeline:
       steps:
         - id: check
           context:
+            shell: "cargo test"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let pipeline = config::load(tmp.path()).unwrap();
+        assert_eq!(pipeline.steps.len(), 1);
+        match &pipeline.steps[0].body {
+            StepBody::DoWhile {
+                max_iterations,
+                exit_when,
+                steps,
+            } => {
+                assert_eq!(*max_iterations, 5);
+                assert_eq!(exit_when.op, ConditionOp::Eq);
+                assert!(exit_when.lhs.contains("step.check.exit_code"));
+                assert_eq!(exit_when.rhs, "0");
+                assert_eq!(steps.len(), 1);
+                assert_eq!(steps[0].id.as_str(), "check");
+            }
+            other => panic!("Expected DoWhile, got {other:?}"),
+        }
+    }
+
+    /// §27 — do_while with max_iterations: 1 is valid (minimum).
+    #[test]
+    fn max_iterations_one_is_valid() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: once_loop
+    do_while:
+      max_iterations: 1
+      exit_when: "{{ step.check.exit_code }} == 0"
+      steps:
+        - id: check
+          context:
+            shell: "echo done"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let pipeline = config::load(tmp.path()).unwrap();
+        match &pipeline.steps[0].body {
+            StepBody::DoWhile { max_iterations, .. } => assert_eq!(*max_iterations, 1),
+            other => panic!("Expected DoWhile, got {other:?}"),
+        }
+    }
+
+    /// §27 — do_while with multiple inner steps parses.
+    #[test]
+    fn multiple_inner_steps_parse() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: multi_loop
+    do_while:
+      max_iterations: 3
+      exit_when: "{{ step.verify.exit_code }} == 0"
+      steps:
+        - id: fix
+          prompt: "Fix the issue"
+        - id: verify
+          context:
+            shell: "cargo test"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let pipeline = config::load(tmp.path()).unwrap();
+        match &pipeline.steps[0].body {
+            StepBody::DoWhile { steps, .. } => {
+                assert_eq!(steps.len(), 2);
+                assert_eq!(steps[0].id.as_str(), "fix");
+                assert_eq!(steps[1].id.as_str(), "verify");
+            }
+            other => panic!("Expected DoWhile, got {other:?}"),
+        }
+    }
+
+    /// §27 — do_while with word-based exit_when operator.
+    #[test]
+    fn exit_when_contains_operator() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: check_loop
+    do_while:
+      max_iterations: 10
+      exit_when: "{{ step.review.response }} contains LGTM"
+      steps:
+        - id: review
+          prompt: "Review the code"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let pipeline = config::load(tmp.path()).unwrap();
+        match &pipeline.steps[0].body {
+            StepBody::DoWhile { exit_when, .. } => {
+                assert_eq!(exit_when.op, ConditionOp::Contains);
+                assert_eq!(exit_when.rhs, "LGTM");
+            }
+            other => panic!("Expected DoWhile, got {other:?}"),
+        }
+    }
+}
+
+mod parse_invalid {
+    use ail_core::config;
+    use ail_core::error::error_types;
+
+    /// §27 — missing max_iterations is rejected.
+    #[test]
+    fn missing_max_iterations_rejected() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: bad_loop
+    do_while:
+      exit_when: "{{ step.check.exit_code }} == 0"
+      steps:
+        - id: check
+          context:
             shell: "echo ok"
 "#;
         let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
         std::fs::write(tmp.path(), yaml).unwrap();
-        let result = config::load(tmp.path());
-        assert!(result.is_err(), "do_while must be rejected");
-        let err = result.unwrap_err();
+        let err = config::load(tmp.path()).unwrap_err();
         assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
         assert!(
-            err.detail().contains("do_while"),
-            "Error should mention the field name, got: {}",
+            err.detail().contains("max_iterations"),
+            "Expected error about max_iterations, got: {}",
             err.detail()
         );
+    }
+
+    /// §27 — max_iterations: 0 is rejected.
+    #[test]
+    fn zero_max_iterations_rejected() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: bad_loop
+    do_while:
+      max_iterations: 0
+      exit_when: "{{ step.check.exit_code }} == 0"
+      steps:
+        - id: check
+          context:
+            shell: "echo ok"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
         assert!(
-            err.detail().contains("reserved"),
-            "Error should mention 'reserved', got: {}",
+            err.detail().contains("max_iterations"),
+            "Expected error about max_iterations, got: {}",
             err.detail()
+        );
+    }
+
+    /// §27 — missing exit_when is rejected.
+    #[test]
+    fn missing_exit_when_rejected() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: bad_loop
+    do_while:
+      max_iterations: 5
+      steps:
+        - id: check
+          context:
+            shell: "echo ok"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("exit_when"),
+            "Expected error about exit_when, got: {}",
+            err.detail()
+        );
+    }
+
+    /// §27 — missing steps is rejected.
+    #[test]
+    fn missing_steps_rejected() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: bad_loop
+    do_while:
+      max_iterations: 5
+      exit_when: "{{ step.check.exit_code }} == 0"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("steps"),
+            "Expected error about steps, got: {}",
+            err.detail()
+        );
+    }
+
+    /// §27 — empty steps array is rejected.
+    #[test]
+    fn empty_steps_rejected() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: bad_loop
+    do_while:
+      max_iterations: 5
+      exit_when: "{{ step.check.exit_code }} == 0"
+      steps: []
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("steps"),
+            "Expected error about steps, got: {}",
+            err.detail()
+        );
+    }
+
+    /// §27 — do_while + prompt on same step is primary field conflict.
+    #[test]
+    fn do_while_plus_prompt_rejected() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: conflict
+    prompt: "hello"
+    do_while:
+      max_iterations: 5
+      exit_when: "{{ step.check.exit_code }} == 0"
+      steps:
+        - id: check
+          context:
+            shell: "echo ok"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("primary field"),
+            "Expected primary field conflict error, got: {}",
+            err.detail()
+        );
+    }
+
+    /// §27 — exit_when with invalid expression syntax is rejected.
+    #[test]
+    fn invalid_exit_when_expression_rejected() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: bad_loop
+    do_while:
+      max_iterations: 5
+      exit_when: "not a valid expression"
+      steps:
+        - id: check
+          context:
+            shell: "echo ok"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+    }
+
+    /// §27 — duplicate inner step IDs are rejected.
+    #[test]
+    fn duplicate_inner_step_ids_rejected() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: dup_loop
+    do_while:
+      max_iterations: 3
+      exit_when: "{{ step.check.exit_code }} == 0"
+      steps:
+        - id: check
+          context:
+            shell: "echo ok"
+        - id: check
+          prompt: "duplicate"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("check"),
+            "Expected error about duplicate id 'check', got: {}",
+            err.detail()
+        );
+    }
+
+    /// §27 — inner step missing id is rejected.
+    #[test]
+    fn inner_step_missing_id_rejected() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: no_id_loop
+    do_while:
+      max_iterations: 3
+      exit_when: "{{ step.check.exit_code }} == 0"
+      steps:
+        - prompt: "no id here"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("id"),
+            "Expected error about missing id, got: {}",
+            err.detail()
+        );
+    }
+}
+
+mod materialize {
+    use ail_core::config;
+    use ail_core::materialize::materialize;
+
+    /// §27 — do_while steps appear in materialize output.
+    #[test]
+    fn do_while_appears_in_materialize() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: retry_loop
+    do_while:
+      max_iterations: 5
+      exit_when: "{{ step.check.exit_code }} == 0"
+      steps:
+        - id: check
+          context:
+            shell: "cargo test"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let pipeline = config::load(tmp.path()).unwrap();
+        let output = materialize(&pipeline);
+        assert!(
+            output.contains("do_while:"),
+            "do_while: missing from materialize output"
+        );
+        assert!(
+            output.contains("max_iterations: 5"),
+            "max_iterations missing"
+        );
+        assert!(output.contains("exit_when:"), "exit_when missing");
+        assert!(output.contains("check"), "inner step id missing");
+        // Verify output is valid YAML.
+        let result: Result<serde_yaml::Value, _> = serde_yaml::from_str(&output);
+        assert!(
+            result.is_ok(),
+            "Materialize output is not valid YAML: {output}"
         );
     }
 }

--- a/ail/src/dry_run.rs
+++ b/ail/src/dry_run.rs
@@ -59,6 +59,7 @@ pub fn run_dry_run(session: &mut ail_core::session::Session, runner: &dyn Runner
             ail_core::config::domain::StepBody::Context(
                 ail_core::config::domain::ContextSource::Shell(_),
             ) => "context:shell",
+            ail_core::config::domain::StepBody::DoWhile { .. } => "do_while",
         };
 
         let condition_note = match &step.condition {
@@ -116,6 +117,17 @@ pub fn run_dry_run(session: &mut ail_core::session::Session, runner: &dyn Runner
                 if let Some(p) = p {
                     println!("  Prompt override: {}", truncate(p, 200));
                 }
+            }
+            ail_core::config::domain::StepBody::DoWhile {
+                max_iterations,
+                steps,
+                ..
+            } => {
+                println!(
+                    "  do_while: max_iterations={max_iterations}, {} inner steps",
+                    steps.len()
+                );
+                println!("  (executor support not yet implemented)");
             }
         }
 


### PR DESCRIPTION
## Summary

- Add `DoWhileDto` to the DTO layer and `StepBody::DoWhile` to the domain layer (§27)
- Full parse-time validation: `max_iterations` ≥ 1 required, `exit_when` must be a valid condition expression (reuses §12.2 parser), `steps` must be non-empty, primary field exclusivity enforced
- Inner steps recursively validated via existing `validate_steps()`
- Materialize output renders `do_while:` blocks with inner steps
- Executor returns clear "not yet implemented" error — loop execution deferred to PR 3
- Dry-run mode recognizes the new step type
- `MAX_LOOP_DEPTH = 8` constant added for future nesting enforcement

## Test plan

- [x] Valid do_while config parses with correct max_iterations, exit_when expression, and inner steps
- [x] max_iterations: 1 (minimum) is accepted
- [x] Multiple inner steps parse correctly
- [x] Word-based exit_when operators (contains, starts_with, etc.) work
- [x] Missing max_iterations rejected
- [x] max_iterations: 0 rejected
- [x] Missing exit_when rejected
- [x] Invalid exit_when expression rejected
- [x] Missing steps rejected
- [x] Empty steps array rejected
- [x] do_while + prompt on same step rejected (primary field conflict)
- [x] Duplicate inner step IDs rejected
- [x] Inner step missing id rejected
- [x] Materialize output contains do_while block and is valid YAML
- [x] All 382+ existing tests still pass, 0 regressions

https://claude.ai/code/session_01PaaBU3rHSK6Vf8VpPTQYAH