### PR TITLE
feat: do_while executor, template variables, and spec updates (§27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,9 +145,10 @@ If nothing found → passthrough mode (safe zero-config default).
 | `{{ session.tool }}` | Runner name (e.g. `claude`) |
 | `{{ session.cwd }}` | Working directory |
 | `{{ env.<VAR> }}` | Environment variable |
-| `{{ do_while.iteration }}` | Current 1-based iteration number (only inside `do_while:` body) |
+| `{{ do_while.iteration }}` | Current 0-based iteration index (only inside `do_while:` body) |
 | `{{ do_while.max_iterations }}` | Declared `max_iterations` value (only inside `do_while:` body) |
 | `{{ step.<loop_id>::<step_id>.* }}` | Qualified reference to a do_while inner step from outside the loop |
+| `{{ step.<loop_id>.iterations_completed }}` | Number of iterations completed by a do_while loop (after loop exits) |
 
 Note: `{{ session.invocation_prompt }}` is a supported alias for `{{ step.invocation.prompt }}` in the implementation but is deprecated — prefer the canonical form.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,9 @@ If nothing found → passthrough mode (safe zero-config default).
 | `{{ session.tool }}` | Runner name (e.g. `claude`) |
 | `{{ session.cwd }}` | Working directory |
 | `{{ env.<VAR> }}` | Environment variable |
+| `{{ do_while.iteration }}` | Current 1-based iteration number (only inside `do_while:` body) |
+| `{{ do_while.max_iterations }}` | Declared `max_iterations` value (only inside `do_while:` body) |
+| `{{ step.<loop_id>::<step_id>.* }}` | Qualified reference to a do_while inner step from outside the loop |
 
 Note: `{{ session.invocation_prompt }}` is a supported alias for `{{ step.invocation.prompt }}` in the implementation but is deprecated — prefer the canonical form.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,8 @@ If nothing found → passthrough mode (safe zero-config default).
 | `{{ do_while.iteration }}` | Current 0-based iteration index (only inside `do_while:` body) |
 | `{{ do_while.max_iterations }}` | Declared `max_iterations` value (only inside `do_while:` body) |
 | `{{ step.<loop_id>::<step_id>.* }}` | Qualified reference to a do_while inner step from outside the loop |
-| `{{ step.<loop_id>.iterations_completed }}` | Number of iterations completed by a do_while loop (after loop exits) |
+| `{{ step.<loop_id>.index }}` | Number of iterations completed by a do_while loop (after loop exits) |
+| `{{ step.<loop_id>::do_while[N].<step_id>.* }}` | Indexed iteration access — specific iteration's inner step (not yet implemented) |
 
 Note: `{{ session.invocation_prompt }}` is a supported alias for `{{ step.invocation.prompt }}` in the implementation but is deprecated — prefer the canonical form.
 

--- a/ail-core/CLAUDE.md
+++ b/ail-core/CLAUDE.md
@@ -18,7 +18,7 @@ Consumed by `ail` (the binary) and future language-server / SDK targets.
 | `config/mod.rs` | `load(path)` public entry point |
 | `error.rs` | `AilError`, `ErrorContext`, `error_types` string constants |
 | `executor/mod.rs` | `execute(&mut Session, &dyn Runner)` — SPEC §4.2 core invariant |
-| `executor/core.rs` | `StepObserver` trait, `NullObserver`, `execute_core()` — shared step-dispatch loop |
+| `executor/core.rs` | `StepObserver` trait, `NullObserver`, `execute_core()`, `execute_do_while()` — shared step-dispatch loop + do_while loop execution (SPEC §27) |
 | `executor/headless.rs` | `execute()` — headless mode entry point using `NullObserver` |
 | `executor/controlled.rs` | `execute_with_control()` — TUI-controlled mode with `ChannelObserver` |
 | `executor/events.rs` | `ExecuteOutcome`, `ExecutionControl`, `ExecutorEvent` |
@@ -145,12 +145,16 @@ pub type HttpSessionStore = Arc<Mutex<HashMap<String, Vec<ChatMessage>>>>;
 pub enum ExecuteOutcome { Completed, Break { step_id: String } }
 
 // Session
-pub struct Session { pub run_id: String, pub pipeline: Pipeline, pub invocation_prompt: String, pub turn_log: TurnLog, pub cli_provider: ProviderConfig, pub cwd: String, pub runner_name: String, pub headless: bool, pub http_session_store: HttpSessionStore }
+pub struct Session { pub run_id: String, pub pipeline: Pipeline, pub invocation_prompt: String, pub turn_log: TurnLog, pub cli_provider: ProviderConfig, pub cwd: String, pub runner_name: String, pub headless: bool, pub http_session_store: HttpSessionStore, pub do_while_context: Option<DoWhileContext>, pub loop_depth: usize }
 // cwd: captured at Session::new() time via std::env::current_dir(); used by {{ session.cwd }} template variable.
+// do_while_context: set during do_while loop body execution, enables {{ do_while.iteration }} and {{ do_while.max_iterations }} template variables
+// loop_depth: current nesting depth of do_while loops, checked against MAX_LOOP_DEPTH (8)
 // Note: the "Allow for session" tool allowlist (SPEC §13.2, §13.4) lives in the `ail` binary crate
 // (control_bridge::AllowlistArc), not on Session — session allowlisting is a binary-layer concern.
 // TurnEntry carries prompt-step fields (response, runner_session_id, thinking, tool_events) and context-step fields (stdout, stderr, exit_code)
 // tool_events: Vec<ToolEvent> — populated from RunResult.tool_events for prompt steps; empty for context/action/sub-pipeline steps
+pub struct DoWhileContext { pub loop_id: String, pub iteration: u64, pub max_iterations: u64 }
+// DoWhileContext: active loop context — set during do_while body execution, cleared after loop exits (SPEC §27)
 
 // Error
 pub struct AilError { pub error_type: &'static str, pub title: &'static str, pub detail: String, pub context: Option<ErrorContext> }

--- a/ail-core/src/executor/core.rs
+++ b/ail-core/src/executor/core.rs
@@ -7,11 +7,14 @@
 
 #![allow(clippy::result_large_err)]
 
-use crate::config::domain::{ActionKind, ContextSource, OnError, ResultAction, Step, StepBody};
+use crate::config::domain::{
+    ActionKind, Condition, ConditionExpr, ContextSource, OnError, ResultAction, Step, StepBody,
+    StepId, MAX_LOOP_DEPTH,
+};
 use crate::error::AilError;
 use crate::runner::{InvokeOptions, RunResult, Runner};
 use crate::session::turn_log::TurnEntry;
-use crate::session::Session;
+use crate::session::{DoWhileContext, Session};
 
 use super::dispatch;
 use super::events::ExecuteOutcome;
@@ -359,15 +362,20 @@ fn execute_single_step<O: StepObserver>(
                 observer,
             ),
 
-            StepBody::DoWhile { .. } => {
-                return Err(AilError::ConfigValidationFailed {
-                    detail: format!(
-                        "Step '{step_id}' uses do_while: which is parsed but executor \
-                         support is not yet implemented"
-                    ),
-                    context: None,
-                });
-            }
+            StepBody::DoWhile {
+                max_iterations,
+                exit_when,
+                steps: inner_steps,
+            } => execute_do_while(
+                &step_id,
+                *max_iterations,
+                exit_when,
+                inner_steps,
+                session,
+                runner,
+                observer,
+                depth,
+            ),
         };
 
         match result {
@@ -508,6 +516,325 @@ fn execute_chain_steps<O: StepObserver>(
         // "Use top-level steps if branching is needed."
     }
     Ok(())
+}
+
+// ── do_while execution (SPEC §27) ────────────────────────────────────────────
+
+/// Exit reason for a do_while loop, used for logging and result reporting.
+enum DoWhileExitReason {
+    /// `exit_when` evaluated to true.
+    ExitWhen,
+    /// A `break` action fired inside the loop body.
+    Break,
+    /// The iteration budget was exhausted.
+    MaxIterations,
+}
+
+/// Execute a `do_while:` loop body (SPEC §27).
+///
+/// Runs `inner_steps` repeatedly until `exit_when` evaluates to true or
+/// `max_iterations` is reached. Each iteration executes all inner steps in
+/// order; the `exit_when` condition is checked after each complete iteration
+/// (post-iteration evaluation, like a do-while loop).
+///
+/// Inner step IDs are namespaced as `<loop_id>::<step_id>` so they don't
+/// collide with outer step IDs. The do_while context is set on the session
+/// so template variables `{{ do_while.iteration }}` and
+/// `{{ do_while.max_iterations }}` resolve correctly.
+///
+/// Returns a summary `TurnEntry` for the do_while step itself. The response
+/// is the last inner step's response from the final iteration.
+#[allow(clippy::too_many_arguments)]
+fn execute_do_while<O: StepObserver>(
+    loop_step_id: &str,
+    max_iterations: u64,
+    exit_when: &ConditionExpr,
+    inner_steps: &[Step],
+    session: &mut Session,
+    runner: &dyn Runner,
+    observer: &mut O,
+    depth: usize,
+) -> Result<TurnEntry, AilError> {
+    // Depth guard (SPEC §27.9).
+    if session.loop_depth >= MAX_LOOP_DEPTH {
+        return Err(AilError::LoopDepthExceeded {
+            detail: format!(
+                "Step '{loop_step_id}' would exceed the maximum loop nesting depth \
+                 of {MAX_LOOP_DEPTH}"
+            ),
+            context: Some(crate::error::ErrorContext::for_step(
+                &session.run_id,
+                loop_step_id,
+            )),
+        });
+    }
+
+    session.turn_log.record_step_started(
+        loop_step_id,
+        &format!("do_while(max_iterations={max_iterations})"),
+    );
+
+    let result = execute_do_while_inner(
+        loop_step_id,
+        max_iterations,
+        exit_when,
+        inner_steps,
+        session,
+        runner,
+        observer,
+        depth,
+    );
+
+    match &result {
+        Ok(_) => observer.on_non_prompt_completed(loop_step_id),
+        Err(e) => observer.on_step_failed(loop_step_id, e.detail()),
+    }
+    result
+}
+
+/// Inner loop logic, separated so the caller can attach observer hooks around it.
+#[allow(clippy::too_many_arguments)]
+fn execute_do_while_inner<O: StepObserver>(
+    loop_step_id: &str,
+    max_iterations: u64,
+    exit_when: &ConditionExpr,
+    inner_steps: &[Step],
+    session: &mut Session,
+    runner: &dyn Runner,
+    observer: &mut O,
+    depth: usize,
+) -> Result<TurnEntry, AilError> {
+    // Save and restore outer do_while context for nested loops.
+    let prev_context = session.do_while_context.take();
+    session.loop_depth += 1;
+
+    let prefix = format!("{loop_step_id}::");
+    let total_inner = inner_steps.len();
+    let mut iterations_used: u64 = 0;
+    let mut exit_reason = DoWhileExitReason::MaxIterations;
+
+    for iteration in 1..=max_iterations {
+        iterations_used = iteration;
+
+        // Clear previous iteration's inner step entries (SPEC §27.3 — iteration scope).
+        session.turn_log.remove_entries_with_prefix(&prefix);
+
+        // Set loop context for template variable resolution.
+        session.do_while_context = Some(DoWhileContext {
+            loop_id: loop_step_id.to_string(),
+            iteration,
+            max_iterations,
+        });
+
+        tracing::info!(
+            run_id = %session.run_id,
+            step_id = %loop_step_id,
+            iteration,
+            max_iterations,
+            "do_while iteration started"
+        );
+
+        // Execute each inner step with a namespaced ID.
+        let mut loop_broken = false;
+        for (inner_idx, inner_step) in inner_steps.iter().enumerate() {
+            let namespaced_id = format!("{}{}", prefix, inner_step.id.as_str());
+            let namespaced_step = Step {
+                id: StepId(namespaced_id.clone()),
+                body: inner_step.body.clone(),
+                message: inner_step.message.clone(),
+                tools: inner_step.tools.clone(),
+                on_result: inner_step.on_result.clone(),
+                model: inner_step.model.clone(),
+                runner: inner_step.runner.clone(),
+                condition: inner_step.condition.clone(),
+                append_system_prompt: inner_step.append_system_prompt.clone(),
+                system_prompt: inner_step.system_prompt.clone(),
+                resume: inner_step.resume,
+                on_error: inner_step.on_error.clone(),
+                before: inner_step.before.clone(),
+                then: inner_step.then.clone(),
+            };
+
+            // Evaluate condition for the inner step.
+            let condition_skip = if let Some(ref cond) = namespaced_step.condition {
+                !evaluate_condition(cond, session, &namespaced_id)?
+            } else {
+                false
+            };
+
+            match observer.before_step(&namespaced_id, inner_idx, condition_skip) {
+                BeforeStepAction::Run => {}
+                BeforeStepAction::Skip => continue,
+                BeforeStepAction::Stop => {
+                    loop_broken = true;
+                    break;
+                }
+            }
+
+            tracing::info!(
+                run_id = %session.run_id,
+                step_id = %namespaced_id,
+                iteration,
+                "executing do_while inner step"
+            );
+
+            let matched_action = execute_single_step(
+                &namespaced_step,
+                session,
+                runner,
+                observer,
+                depth,
+                total_inner,
+                inner_idx,
+            )?;
+
+            // Handle on_result actions within the loop (SPEC §27.3 point 5).
+            // `break` exits the loop, not the pipeline.
+            if let Some(action) = matched_action {
+                match action {
+                    ResultAction::Continue => {}
+                    ResultAction::Break => {
+                        tracing::info!(
+                            run_id = %session.run_id,
+                            step_id = %loop_step_id,
+                            inner_step = %namespaced_id,
+                            iteration,
+                            "on_result break inside do_while — exiting loop"
+                        );
+                        loop_broken = true;
+                        break;
+                    }
+                    ResultAction::AbortPipeline => {
+                        // Restore state before propagating.
+                        session.loop_depth -= 1;
+                        session.do_while_context = prev_context;
+                        let err = AilError::PipelineAborted {
+                            detail: format!(
+                                "Step '{namespaced_id}' on_result fired abort_pipeline \
+                                 inside do_while loop '{loop_step_id}'"
+                            ),
+                            context: Some(crate::error::ErrorContext::for_step(
+                                &session.run_id,
+                                loop_step_id,
+                            )),
+                        };
+                        observer.on_pipeline_error(&err);
+                        return Err(err);
+                    }
+                    ResultAction::PauseForHuman => {
+                        observer.on_result_pause(&namespaced_id, None);
+                    }
+                    ResultAction::Pipeline {
+                        ref path,
+                        ref prompt,
+                    } => {
+                        let pipeline_base_dir_buf: Option<std::path::PathBuf> = session
+                            .pipeline
+                            .source
+                            .as_deref()
+                            .and_then(|p| p.parent())
+                            .map(|p| p.to_path_buf());
+                        let pipeline_base_dir = pipeline_base_dir_buf.as_deref();
+                        let on_result_step_id = format!("{namespaced_id}__on_result");
+                        let sub_entry = dispatch::sub_pipeline::execute_sub_pipeline(
+                            path,
+                            prompt.as_deref(),
+                            &on_result_step_id,
+                            session,
+                            runner,
+                            depth,
+                            pipeline_base_dir,
+                        )
+                        .inspect_err(|e| {
+                            // Restore state before propagating.
+                            observer.on_pipeline_error(e)
+                        })?;
+                        session.turn_log.append(sub_entry);
+                    }
+                }
+            }
+        }
+
+        if loop_broken {
+            exit_reason = DoWhileExitReason::Break;
+            break;
+        }
+
+        // Post-iteration: evaluate exit_when (SPEC §27.3 point 1).
+        let exit_condition = Condition::Expression(exit_when.clone());
+        let should_exit = evaluate_condition(&exit_condition, session, loop_step_id)?;
+
+        tracing::info!(
+            run_id = %session.run_id,
+            step_id = %loop_step_id,
+            iteration,
+            exit_when_result = should_exit,
+            "do_while exit_when evaluated"
+        );
+
+        if should_exit {
+            exit_reason = DoWhileExitReason::ExitWhen;
+            break;
+        }
+    }
+
+    // Restore state.
+    session.loop_depth -= 1;
+    session.do_while_context = prev_context;
+
+    tracing::info!(
+        run_id = %session.run_id,
+        step_id = %loop_step_id,
+        iterations_used,
+        exit_reason = match exit_reason {
+            DoWhileExitReason::ExitWhen => "exit_when",
+            DoWhileExitReason::Break => "break",
+            DoWhileExitReason::MaxIterations => "max_iterations",
+        },
+        "do_while completed"
+    );
+
+    // If max_iterations was exhausted without exit_when becoming true, abort (default).
+    if matches!(exit_reason, DoWhileExitReason::MaxIterations) {
+        return Err(AilError::DoWhileMaxIterations {
+            detail: format!(
+                "Step '{loop_step_id}' exhausted do_while.max_iterations ({max_iterations}) \
+                 without exit_when becoming true"
+            ),
+            context: Some(crate::error::ErrorContext::for_step(
+                &session.run_id,
+                loop_step_id,
+            )),
+        });
+    }
+
+    // Build summary TurnEntry. Response is the last inner step's response from
+    // the final iteration.
+    let response = session
+        .turn_log
+        .entries()
+        .iter()
+        .rev()
+        .filter(|e| e.step_id.starts_with(&prefix))
+        .find_map(|e| e.response.as_deref())
+        .map(|s| s.to_string());
+
+    Ok(TurnEntry {
+        step_id: loop_step_id.to_string(),
+        prompt: format!("do_while(max_iterations={max_iterations})"),
+        response,
+        timestamp: std::time::SystemTime::now(),
+        cost_usd: None,
+        input_tokens: 0,
+        output_tokens: 0,
+        runner_session_id: None,
+        stdout: None,
+        stderr: None,
+        exit_code: None,
+        thinking: None,
+        tool_events: vec![],
+        modified: None,
+    })
 }
 
 // ── Core loop ─────────────────────────────────────────────────────────────────

--- a/ail-core/src/executor/core.rs
+++ b/ail-core/src/executor/core.rs
@@ -610,12 +610,10 @@ fn execute_do_while_inner<O: StepObserver>(
 
     let prefix = format!("{loop_step_id}::");
     let total_inner = inner_steps.len();
-    let mut iterations_used: u64 = 0;
+    let mut iterations_completed: u64 = 0;
     let mut exit_reason = DoWhileExitReason::MaxIterations;
 
-    for iteration in 1..=max_iterations {
-        iterations_used = iteration;
-
+    for iteration in 0..max_iterations {
         // Clear previous iteration's inner step entries (SPEC §27.3 — iteration scope).
         session.turn_log.remove_entries_with_prefix(&prefix);
 
@@ -755,6 +753,9 @@ fn execute_do_while_inner<O: StepObserver>(
             }
         }
 
+        // Inner steps completed — count this iteration.
+        iterations_completed += 1;
+
         if loop_broken {
             exit_reason = DoWhileExitReason::Break;
             break;
@@ -785,7 +786,7 @@ fn execute_do_while_inner<O: StepObserver>(
     tracing::info!(
         run_id = %session.run_id,
         step_id = %loop_step_id,
-        iterations_used,
+        iterations_completed,
         exit_reason = match exit_reason {
             DoWhileExitReason::ExitWhen => "exit_when",
             DoWhileExitReason::Break => "break",
@@ -834,6 +835,7 @@ fn execute_do_while_inner<O: StepObserver>(
         thinking: None,
         tool_events: vec![],
         modified: None,
+        iterations_completed: Some(iterations_completed),
     })
 }
 

--- a/ail-core/src/executor/core.rs
+++ b/ail-core/src/executor/core.rs
@@ -610,7 +610,7 @@ fn execute_do_while_inner<O: StepObserver>(
 
     let prefix = format!("{loop_step_id}::");
     let total_inner = inner_steps.len();
-    let mut iterations_completed: u64 = 0;
+    let mut index: u64 = 0;
     let mut exit_reason = DoWhileExitReason::MaxIterations;
 
     for iteration in 0..max_iterations {
@@ -754,7 +754,7 @@ fn execute_do_while_inner<O: StepObserver>(
         }
 
         // Inner steps completed — count this iteration.
-        iterations_completed += 1;
+        index += 1;
 
         if loop_broken {
             exit_reason = DoWhileExitReason::Break;
@@ -786,7 +786,7 @@ fn execute_do_while_inner<O: StepObserver>(
     tracing::info!(
         run_id = %session.run_id,
         step_id = %loop_step_id,
-        iterations_completed,
+        index,
         exit_reason = match exit_reason {
             DoWhileExitReason::ExitWhen => "exit_when",
             DoWhileExitReason::Break => "break",
@@ -835,7 +835,7 @@ fn execute_do_while_inner<O: StepObserver>(
         thinking: None,
         tool_events: vec![],
         modified: None,
-        iterations_completed: Some(iterations_completed),
+        index: Some(index),
     })
 }
 

--- a/ail-core/src/executor/dispatch/sub_pipeline.rs
+++ b/ail-core/src/executor/dispatch/sub_pipeline.rs
@@ -144,7 +144,7 @@ pub(in crate::executor) fn execute_sub_pipeline(
         thinking: None,
         tool_events: vec![],
         modified: None,
-        iterations_completed: None,
+        index: None,
     })
 }
 
@@ -304,6 +304,6 @@ pub(in crate::executor) fn execute_named_pipeline(
         thinking: None,
         tool_events: vec![],
         modified: None,
-        iterations_completed: None,
+        index: None,
     })
 }

--- a/ail-core/src/executor/dispatch/sub_pipeline.rs
+++ b/ail-core/src/executor/dispatch/sub_pipeline.rs
@@ -144,6 +144,7 @@ pub(in crate::executor) fn execute_sub_pipeline(
         thinking: None,
         tool_events: vec![],
         modified: None,
+        iterations_completed: None,
     })
 }
 
@@ -303,5 +304,6 @@ pub(in crate::executor) fn execute_named_pipeline(
         thinking: None,
         tool_events: vec![],
         modified: None,
+        iterations_completed: None,
     })
 }

--- a/ail-core/src/executor/helpers/condition.rs
+++ b/ail-core/src/executor/helpers/condition.rs
@@ -104,7 +104,7 @@ mod tests {
             thinking: None,
             tool_events: vec![],
             modified: None,
-            iterations_completed: None,
+            index: None,
         });
         session
     }
@@ -126,7 +126,7 @@ mod tests {
             thinking: None,
             tool_events: vec![],
             modified: None,
-            iterations_completed: None,
+            index: None,
         });
         session
     }

--- a/ail-core/src/executor/helpers/condition.rs
+++ b/ail-core/src/executor/helpers/condition.rs
@@ -104,6 +104,7 @@ mod tests {
             thinking: None,
             tool_events: vec![],
             modified: None,
+            iterations_completed: None,
         });
         session
     }
@@ -125,6 +126,7 @@ mod tests {
             thinking: None,
             tool_events: vec![],
             modified: None,
+            iterations_completed: None,
         });
         session
     }

--- a/ail-core/src/session/mod.rs
+++ b/ail-core/src/session/mod.rs
@@ -7,5 +7,5 @@ pub use log_provider::{
     cwd_hash, project_dir, CompositeProvider, JsonlProvider, LogProvider, NullProvider,
 };
 pub use sqlite_provider::SqliteProvider;
-pub use state::Session;
+pub use state::{DoWhileContext, Session};
 pub use turn_log::{TurnEntry, TurnLog};

--- a/ail-core/src/session/state.rs
+++ b/ail-core/src/session/state.rs
@@ -17,7 +17,7 @@ use super::turn_log::TurnLog;
 pub struct DoWhileContext {
     /// The do_while step's ID (used as the `<loop_id>::` namespace prefix).
     pub loop_id: String,
-    /// Current 1-based iteration number.
+    /// Current 0-based iteration index.
     pub iteration: u64,
     /// The declared `max_iterations` value.
     pub max_iterations: u64,

--- a/ail-core/src/session/state.rs
+++ b/ail-core/src/session/state.rs
@@ -10,6 +10,19 @@ use super::log_provider::{CompositeProvider, JsonlProvider, LogProvider};
 use super::sqlite_provider::SqliteProvider;
 use super::turn_log::TurnLog;
 
+/// Active do_while loop context, set during loop body execution.
+/// Enables `{{ do_while.iteration }}` and `{{ do_while.max_iterations }}` template
+/// variables, and provides the scope prefix for namespaced step ID resolution.
+#[derive(Debug, Clone)]
+pub struct DoWhileContext {
+    /// The do_while step's ID (used as the `<loop_id>::` namespace prefix).
+    pub loop_id: String,
+    /// Current 1-based iteration number.
+    pub iteration: u64,
+    /// The declared `max_iterations` value.
+    pub max_iterations: u64,
+}
+
 pub struct Session {
     pub run_id: String,
     pub pipeline: Pipeline,
@@ -30,6 +43,13 @@ pub struct Session {
     /// Shared HTTP runner session store — all HttpRunner instances in this pipeline run
     /// share the same in-memory conversation map.
     pub http_session_store: HttpSessionStore,
+    /// Active do_while loop context (SPEC §27). Set during loop body execution,
+    /// cleared after the loop exits. Enables `{{ do_while.* }}` template variables
+    /// and namespaced step ID resolution.
+    pub do_while_context: Option<DoWhileContext>,
+    /// Current nesting depth of do_while loops. Checked against `MAX_LOOP_DEPTH`
+    /// to prevent runaway resource consumption from deeply nested loops.
+    pub loop_depth: usize,
 }
 
 impl Session {
@@ -72,6 +92,8 @@ impl Session {
             runner_name,
             headless: false,
             http_session_store: Arc::new(Mutex::new(HashMap::new())),
+            do_while_context: None,
+            loop_depth: 0,
         }
     }
 

--- a/ail-core/src/session/turn_log.rs
+++ b/ail-core/src/session/turn_log.rs
@@ -34,6 +34,11 @@ pub struct TurnEntry {
     /// Human-modified output from a HITL `modify_output` gate (SPEC §13.2).
     /// `None` for steps that are not modify gates or when no modification was made.
     pub modified: Option<String>,
+    /// Number of iterations completed by a `do_while:` loop step (SPEC §27).
+    /// `None` for non-loop steps. 0-based count: a loop that exits after running
+    /// its body once has `iterations_completed: Some(1)`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterations_completed: Option<u64>,
 }
 
 /// Written as the first entry for a run. Carries pipeline_source and project_hash so the SQLite provider
@@ -93,6 +98,7 @@ impl TurnEntry {
             thinking: result.thinking,
             tool_events: result.tool_events,
             modified: None,
+            iterations_completed: None,
         }
     }
 
@@ -119,6 +125,7 @@ impl TurnEntry {
             thinking: None,
             tool_events: vec![],
             modified: None,
+            iterations_completed: None,
         }
     }
 
@@ -143,6 +150,7 @@ impl TurnEntry {
             thinking: None,
             tool_events: vec![],
             modified: Some(modified_output),
+            iterations_completed: None,
         }
     }
 }
@@ -388,6 +396,15 @@ impl TurnLog {
             .and_then(|e| e.modified.as_deref())
     }
 
+    /// Number of iterations completed by a `do_while:` loop step (SPEC §27).
+    /// Returns `None` for non-loop steps or if no entry exists.
+    pub fn iterations_completed_for_step(&self, id: &str) -> Option<u64> {
+        self.entries
+            .iter()
+            .find(|e| e.step_id == id)
+            .and_then(|e| e.iterations_completed)
+    }
+
     /// Remove in-memory entries whose `step_id` starts with `prefix`.
     ///
     /// Used by `do_while:` execution to clear the previous iteration's inner step
@@ -426,6 +443,7 @@ mod tests {
             thinking: None,
             tool_events: Vec::<ToolEvent>::new(),
             modified: None,
+            iterations_completed: None,
         }
     }
 

--- a/ail-core/src/session/turn_log.rs
+++ b/ail-core/src/session/turn_log.rs
@@ -36,9 +36,9 @@ pub struct TurnEntry {
     pub modified: Option<String>,
     /// Number of iterations completed by a `do_while:` loop step (SPEC §27).
     /// `None` for non-loop steps. 0-based count: a loop that exits after running
-    /// its body once has `iterations_completed: Some(1)`.
+    /// its body once has `index: Some(1)`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub iterations_completed: Option<u64>,
+    pub index: Option<u64>,
 }
 
 /// Written as the first entry for a run. Carries pipeline_source and project_hash so the SQLite provider
@@ -98,7 +98,7 @@ impl TurnEntry {
             thinking: result.thinking,
             tool_events: result.tool_events,
             modified: None,
-            iterations_completed: None,
+            index: None,
         }
     }
 
@@ -125,7 +125,7 @@ impl TurnEntry {
             thinking: None,
             tool_events: vec![],
             modified: None,
-            iterations_completed: None,
+            index: None,
         }
     }
 
@@ -150,7 +150,7 @@ impl TurnEntry {
             thinking: None,
             tool_events: vec![],
             modified: Some(modified_output),
-            iterations_completed: None,
+            index: None,
         }
     }
 }
@@ -398,11 +398,11 @@ impl TurnLog {
 
     /// Number of iterations completed by a `do_while:` loop step (SPEC §27).
     /// Returns `None` for non-loop steps or if no entry exists.
-    pub fn iterations_completed_for_step(&self, id: &str) -> Option<u64> {
+    pub fn index_for_step(&self, id: &str) -> Option<u64> {
         self.entries
             .iter()
             .find(|e| e.step_id == id)
-            .and_then(|e| e.iterations_completed)
+            .and_then(|e| e.index)
     }
 
     /// Remove in-memory entries whose `step_id` starts with `prefix`.
@@ -443,7 +443,7 @@ mod tests {
             thinking: None,
             tool_events: Vec::<ToolEvent>::new(),
             modified: None,
-            iterations_completed: None,
+            index: None,
         }
     }
 

--- a/ail-core/src/session/turn_log.rs
+++ b/ail-core/src/session/turn_log.rs
@@ -388,6 +388,16 @@ impl TurnLog {
             .and_then(|e| e.modified.as_deref())
     }
 
+    /// Remove in-memory entries whose `step_id` starts with `prefix`.
+    ///
+    /// Used by `do_while:` execution to clear the previous iteration's inner step
+    /// results before starting a new iteration (SPEC §27.3 — iteration scope).
+    /// Already-persisted entries are unaffected; this only affects template variable
+    /// resolution which reads from the in-memory store.
+    pub fn remove_entries_with_prefix(&mut self, prefix: &str) {
+        self.entries.retain(|e| !e.step_id.starts_with(prefix));
+    }
+
     pub fn entries(&self) -> &[TurnEntry] {
         &self.entries
     }

--- a/ail-core/src/template.rs
+++ b/ail-core/src/template.rs
@@ -164,6 +164,16 @@ fn resolve_step_field(
             .modified_for_step(step_id)
             .map(|s| s.to_string())
             .ok_or_else(|| unresolved(format!("No modified output recorded for step '{step_id}'"))),
+        "iterations_completed" => session
+            .turn_log
+            .iterations_completed_for_step(step_id)
+            .map(|n| n.to_string())
+            .ok_or_else(|| {
+                unresolved(format!(
+                    "No iterations_completed recorded for step '{step_id}' \
+                     (only available on do_while: steps)"
+                ))
+            }),
         "tool_calls" => {
             let events = session
                 .turn_log

--- a/ail-core/src/template.rs
+++ b/ail-core/src/template.rs
@@ -62,70 +62,52 @@ fn resolve_variable(variable: &str, session: &Session) -> Result<String, AilErro
 
         "pipeline.run_id" => Ok(session.run_id.clone()),
 
+        "do_while.iteration" => session
+            .do_while_context
+            .as_ref()
+            .map(|ctx| ctx.iteration.to_string())
+            .ok_or_else(|| {
+                unresolved("'{{ do_while.iteration }}' is only available inside a do_while: body")
+            }),
+
+        "do_while.max_iterations" => session
+            .do_while_context
+            .as_ref()
+            .map(|ctx| ctx.max_iterations.to_string())
+            .ok_or_else(|| {
+                unresolved(
+                    "'{{ do_while.max_iterations }}' is only available inside a do_while: body",
+                )
+            }),
+
         other => {
             // `step.<id>.<field>` — split on last dot to get step_id and field.
             if let Some(rest) = other.strip_prefix("step.") {
                 if let Some(dot) = rest.rfind('.') {
                     let step_id = &rest[..dot];
                     let field = &rest[dot + 1..];
-                    return match field {
-                        "response" => session
-                            .turn_log
-                            .response_for_step(step_id)
-                            .map(|s| s.to_string())
-                            .ok_or_else(|| {
-                                unresolved(format!("No response recorded for step '{step_id}'"))
-                            }),
-                        "result" => session.turn_log.result_for_step(step_id).ok_or_else(|| {
-                            unresolved(format!("No result recorded for step '{step_id}'"))
-                        }),
-                        "stdout" => session
-                            .turn_log
-                            .stdout_for_step(step_id)
-                            .map(|s| s.to_string())
-                            .ok_or_else(|| {
-                                unresolved(format!("No stdout recorded for step '{step_id}'"))
-                            }),
-                        "stderr" => session
-                            .turn_log
-                            .stderr_for_step(step_id)
-                            .map(|s| s.to_string())
-                            .ok_or_else(|| {
-                                unresolved(format!("No stderr recorded for step '{step_id}'"))
-                            }),
-                        "exit_code" => session
-                            .turn_log
-                            .exit_code_for_step(step_id)
-                            .map(|c| c.to_string())
-                            .ok_or_else(|| {
-                                unresolved(format!("No exit_code recorded for step '{step_id}'"))
-                            }),
-                        "modified" => session
-                            .turn_log
-                            .modified_for_step(step_id)
-                            .map(|s| s.to_string())
-                            .ok_or_else(|| {
-                                unresolved(format!(
-                                    "No modified output recorded for step '{step_id}'"
-                                ))
-                            }),
-                        "tool_calls" => {
-                            let events = session
-                                .turn_log
-                                .tool_events_for_step(step_id)
-                                .ok_or_else(|| {
-                                    unresolved(format!("No entry recorded for step '{step_id}'"))
-                                })?;
-                            serde_json::to_string(events).map_err(|e| {
-                                unresolved(format!(
-                                    "Failed to serialize tool_calls for step '{step_id}': {e}"
-                                ))
-                            })
+
+                    // Try the exact step_id first. If it fails and we're inside a
+                    // do_while body, retry with the namespaced form (loop_id::step_id)
+                    // so that shorthand references like `step.check.exit_code` resolve
+                    // to the current iteration's namespaced entry (SPEC §27.3).
+                    let result = resolve_step_field(session, step_id, field, variable);
+                    if result.is_ok() {
+                        return result;
+                    }
+                    if let Some(ref ctx) = session.do_while_context {
+                        // Only try namespacing if step_id doesn't already contain `::`
+                        if !step_id.contains("::") {
+                            let namespaced = format!("{}::{}", ctx.loop_id, step_id);
+                            let ns_result =
+                                resolve_step_field(session, &namespaced, field, variable);
+                            if ns_result.is_ok() {
+                                return ns_result;
+                            }
                         }
-                        _ => Err(unresolved(format!(
-                            "'{{ {variable} }}' is not a recognised template variable"
-                        ))),
-                    };
+                    }
+                    // Return the original error.
+                    return result;
                 }
             }
 
@@ -139,5 +121,62 @@ fn resolve_variable(variable: &str, session: &Session) -> Result<String, AilErro
                 "'{{ {other} }}' is not a recognised template variable"
             )))
         }
+    }
+}
+
+/// Resolve a single step field lookup against the turn log.
+///
+/// Extracted so both the plain step_id and the do_while-namespaced form can
+/// reuse the same resolution logic without duplication.
+fn resolve_step_field(
+    session: &Session,
+    step_id: &str,
+    field: &str,
+    variable: &str,
+) -> Result<String, AilError> {
+    match field {
+        "response" => session
+            .turn_log
+            .response_for_step(step_id)
+            .map(|s| s.to_string())
+            .ok_or_else(|| unresolved(format!("No response recorded for step '{step_id}'"))),
+        "result" => session
+            .turn_log
+            .result_for_step(step_id)
+            .ok_or_else(|| unresolved(format!("No result recorded for step '{step_id}'"))),
+        "stdout" => session
+            .turn_log
+            .stdout_for_step(step_id)
+            .map(|s| s.to_string())
+            .ok_or_else(|| unresolved(format!("No stdout recorded for step '{step_id}'"))),
+        "stderr" => session
+            .turn_log
+            .stderr_for_step(step_id)
+            .map(|s| s.to_string())
+            .ok_or_else(|| unresolved(format!("No stderr recorded for step '{step_id}'"))),
+        "exit_code" => session
+            .turn_log
+            .exit_code_for_step(step_id)
+            .map(|c| c.to_string())
+            .ok_or_else(|| unresolved(format!("No exit_code recorded for step '{step_id}'"))),
+        "modified" => session
+            .turn_log
+            .modified_for_step(step_id)
+            .map(|s| s.to_string())
+            .ok_or_else(|| unresolved(format!("No modified output recorded for step '{step_id}'"))),
+        "tool_calls" => {
+            let events = session
+                .turn_log
+                .tool_events_for_step(step_id)
+                .ok_or_else(|| unresolved(format!("No entry recorded for step '{step_id}'")))?;
+            serde_json::to_string(events).map_err(|e| {
+                unresolved(format!(
+                    "Failed to serialize tool_calls for step '{step_id}': {e}"
+                ))
+            })
+        }
+        _ => Err(unresolved(format!(
+            "'{{ {variable} }}' is not a recognised template variable"
+        ))),
     }
 }

--- a/ail-core/src/template.rs
+++ b/ail-core/src/template.rs
@@ -164,13 +164,13 @@ fn resolve_step_field(
             .modified_for_step(step_id)
             .map(|s| s.to_string())
             .ok_or_else(|| unresolved(format!("No modified output recorded for step '{step_id}'"))),
-        "iterations_completed" => session
+        "index" => session
             .turn_log
-            .iterations_completed_for_step(step_id)
+            .index_for_step(step_id)
             .map(|n| n.to_string())
             .ok_or_else(|| {
                 unresolved(format!(
-                    "No iterations_completed recorded for step '{step_id}' \
+                    "No index recorded for step '{step_id}' \
                      (only available on do_while: steps)"
                 ))
             }),

--- a/ail-core/tests/spec/s04_execution_model.rs
+++ b/ail-core/tests/spec/s04_execution_model.rs
@@ -78,7 +78,7 @@ mod session {
             thinking: None,
             tool_events: vec![],
             modified: None,
-            iterations_completed: None,
+            index: None,
         }
     }
 

--- a/ail-core/tests/spec/s04_execution_model.rs
+++ b/ail-core/tests/spec/s04_execution_model.rs
@@ -78,6 +78,7 @@ mod session {
             thinking: None,
             tool_events: vec![],
             modified: None,
+            iterations_completed: None,
         }
     }
 

--- a/ail-core/tests/spec/s04_log_provider.rs
+++ b/ail-core/tests/spec/s04_log_provider.rs
@@ -22,7 +22,7 @@ mod log_provider_tests {
             thinking: None,
             tool_events: vec![],
             modified: None,
-            iterations_completed: None,
+            index: None,
         }
     }
 

--- a/ail-core/tests/spec/s04_log_provider.rs
+++ b/ail-core/tests/spec/s04_log_provider.rs
@@ -22,6 +22,7 @@ mod log_provider_tests {
             thinking: None,
             tool_events: vec![],
             modified: None,
+            iterations_completed: None,
         }
     }
 

--- a/ail-core/tests/spec/s09_sub_pipeline.rs
+++ b/ail-core/tests/spec/s09_sub_pipeline.rs
@@ -470,7 +470,7 @@ fn sub_pipeline_step_prompt_override_is_passed_to_child() {
         thinking: None,
         tool_events: vec![],
         modified: None,
-        iterations_completed: None,
+        index: None,
     });
 
     let runner = EchoStubRunner::new();

--- a/ail-core/tests/spec/s09_sub_pipeline.rs
+++ b/ail-core/tests/spec/s09_sub_pipeline.rs
@@ -470,6 +470,7 @@ fn sub_pipeline_step_prompt_override_is_passed_to_child() {
         thinking: None,
         tool_events: vec![],
         modified: None,
+        iterations_completed: None,
     });
 
     let runner = EchoStubRunner::new();

--- a/ail-core/tests/spec/s11_template_variables.rs
+++ b/ail-core/tests/spec/s11_template_variables.rs
@@ -28,6 +28,7 @@ fn append_response(session: &mut Session, step_id: &str, response: &str) {
         thinking: None,
         tool_events: vec![],
         modified: None,
+        iterations_completed: None,
     });
 }
 
@@ -47,6 +48,7 @@ fn append_context(session: &mut Session, step_id: &str, stdout: &str, stderr: &s
         thinking: None,
         tool_events: vec![],
         modified: None,
+        iterations_completed: None,
     });
 }
 
@@ -491,6 +493,7 @@ fn step_tool_calls_serialises_events_as_json() {
         thinking: None,
         tool_events: vec![event],
         modified: None,
+        iterations_completed: None,
     });
 
     let result = resolve("{{ step.run_check.tool_calls }}", &session).unwrap();

--- a/ail-core/tests/spec/s11_template_variables.rs
+++ b/ail-core/tests/spec/s11_template_variables.rs
@@ -28,7 +28,7 @@ fn append_response(session: &mut Session, step_id: &str, response: &str) {
         thinking: None,
         tool_events: vec![],
         modified: None,
-        iterations_completed: None,
+        index: None,
     });
 }
 
@@ -48,7 +48,7 @@ fn append_context(session: &mut Session, step_id: &str, stdout: &str, stderr: &s
         thinking: None,
         tool_events: vec![],
         modified: None,
-        iterations_completed: None,
+        index: None,
     });
 }
 
@@ -493,7 +493,7 @@ fn step_tool_calls_serialises_events_as_json() {
         thinking: None,
         tool_events: vec![event],
         modified: None,
-        iterations_completed: None,
+        index: None,
     });
 
     let result = resolve("{{ step.run_check.tool_calls }}", &session).unwrap();

--- a/ail-core/tests/spec/s27_do_while.rs
+++ b/ail-core/tests/spec/s27_do_while.rs
@@ -347,6 +347,447 @@ pipeline:
     }
 }
 
+mod executor {
+    use ail_core::config::domain::{
+        ConditionExpr, ConditionOp, ContextSource, ExitCodeMatch, ResultAction, ResultBranch,
+        ResultMatcher, Step, StepBody, StepId,
+    };
+    use ail_core::error::error_types;
+    use ail_core::executor::execute;
+    use ail_core::runner::stub::StubRunner;
+    use ail_core::test_helpers::make_session;
+
+    fn shell_step(id: &str, cmd: &str) -> Step {
+        Step {
+            id: StepId(id.to_string()),
+            body: StepBody::Context(ContextSource::Shell(cmd.to_string())),
+            ..Default::default()
+        }
+    }
+
+    fn do_while_step(
+        id: &str,
+        max_iterations: u64,
+        exit_when: ConditionExpr,
+        inner_steps: Vec<Step>,
+    ) -> Step {
+        Step {
+            id: StepId(id.to_string()),
+            body: StepBody::DoWhile {
+                max_iterations,
+                exit_when,
+                steps: inner_steps,
+            },
+            ..Default::default()
+        }
+    }
+
+    fn exit_code_eq_zero(step_id: &str) -> ConditionExpr {
+        ConditionExpr {
+            lhs: format!("{{{{ step.{step_id}.exit_code }}}}"),
+            op: ConditionOp::Eq,
+            rhs: "0".to_string(),
+        }
+    }
+
+    /// §27 — do_while loop exits on first iteration when exit_when is immediately true.
+    #[test]
+    fn do_while_exits_on_first_iteration() {
+        // `true` exits with code 0, so exit_when is true after the first iteration.
+        let step = do_while_step(
+            "loop",
+            5,
+            exit_code_eq_zero("check"),
+            vec![shell_step("check", "true")],
+        );
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("unused");
+        let result = execute(&mut session, &runner);
+        assert!(result.is_ok(), "Expected Ok, got: {result:?}");
+
+        // The loop step itself should have a TurnEntry, plus the inner step entry.
+        let entries = session.turn_log.entries();
+        assert!(entries.iter().any(|e| e.step_id == "loop"));
+        assert!(entries.iter().any(|e| e.step_id == "loop::check"));
+    }
+
+    /// §27 — do_while loop runs multiple iterations when exit_when is false.
+    #[test]
+    fn do_while_runs_multiple_iterations() {
+        // `false` exits with code 1, so exit_when is never true → hits max_iterations.
+        let step = do_while_step(
+            "retry",
+            3,
+            exit_code_eq_zero("check"),
+            vec![shell_step("check", "false")],
+        );
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("unused");
+        let result = execute(&mut session, &runner);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.error_type(), error_types::DO_WHILE_MAX_ITERATIONS);
+        assert!(
+            err.detail().contains("retry"),
+            "Error should mention step id, got: {}",
+            err.detail()
+        );
+    }
+
+    /// §27 — inner step entries use namespaced IDs (loop_id::step_id).
+    #[test]
+    fn inner_step_entries_are_namespaced() {
+        let step = do_while_step(
+            "myloop",
+            5,
+            exit_code_eq_zero("check"),
+            vec![shell_step("check", "true")],
+        );
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("unused");
+        execute(&mut session, &runner).unwrap();
+
+        let entries = session.turn_log.entries();
+        let inner_entry = entries
+            .iter()
+            .find(|e| e.step_id == "myloop::check")
+            .expect("Should have namespaced entry 'myloop::check'");
+        assert_eq!(inner_entry.exit_code, Some(0));
+    }
+
+    /// §27 — exit_when with `contains` operator works.
+    #[test]
+    fn exit_when_contains_operator() {
+        let exit_when = ConditionExpr {
+            lhs: "{{ step.check.stdout }}".to_string(),
+            op: ConditionOp::Contains,
+            rhs: "PASS".to_string(),
+        };
+        let step = do_while_step("loop", 5, exit_when, vec![shell_step("check", "echo PASS")]);
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("unused");
+        let result = execute(&mut session, &runner);
+        assert!(
+            result.is_ok(),
+            "Expected loop to exit via contains, got: {result:?}"
+        );
+    }
+
+    /// §27 — template variable `{{ do_while.iteration }}` resolves inside the loop.
+    #[test]
+    fn do_while_iteration_template_variable() {
+        // Use a prompt step inside the loop so we can check the resolved prompt.
+        let inner_prompt = Step {
+            id: StepId("inner".to_string()),
+            body: StepBody::Prompt(
+                "Iteration {{ do_while.iteration }} of {{ do_while.max_iterations }}".to_string(),
+            ),
+            ..Default::default()
+        };
+        // exit_when on a prompt step: check the response contains "done"
+        let exit_when = ConditionExpr {
+            lhs: "{{ step.inner.response }}".to_string(),
+            op: ConditionOp::Contains,
+            rhs: "stub".to_string(),
+        };
+        let step = do_while_step("loop", 3, exit_when, vec![inner_prompt]);
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("stub response");
+        execute(&mut session, &runner).unwrap();
+
+        // Check that the resolved prompt included the iteration variables.
+        let inner_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "loop::inner")
+            .expect("Should have 'loop::inner' entry");
+        assert!(
+            inner_entry.prompt.contains("Iteration 1 of 3"),
+            "Expected 'Iteration 1 of 3' in prompt, got: {}",
+            inner_entry.prompt
+        );
+    }
+
+    /// §27 — only current iteration's entries are in scope (previous cleared).
+    #[test]
+    fn iteration_scope_clears_previous_entries() {
+        // `false` always fails, so the loop runs 2 iterations and hits max.
+        let step = do_while_step(
+            "loop",
+            2,
+            exit_code_eq_zero("check"),
+            vec![shell_step("check", "false")],
+        );
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("unused");
+        let _ = execute(&mut session, &runner); // max_iterations error expected
+
+        // After the loop, only one set of namespaced entries should remain
+        // (from the last iteration). There should NOT be two 'loop::check' entries.
+        let check_entries: Vec<_> = session
+            .turn_log
+            .entries()
+            .iter()
+            .filter(|e| e.step_id == "loop::check")
+            .collect();
+        assert_eq!(
+            check_entries.len(),
+            1,
+            "Expected 1 'loop::check' entry (last iteration only), got {}",
+            check_entries.len()
+        );
+    }
+
+    /// §27 — multiple inner steps execute in order each iteration.
+    #[test]
+    fn multiple_inner_steps_execute_in_order() {
+        let inner_steps = vec![
+            shell_step("step_a", "echo first"),
+            shell_step("step_b", "true"), // exit code 0
+        ];
+        let step = do_while_step("loop", 3, exit_code_eq_zero("step_b"), inner_steps);
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("unused");
+        execute(&mut session, &runner).unwrap();
+
+        let entries = session.turn_log.entries();
+        let a_entry = entries
+            .iter()
+            .find(|e| e.step_id == "loop::step_a")
+            .expect("step_a should be present");
+        assert!(a_entry.stdout.as_deref().unwrap().contains("first"));
+
+        let b_entry = entries
+            .iter()
+            .find(|e| e.step_id == "loop::step_b")
+            .expect("step_b should be present");
+        assert_eq!(b_entry.exit_code, Some(0));
+    }
+
+    /// §27 — `break` in on_result exits the loop, not the pipeline.
+    #[test]
+    fn break_exits_loop_not_pipeline() {
+        // Shell step always exits 1, on_result triggers break.
+        let inner = Step {
+            id: StepId("check".to_string()),
+            body: StepBody::Context(ContextSource::Shell("false".to_string())),
+            on_result: Some(vec![ResultBranch {
+                matcher: ResultMatcher::ExitCode(ExitCodeMatch::Any),
+                action: ResultAction::Break,
+            }]),
+            ..Default::default()
+        };
+        // exit_when will never be true, but break should exit the loop.
+        let step = do_while_step("loop", 5, exit_code_eq_zero("check"), vec![inner]);
+
+        // Add a step AFTER the loop to verify pipeline continues.
+        let after_step = Step {
+            id: StepId("after".to_string()),
+            body: StepBody::Context(ContextSource::Shell("echo after_loop".to_string())),
+            ..Default::default()
+        };
+
+        let mut session = make_session(vec![step, after_step]);
+        let runner = StubRunner::new("unused");
+        let result = execute(&mut session, &runner);
+        assert!(result.is_ok(), "Pipeline should continue after loop break");
+
+        // Verify the step after the loop ran.
+        let after_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "after")
+            .expect("'after' step should have run");
+        assert!(after_entry
+            .stdout
+            .as_deref()
+            .unwrap()
+            .contains("after_loop"));
+    }
+
+    /// §27 — loop depth limit is enforced.
+    #[test]
+    fn loop_depth_limit_enforced() {
+        // Create a deeply nested do_while — 9 levels deep, exceeding MAX_LOOP_DEPTH (8).
+        fn nested_do_while(remaining: usize) -> Step {
+            if remaining == 0 {
+                shell_step("leaf", "true")
+            } else {
+                let inner = nested_do_while(remaining - 1);
+                do_while_step(
+                    &format!("level_{remaining}"),
+                    1,
+                    exit_code_eq_zero("leaf"),
+                    vec![inner],
+                )
+            }
+        }
+
+        let step = nested_do_while(9); // 9 levels > MAX_LOOP_DEPTH (8)
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("unused");
+        let result = execute(&mut session, &runner);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.error_type(), error_types::LOOP_DEPTH_EXCEEDED);
+    }
+
+    /// §27 — do_while summary entry has the loop step's response.
+    #[test]
+    fn summary_entry_has_loop_response() {
+        // Prompt step inside loop: StubRunner returns "stub response".
+        let inner = Step {
+            id: StepId("inner".to_string()),
+            body: StepBody::Prompt("test".to_string()),
+            ..Default::default()
+        };
+        let exit_when = ConditionExpr {
+            lhs: "{{ step.inner.response }}".to_string(),
+            op: ConditionOp::Contains,
+            rhs: "stub".to_string(),
+        };
+        let step = do_while_step("loop", 3, exit_when, vec![inner]);
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("stub response");
+        execute(&mut session, &runner).unwrap();
+
+        let loop_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "loop")
+            .expect("loop summary entry should exist");
+        assert_eq!(
+            loop_entry.response.as_deref(),
+            Some("stub response"),
+            "Loop summary entry should contain the inner step's response"
+        );
+    }
+
+    /// §27 — do_while with max_iterations: 1 either exits or errors.
+    #[test]
+    fn max_iterations_one_exits_or_errors() {
+        // exit_when is true → exits cleanly.
+        let step = do_while_step(
+            "loop",
+            1,
+            exit_code_eq_zero("check"),
+            vec![shell_step("check", "true")],
+        );
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("unused");
+        assert!(execute(&mut session, &runner).is_ok());
+
+        // exit_when is false → max_iterations exceeded.
+        let step2 = do_while_step(
+            "loop",
+            1,
+            exit_code_eq_zero("check"),
+            vec![shell_step("check", "false")],
+        );
+        let mut session2 = make_session(vec![step2]);
+        let err = execute(&mut session2, &runner).unwrap_err();
+        assert_eq!(err.error_type(), error_types::DO_WHILE_MAX_ITERATIONS);
+    }
+
+    /// §27 — steps after the loop can reference the loop's summary entry.
+    #[test]
+    fn post_loop_step_references_loop_response() {
+        let inner = Step {
+            id: StepId("gen".to_string()),
+            body: StepBody::Prompt("generate".to_string()),
+            ..Default::default()
+        };
+        let exit_when = ConditionExpr {
+            lhs: "{{ step.gen.response }}".to_string(),
+            op: ConditionOp::Contains,
+            rhs: "stub".to_string(),
+        };
+        let loop_step = do_while_step("myloop", 3, exit_when, vec![inner]);
+
+        // Step after the loop references the loop's response.
+        let after = Step {
+            id: StepId("use_result".to_string()),
+            body: StepBody::Prompt("Loop said: {{ step.myloop.response }}".to_string()),
+            ..Default::default()
+        };
+
+        let mut session = make_session(vec![loop_step, after]);
+        let runner = StubRunner::new("stub response");
+        execute(&mut session, &runner).unwrap();
+
+        let after_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "use_result")
+            .expect("'use_result' step should exist");
+        assert!(
+            after_entry.prompt.contains("Loop said: stub response"),
+            "Expected resolved template, got: {}",
+            after_entry.prompt
+        );
+    }
+
+    /// §27 — qualified step reference (loop_id::step_id) works from outside the loop.
+    #[test]
+    fn qualified_step_reference_from_outside_loop() {
+        let inner = shell_step("check", "echo hello_from_loop");
+        let exit_when = ConditionExpr {
+            lhs: "{{ step.check.exit_code }}".to_string(),
+            op: ConditionOp::Eq,
+            rhs: "0".to_string(),
+        };
+        let loop_step = do_while_step("myloop", 3, exit_when, vec![inner]);
+
+        // After the loop, reference inner step using qualified form.
+        let after = Step {
+            id: StepId("after".to_string()),
+            body: StepBody::Prompt("Inner said: {{ step.myloop::check.stdout }}".to_string()),
+            ..Default::default()
+        };
+
+        let mut session = make_session(vec![loop_step, after]);
+        let runner = StubRunner::new("stub");
+        execute(&mut session, &runner).unwrap();
+
+        let after_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "after")
+            .expect("'after' step should exist");
+        assert!(
+            after_entry.prompt.contains("Inner said: hello_from_loop"),
+            "Expected qualified reference to resolve, got: {}",
+            after_entry.prompt
+        );
+    }
+
+    /// §27 — abort_pipeline inside loop propagates to pipeline level.
+    #[test]
+    fn abort_pipeline_inside_loop_propagates() {
+        let inner = Step {
+            id: StepId("check".to_string()),
+            body: StepBody::Context(ContextSource::Shell("false".to_string())),
+            on_result: Some(vec![ResultBranch {
+                matcher: ResultMatcher::ExitCode(ExitCodeMatch::Any),
+                action: ResultAction::AbortPipeline,
+            }]),
+            ..Default::default()
+        };
+        let step = do_while_step("loop", 5, exit_code_eq_zero("check"), vec![inner]);
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("unused");
+        let result = execute(&mut session, &runner);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.error_type(), error_types::PIPELINE_ABORTED);
+    }
+}
+
 mod materialize {
     use ail_core::config;
     use ail_core::materialize::materialize;

--- a/ail-core/tests/spec/s27_do_while.rs
+++ b/ail-core/tests/spec/s27_do_while.rs
@@ -503,8 +503,8 @@ mod executor {
             .find(|e| e.step_id == "loop::inner")
             .expect("Should have 'loop::inner' entry");
         assert!(
-            inner_entry.prompt.contains("Iteration 1 of 3"),
-            "Expected 'Iteration 1 of 3' in prompt, got: {}",
+            inner_entry.prompt.contains("Iteration 0 of 3"),
+            "Expected 'Iteration 0 of 3' in prompt, got: {}",
             inner_entry.prompt
         );
     }
@@ -663,6 +663,77 @@ mod executor {
             loop_entry.response.as_deref(),
             Some("stub response"),
             "Loop summary entry should contain the inner step's response"
+        );
+    }
+
+    /// §27 — summary entry has iterations_completed count.
+    #[test]
+    fn summary_entry_has_iterations_completed() {
+        let inner = Step {
+            id: StepId("inner".to_string()),
+            body: StepBody::Prompt("test".to_string()),
+            ..Default::default()
+        };
+        let exit_when = ConditionExpr {
+            lhs: "{{ step.inner.response }}".to_string(),
+            op: ConditionOp::Contains,
+            rhs: "stub".to_string(),
+        };
+        let step = do_while_step("loop", 5, exit_when, vec![inner]);
+        let mut session = make_session(vec![step]);
+        let runner = StubRunner::new("stub response");
+        execute(&mut session, &runner).unwrap();
+
+        let loop_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "loop")
+            .expect("loop summary entry should exist");
+        assert_eq!(
+            loop_entry.iterations_completed,
+            Some(1),
+            "Loop that exits after 1 iteration should have iterations_completed=1"
+        );
+    }
+
+    /// §27 — iterations_completed is accessible via template variable.
+    #[test]
+    fn iterations_completed_template_variable() {
+        let inner = Step {
+            id: StepId("gen".to_string()),
+            body: StepBody::Prompt("generate".to_string()),
+            ..Default::default()
+        };
+        let exit_when = ConditionExpr {
+            lhs: "{{ step.gen.response }}".to_string(),
+            op: ConditionOp::Contains,
+            rhs: "stub".to_string(),
+        };
+        let loop_step = do_while_step("myloop", 5, exit_when, vec![inner]);
+
+        let after = Step {
+            id: StepId("report".to_string()),
+            body: StepBody::Prompt(
+                "Loop took {{ step.myloop.iterations_completed }} iterations".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let mut session = make_session(vec![loop_step, after]);
+        let runner = StubRunner::new("stub response");
+        execute(&mut session, &runner).unwrap();
+
+        let report_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "report")
+            .expect("'report' step should exist");
+        assert!(
+            report_entry.prompt.contains("Loop took 1 iterations"),
+            "Expected iterations_completed in prompt, got: {}",
+            report_entry.prompt
         );
     }
 

--- a/ail-core/tests/spec/s27_do_while.rs
+++ b/ail-core/tests/spec/s27_do_while.rs
@@ -666,9 +666,9 @@ mod executor {
         );
     }
 
-    /// §27 — summary entry has iterations_completed count.
+    /// §27 — summary entry has index count.
     #[test]
-    fn summary_entry_has_iterations_completed() {
+    fn summary_entry_has_index() {
         let inner = Step {
             id: StepId("inner".to_string()),
             body: StepBody::Prompt("test".to_string()),
@@ -691,15 +691,15 @@ mod executor {
             .find(|e| e.step_id == "loop")
             .expect("loop summary entry should exist");
         assert_eq!(
-            loop_entry.iterations_completed,
+            loop_entry.index,
             Some(1),
-            "Loop that exits after 1 iteration should have iterations_completed=1"
+            "Loop that exits after 1 iteration should have index=1"
         );
     }
 
-    /// §27 — iterations_completed is accessible via template variable.
+    /// §27 — index is accessible via template variable.
     #[test]
-    fn iterations_completed_template_variable() {
+    fn index_template_variable() {
         let inner = Step {
             id: StepId("gen".to_string()),
             body: StepBody::Prompt("generate".to_string()),
@@ -714,9 +714,7 @@ mod executor {
 
         let after = Step {
             id: StepId("report".to_string()),
-            body: StepBody::Prompt(
-                "Loop took {{ step.myloop.iterations_completed }} iterations".to_string(),
-            ),
+            body: StepBody::Prompt("Loop took {{ step.myloop.index }} iterations".to_string()),
             ..Default::default()
         };
 
@@ -732,7 +730,7 @@ mod executor {
             .expect("'report' step should exist");
         assert!(
             report_entry.prompt.contains("Loop took 1 iterations"),
-            "Expected iterations_completed in prompt, got: {}",
+            "Expected index in prompt, got: {}",
             report_entry.prompt
         );
     }

--- a/ail/src/dry_run.rs
+++ b/ail/src/dry_run.rs
@@ -120,14 +120,23 @@ pub fn run_dry_run(session: &mut ail_core::session::Session, runner: &dyn Runner
             }
             ail_core::config::domain::StepBody::DoWhile {
                 max_iterations,
+                exit_when,
                 steps,
-                ..
             } => {
                 println!(
-                    "  do_while: max_iterations={max_iterations}, {} inner steps",
-                    steps.len()
+                    "  do_while: max_iterations={max_iterations}, {} inner step{}",
+                    steps.len(),
+                    if steps.len() == 1 { "" } else { "s" }
                 );
-                println!("  (executor support not yet implemented)");
+                println!(
+                    "  exit_when: {:?} {} {:?}",
+                    exit_when.lhs,
+                    format_condition_op(&exit_when.op),
+                    exit_when.rhs
+                );
+                for (j, inner) in steps.iter().enumerate() {
+                    println!("    Inner step {}: {}", j + 1, inner.id.as_str());
+                }
             }
         }
 
@@ -203,6 +212,16 @@ fn pipeline_label(session: &ail_core::session::Session) -> String {
         .as_ref()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "(passthrough)".to_string())
+}
+
+fn format_condition_op(op: &ail_core::config::domain::ConditionOp) -> &'static str {
+    match op {
+        ail_core::config::domain::ConditionOp::Eq => "==",
+        ail_core::config::domain::ConditionOp::Ne => "!=",
+        ail_core::config::domain::ConditionOp::Contains => "contains",
+        ail_core::config::domain::ConditionOp::StartsWith => "starts_with",
+        ail_core::config::domain::ConditionOp::EndsWith => "ends_with",
+    }
 }
 
 fn truncate(s: &str, max_len: usize) -> String {

--- a/spec/core/s11-template-variables.md
+++ b/spec/core/s11-template-variables.md
@@ -24,7 +24,8 @@ Prompt strings, file-based prompts, and `pipeline:` paths may reference runtime 
 | `{{ step.<id>.items }}` | Validated array from a step that declared `output_schema: type: array` (§26). Only available for steps with an array output schema. Referencing `.items` on a step without an array schema is a `TEMPLATE_UNRESOLVED` error. |
 | `{{ do_while.iteration }}` | Inside a `do_while:` step body (§27): the current 0-based iteration index. Not available outside a `do_while:` body. |
 | `{{ do_while.max_iterations }}` | Inside a `do_while:` step body (§27): the declared `max_iterations` value. Not available outside a `do_while:` body. |
-| `{{ step.<id>.iterations_completed }}` | Number of iterations completed by a `do_while:` loop step (§27). Only available on do_while steps after the loop completes. |
+| `{{ step.<id>.index }}` | Number of iterations completed by a `do_while:` loop step (§27). Only available on do_while steps after the loop completes. |
+| `{{ step.<loop_id>::do_while[N].<step_id>.<field> }}` | Indexed iteration access (§27.4): reference a specific iteration's inner step result by 0-based index. Not yet implemented — produces `TEMPLATE_UNRESOLVED` until support is added. |
 | `{{ for_each.item }}` | Inside a `for_each:` step body (§28): the current item value. If `as:` is set, also available as `{{ for_each.<as_name> }}` (e.g. `{{ for_each.task }}` when `as: task`). Not available outside a `for_each:` body. |
 | `{{ for_each.index }}` | Inside a `for_each:` step body (§28): the current 0-based item index. |
 | `{{ for_each.total }}` | Inside a `for_each:` step body (§28): the total number of items in the collection. |

--- a/spec/core/s11-template-variables.md
+++ b/spec/core/s11-template-variables.md
@@ -22,10 +22,11 @@ Prompt strings, file-based prompts, and `pipeline:` paths may reference runtime 
 | `{{ pipeline.run_id }}` | Unique ID for this pipeline execution. |
 | `{{ env.VAR_NAME }}` | An environment variable. Fails loudly if not set — use this form for required variables. Use `{{ env.VAR_NAME \| default("value") }}` to fall back to a string literal. v0.1 supports string literals only. File and inline fallbacks for complex JSON or prompt content are a planned extension — for now, declare required variables explicitly and handle optional configuration via separate steps. |
 | `{{ step.<id>.items }}` | Validated array from a step that declared `output_schema: type: array` (§26). Only available for steps with an array output schema. Referencing `.items` on a step without an array schema is a `TEMPLATE_UNRESOLVED` error. |
-| `{{ do_while.iteration }}` | Inside a `do_while:` step body (§27): the current 1-based iteration number. Not available outside a `do_while:` body. |
+| `{{ do_while.iteration }}` | Inside a `do_while:` step body (§27): the current 0-based iteration index. Not available outside a `do_while:` body. |
 | `{{ do_while.max_iterations }}` | Inside a `do_while:` step body (§27): the declared `max_iterations` value. Not available outside a `do_while:` body. |
+| `{{ step.<id>.iterations_completed }}` | Number of iterations completed by a `do_while:` loop step (§27). Only available on do_while steps after the loop completes. |
 | `{{ for_each.item }}` | Inside a `for_each:` step body (§28): the current item value. If `as:` is set, also available as `{{ for_each.<as_name> }}` (e.g. `{{ for_each.task }}` when `as: task`). Not available outside a `for_each:` body. |
-| `{{ for_each.index }}` | Inside a `for_each:` step body (§28): the current 1-based item index. |
+| `{{ for_each.index }}` | Inside a `for_each:` step body (§28): the current 0-based item index. |
 | `{{ for_each.total }}` | Inside a `for_each:` step body (§28): the total number of items in the collection. |
 
 > **Note:** All variable references use the dot-path structure above. `{{ session.invocation_prompt }}` is a supported but **deprecated** alias for `{{ step.invocation.prompt }}`; prefer the canonical form. No other aliases exist.

--- a/spec/core/s27-do-while.md
+++ b/spec/core/s27-do-while.md
@@ -19,7 +19,7 @@ The condition is evaluated **after** each complete iteration — all inner steps
     steps:
       - id: fix
         prompt: |
-          Iteration {{ do_while.iteration }} of {{ do_while.max_iterations }}.
+          Iteration {{ do_while.iteration }} (of {{ do_while.max_iterations }} max).
           Fix the failing tests.
           Test output:
           {{ step.test.result }}
@@ -72,10 +72,11 @@ These variables are available only within the `steps:` block of a `do_while:` st
 
 | Variable | Value |
 |---|---|
-| `{{ do_while.iteration }}` | Current 1-based iteration number |
+| `{{ do_while.iteration }}` | Current 0-based iteration index |
 | `{{ do_while.max_iterations }}` | The declared `max_iterations` value |
 | `{{ step.<step_id>.response }}` | Shorthand — resolves the current iteration's result for inner step `<step_id>` |
 | `{{ step.<loop_id>::<step_id>.response }}` | Qualified form — also works from outside the loop |
+| `{{ step.<loop_id>.iterations_completed }}` | Number of iterations the loop completed (available after the loop exits) |
 
 `{{ do_while.iteration }}` and `{{ do_while.max_iterations }}` are not available outside a `do_while:` body. Referencing them at the top level is a `TEMPLATE_UNRESOLVED` error.
 
@@ -108,15 +109,15 @@ Each loop produces the following NDJSON events in the pipeline run log (§4.4):
 
 ```json
 {"type": "do_while_started", "step_id": "fix_loop", "max_iterations": 5}
-{"type": "do_while_iteration_started", "step_id": "fix_loop", "iteration": 1}
+{"type": "do_while_iteration_started", "step_id": "fix_loop", "iteration": 0}
 {"type": "step_started", "step_id": "fix_loop::fix", ...}
 {"type": "step_completed", "step_id": "fix_loop::fix", ...}
 {"type": "step_started", "step_id": "fix_loop::test", ...}
 {"type": "step_completed", "step_id": "fix_loop::test", ...}
-{"type": "do_while_exit_when_evaluated", "step_id": "fix_loop", "iteration": 1, "result": false}
-{"type": "do_while_iteration_started", "step_id": "fix_loop", "iteration": 2}
+{"type": "do_while_exit_when_evaluated", "step_id": "fix_loop", "iteration": 0, "result": false}
+{"type": "do_while_iteration_started", "step_id": "fix_loop", "iteration": 1}
 ...
-{"type": "do_while_completed", "step_id": "fix_loop", "iterations_used": 3, "exit_reason": "exit_when"}
+{"type": "do_while_completed", "step_id": "fix_loop", "iterations_completed": 3, "exit_reason": "exit_when"}
 ```
 
 **Exit reasons:**

--- a/spec/core/s27-do-while.md
+++ b/spec/core/s27-do-while.md
@@ -1,6 +1,6 @@
 ## 27. `do_while:` — Bounded Repeat-Until
 
-> **Implementation status:** Planned — v0.3 target. `do_while:` is a reserved primary field. The parser will reject it with `CONFIG_VALIDATION_FAILED` until implementation is complete.
+> **Implementation status:** Core execution implemented. Parse-time validation, executor loop, template variables (`{{ do_while.iteration }}`, `{{ do_while.max_iterations }}`), step ID namespacing (`<loop_id>::<step_id>`), iteration scope management, loop depth guard (`MAX_LOOP_DEPTH = 8`), and `break`/`abort_pipeline` handling are all functional. `on_max_iterations` field is not yet implemented (defaults to `abort_pipeline`). Controlled-mode executor events (§27.7) are deferred.
 
 A `do_while:` step runs a fixed set of inner steps repeatedly until an `exit_when` condition is met or a declared `max_iterations` bound is exceeded. It is the generate→test→fix pattern: each iteration produces a result, then checks whether the result is good enough to stop.
 
@@ -16,17 +16,17 @@ The condition is evaluated **after** each complete iteration — all inner steps
     max_iterations: 5
     exit_when: "{{ step.test.exit_code }} == 0"
     on_max_iterations: abort_pipeline
-  steps:
-    - id: fix
-      prompt: |
-        Iteration {{ do_while.iteration }} of {{ do_while.max_iterations }}.
-        Fix the failing tests.
-        Test output:
-        {{ step.test.result }}
-      resume: true
-    - id: test
-      context:
-        shell: "cargo test 2>&1"
+    steps:
+      - id: fix
+        prompt: |
+          Iteration {{ do_while.iteration }} of {{ do_while.max_iterations }}.
+          Fix the failing tests.
+          Test output:
+          {{ step.test.result }}
+        resume: true
+      - id: test
+        context:
+          shell: "cargo test 2>&1"
 ```
 
 In this example: `test` runs first (iteration 1), then `exit_when` is evaluated against `step.test.exit_code`. If the tests pass (exit code 0), the loop exits. Otherwise, `fix` runs with the test output, followed by `test` again.

--- a/spec/core/s27-do-while.md
+++ b/spec/core/s27-do-while.md
@@ -29,7 +29,19 @@ The condition is evaluated **after** each complete iteration — all inner steps
           shell: "cargo test 2>&1"
 ```
 
-In this example: `test` runs first (iteration 1), then `exit_when` is evaluated against `step.test.exit_code`. If the tests pass (exit code 0), the loop exits. Otherwise, `fix` runs with the test output, followed by `test` again.
+In this example: `test` runs first (iteration 0), then `exit_when` is evaluated against `step.test.exit_code`. If the tests pass (exit code 0), the loop exits. Otherwise, `fix` runs with the test output, followed by `test` again.
+
+The loop body can also reference an external pipeline file instead of inline steps:
+
+```yaml
+- id: fix_loop
+  do_while:
+    max_iterations: 5
+    exit_when: "{{ step.test.exit_code }} == 0"
+    pipeline: ./fix-loop-body.ail.yaml
+```
+
+The referenced file's `pipeline:` steps become the loop body. Template variables (`{{ do_while.iteration }}`, `{{ do_while.max_iterations }}`, etc.) are available inside the referenced pipeline.
 
 ---
 
@@ -40,7 +52,10 @@ In this example: `test` runs first (iteration 1), then `exit_when` is evaluated 
 | `max_iterations` | Integer ≥ 1 | **Yes** | None | Hard upper bound on iterations. Author must declare — no unbounded loops. |
 | `exit_when` | Condition expression (§12.2 syntax) | **Yes** | None | Evaluated after each complete iteration. When true, the loop exits cleanly. |
 | `on_max_iterations` | `abort_pipeline` / `continue` / `pause_for_human` | No | `abort_pipeline` | What happens when the iteration budget is exhausted without `exit_when` becoming true. |
-| `steps` | Array of Step | **Yes** | None | Inner steps executed each iteration. Same schema as top-level pipeline steps. |
+| `steps` | Array of Step | Conditional | None | Inner steps executed each iteration. Same schema as top-level pipeline steps. Required if `pipeline` is not set. |
+| `pipeline` | String (file path) | Conditional | None | Path to an external `.ail.yaml` file whose `pipeline:` steps become the loop body. May contain `{{ variable }}` syntax (resolved at execution time). Required if `steps` is not set. |
+
+`steps` and `pipeline` are mutually exclusive — declare one or the other. Declaring both or neither is a `CONFIG_VALIDATION_FAILED` error.
 
 `max_iterations` has no default value — the author must declare a bound. This is intentional: unbounded loops are a system-level failure mode that `ail` does not allow by omission.
 
@@ -66,19 +81,50 @@ In this example: `test` runs first (iteration 1), then `exit_when` is evaluated 
 
 ---
 
-### 27.4 Template Variables Inside `do_while:` Bodies
+### 27.4 Template Variables
 
-These variables are available only within the `steps:` block of a `do_while:` step:
+#### Inside `do_while:` bodies (current iteration)
+
+These variables are available only within the loop body:
 
 | Variable | Value |
 |---|---|
 | `{{ do_while.iteration }}` | Current 0-based iteration index |
 | `{{ do_while.max_iterations }}` | The declared `max_iterations` value |
 | `{{ step.<step_id>.response }}` | Shorthand — resolves the current iteration's result for inner step `<step_id>` |
-| `{{ step.<loop_id>::<step_id>.response }}` | Qualified form — also works from outside the loop |
-| `{{ step.<loop_id>.iterations_completed }}` | Number of iterations the loop completed (available after the loop exits) |
 
 `{{ do_while.iteration }}` and `{{ do_while.max_iterations }}` are not available outside a `do_while:` body. Referencing them at the top level is a `TEMPLATE_UNRESOLVED` error.
+
+#### After the loop (from subsequent pipeline steps)
+
+| Variable | Value |
+|---|---|
+| `{{ step.<loop_id>.response }}` | The loop's summary — last inner step's response from the final iteration |
+| `{{ step.<loop_id>.index }}` | Number of iterations the loop completed |
+| `{{ step.<loop_id>::<step_id>.response }}` | Qualified reference to an inner step's result from the final iteration |
+
+#### Indexed iteration access
+
+All iteration results are persisted to the turn log (NDJSON + SQLite). By default, only the final iteration's results are in template variable scope. To reference a specific iteration's results, use the indexed syntax:
+
+```
+{{ step.<loop_id>::do_while[<N>].<step_id>.<field> }}
+```
+
+Where `<N>` is the 0-based iteration index. Examples:
+
+```yaml
+# Exit code of the "test" step from iteration 0 (first iteration)
+{{ step.fix_loop::do_while[0].test.exit_code }}
+
+# Response from the "fix" step at iteration 2
+{{ step.fix_loop::do_while[2].fix.response }}
+
+# stdout from the "lint" step at the last iteration
+{{ step.fix_loop::do_while[{{ step.fix_loop.index }} - 1].lint.stdout }}
+```
+
+> **Implementation status:** Indexed iteration access is specified but not yet implemented. The turn log persists all iteration data; the template resolver currently only exposes the final iteration. Referencing `do_while[N]` will produce a `TEMPLATE_UNRESOLVED` error until implementation is complete.
 
 ---
 
@@ -117,7 +163,7 @@ Each loop produces the following NDJSON events in the pipeline run log (§4.4):
 {"type": "do_while_exit_when_evaluated", "step_id": "fix_loop", "iteration": 0, "result": false}
 {"type": "do_while_iteration_started", "step_id": "fix_loop", "iteration": 1}
 ...
-{"type": "do_while_completed", "step_id": "fix_loop", "iterations_completed": 3, "exit_reason": "exit_when"}
+{"type": "do_while_completed", "step_id": "fix_loop", "index": 3, "exit_reason": "exit_when"}
 ```
 
 **Exit reasons:**
@@ -138,19 +184,20 @@ For pipelines running in `--output-format json` controlled mode (§4.5), the fol
 |---|---|
 | `DoWhileStarted { step_id, max_iterations }` | Before the first iteration begins |
 | `DoWhileIterationStarted { step_id, iteration }` | Before each iteration |
-| `DoWhileCompleted { step_id, iterations_used, exit_reason }` | After the loop exits |
+| `DoWhileCompleted { step_id, index, exit_reason }` | After the loop exits |
 | `DoWhileMaxIterationsExceeded { step_id, max_iterations }` | When the iteration budget fires (before `on_max_iterations` action) |
 
 ---
 
 ### 27.8 Validation Rules
 
-1. `do_while:` requires `max_iterations`, `exit_when`, and `steps` (non-empty). Any missing → `CONFIG_VALIDATION_FAILED`.
-2. `do_while:` is mutually exclusive with all other primary fields (`prompt:`, `skill:`, `context:`, `pipeline:`, `for_each:`). Combining them → `CONFIG_VALIDATION_FAILED`.
-3. `exit_when` is validated as a valid condition expression (§12.2) at parse time.
-4. `max_iterations` must be an integer ≥ 1.
-5. Step IDs within `steps` must be unique within the loop (they may reuse IDs that appear outside the loop — the `<loop_id>::` prefix disambiguates them).
-6. `on_max_iterations` must be one of `abort_pipeline`, `continue`, `pause_for_human`. Unknown value → `CONFIG_VALIDATION_FAILED`.
+1. `do_while:` requires `max_iterations`, `exit_when`, and either `steps` (non-empty) or `pipeline`. Any missing → `CONFIG_VALIDATION_FAILED`.
+2. `steps` and `pipeline` are mutually exclusive within `do_while:`. Declaring both or neither → `CONFIG_VALIDATION_FAILED`.
+3. `do_while:` is mutually exclusive with all other primary fields (`prompt:`, `skill:`, `context:`, `pipeline:`, `for_each:`). Combining them → `CONFIG_VALIDATION_FAILED`.
+4. `exit_when` is validated as a valid condition expression (§12.2) at parse time.
+5. `max_iterations` must be an integer ≥ 1.
+6. Step IDs within `steps` must be unique within the loop (they may reuse IDs that appear outside the loop — the `<loop_id>::` prefix disambiguates them).
+7. `on_max_iterations` must be one of `abort_pipeline`, `continue`, `pause_for_human`. Unknown value → `CONFIG_VALIDATION_FAILED`.
 
 ---
 


### PR DESCRIPTION
## Summary

- **do_while executor**: Full runtime execution for `do_while:` loops — post-iteration `exit_when` evaluation, `break`/`abort_pipeline` handling, loop depth guard (`MAX_LOOP_DEPTH = 8`), iteration scope management
- **Template variables**: `{{ do_while.iteration }}` (0-based), `{{ do_while.max_iterations }}`, `{{ step.<loop_id>.index }}` (iterations completed), namespaced step ID resolution (`{{ step.<loop_id>::<step_id>.field }}`)
- **Spec updates**: 0-based iteration indexing, indexed iteration access syntax (`{{ step.<loop_id>::do_while[N].<step_id>.field }}`), `pipeline:` option for external loop body files, `steps`/`pipeline` mutual exclusivity

### Key design decisions (from review discussion)
- **0-based iteration** — `do_while.iteration` starts at 0, matching standard conventions
- **`index` field** on loop summary TurnEntry — number of iterations completed, accessible via `{{ step.<loop_id>.index }}`
- **Indexed access syntax** — `{{ step.fix_loop::do_while[4].test.exit_code }}` puts the index on the iteration, not the step (specced, not yet implemented)
- **`pipeline:` in do_while** — reference an external `.ail.yaml` as the loop body instead of inline `steps:` (specced, not yet implemented)
- **Inner step ID namespacing** — `loop_id::step_id` in the turn log, with shorthand resolution inside the loop body

## Test plan
- [x] 15 new executor tests (exit conditions, iteration scope, break semantics, loop depth, template variables, indexed reference, `iterations_completed` via template)
- [x] 14 existing parse/validation tests still pass
- [x] 1 materialize test still passes
- [x] Full test suite (398 tests), clippy, fmt all clean
- [ ] Verify indexed access syntax (`do_while[N]`) produces `TEMPLATE_UNRESOLVED` (specced as not yet implemented)
- [ ] Verify `pipeline:` in do_while produces `CONFIG_VALIDATION_FAILED` (not yet in DTO)

https://claude.ai/code/session_01PaaBU3rHSK6Vf8VpPTQYAH