### PR TITLE
feat: implement for_each collection iteration (§28)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,10 @@ If nothing found → passthrough mode (safe zero-config default).
 | `{{ step.<loop_id>::<step_id>.* }}` | Qualified reference to a do_while inner step from outside the loop |
 | `{{ step.<loop_id>.index }}` | Number of iterations completed by a do_while loop (after loop exits) |
 | `{{ step.<loop_id>::do_while[N].<step_id>.* }}` | Indexed iteration access — specific iteration's inner step (not yet implemented) |
+| `{{ for_each.item }}` | Current item value (default name — used when `as:` is not set; always available) |
+| `{{ for_each.<as_name> }}` | Current item value under the declared `as:` name (e.g. `{{ for_each.task }}` when `as: task`) |
+| `{{ for_each.index }}` | Current 1-based item index (only inside `for_each:` body) |
+| `{{ for_each.total }}` | Total number of items in the collection, after `max_items` cap (only inside `for_each:` body) |
 
 Note: `{{ session.invocation_prompt }}` is a supported alias for `{{ step.invocation.prompt }}` in the implementation but is deprecated — prefer the canonical form.
 

--- a/ail-core/CLAUDE.md
+++ b/ail-core/CLAUDE.md
@@ -11,14 +11,14 @@ Consumed by `ail` (the binary) and future language-server / SDK targets.
 | `config/dto.rs` | Serde-deserialised raw structs — derives `Deserialize` |
 | `config/domain.rs` | Validated domain types — no `Deserialize` derives |
 | `config/validation/mod.rs` | `validate()` entry point, `cfg_err!` macro, `tools_to_policy` helper |
-| `config/validation/step_body.rs` | `parse_step_body()` — primary field count check + body construction |
+| `config/validation/step_body.rs` | `parse_step_body()` — primary field count check + body construction (including `parse_do_while_body`, `parse_for_each_body`) |
 | `config/validation/on_result.rs` | `parse_result_branches()` — DTO → domain for result matchers and actions |
 | `config/validation/system_prompt.rs` | `parse_append_system_prompt()` — DTO → domain for system prompt entries |
 | `config/inheritance.rs` | FROM inheritance — path resolution, cycle detection, DTO merging, hook operations (SPEC §7, §8) |
 | `config/mod.rs` | `load(path)` public entry point |
 | `error.rs` | `AilError`, `ErrorContext`, `error_types` string constants |
 | `executor/mod.rs` | `execute(&mut Session, &dyn Runner)` — SPEC §4.2 core invariant |
-| `executor/core.rs` | `StepObserver` trait, `NullObserver`, `execute_core()`, `execute_do_while()` — shared step-dispatch loop + do_while loop execution (SPEC §27) |
+| `executor/core.rs` | `StepObserver` trait, `NullObserver`, `execute_core()`, `execute_do_while()`, `execute_for_each()` — shared step-dispatch loop + loop execution (SPEC §27, §28) |
 | `executor/headless.rs` | `execute()` — headless mode entry point using `NullObserver` |
 | `executor/controlled.rs` | `execute_with_control()` — TUI-controlled mode with `ChannelObserver` |
 | `executor/events.rs` | `ExecuteOutcome`, `ExecutionControl`, `ExecutorEvent` |
@@ -50,7 +50,7 @@ Consumed by `ail` (the binary) and future language-server / SDK targets.
 | `runner/plugin/protocol_runner.rs` | `ProtocolRunner` — generic `Runner` impl that speaks JSON-RPC to any compliant executable |
 | `runner/http.rs` | `HttpRunner` — direct OpenAI-compatible HTTP runner (Ollama, direct API); full system-prompt control, think flag, in-memory session continuity |
 | `runner/dry_run.rs` | `DryRunRunner` — production no-op runner for `--dry-run` mode; returns synthetic response, zero tokens, zero cost |
-| `runner/stub.rs` | `StubRunner`, `CountingStubRunner`, `EchoStubRunner`, `RecordingStubRunner` — deterministic test doubles |
+| `runner/stub.rs` | `StubRunner`, `CountingStubRunner`, `EchoStubRunner`, `RecordingStubRunner`, `SequenceStubRunner` — deterministic test doubles |
 | `session/log_provider.rs` | `LogProvider` trait + `JsonlProvider` (NDJSON) + `NullProvider` (tests) |
 | `session/state.rs` | `Session` — `run_id`, `pipeline`, `invocation_prompt`, `turn_log` |
 | `session/turn_log.rs` | `TurnLog` — in-memory entry store + delegates persistence to `LogProvider` |
@@ -77,7 +77,7 @@ pub struct Pipeline { pub steps: Vec<Step>, pub source: Option<PathBuf>, pub def
 // default_tools: pipeline-wide fallback; per-step tools override entirely (SPEC §3.2)
 // named_pipelines: named pipeline definitions from the `pipelines:` section (SPEC §10)
 pub struct Step    { pub id: StepId, pub body: StepBody, pub tools: Option<ToolPolicy>, pub on_result: Option<Vec<ResultBranch>>, pub model: Option<String>, pub runner: Option<String> }
-pub enum StepBody  { Prompt(String), Skill { name: String }, SubPipeline { path: String, prompt: Option<String> }, NamedPipeline { name: String, prompt: Option<String> }, Action(ActionKind), Context(ContextSource) }
+pub enum StepBody  { Prompt(String), Skill { name: String }, SubPipeline { path: String, prompt: Option<String> }, NamedPipeline { name: String, prompt: Option<String> }, Action(ActionKind), Context(ContextSource), DoWhile { max_iterations, exit_when, steps }, ForEach { over, as_name, max_items, on_max_items, steps } }
 // NamedPipeline: references a named pipeline defined in pipelines: section (SPEC §10)
 // NamedPipeline.prompt: when Some, overrides child session's invocation_prompt (same as SubPipeline)
 // SubPipeline.path may contain {{ variable }} syntax — resolved at execution time (SPEC §11)
@@ -148,16 +148,21 @@ pub type HttpSessionStore = Arc<Mutex<HashMap<String, Vec<ChatMessage>>>>;
 pub enum ExecuteOutcome { Completed, Break { step_id: String } }
 
 // Session
-pub struct Session { pub run_id: String, pub pipeline: Pipeline, pub invocation_prompt: String, pub turn_log: TurnLog, pub cli_provider: ProviderConfig, pub cwd: String, pub runner_name: String, pub headless: bool, pub http_session_store: HttpSessionStore, pub do_while_context: Option<DoWhileContext>, pub loop_depth: usize }
+pub struct Session { pub run_id: String, pub pipeline: Pipeline, pub invocation_prompt: String, pub turn_log: TurnLog, pub cli_provider: ProviderConfig, pub cwd: String, pub runner_name: String, pub headless: bool, pub http_session_store: HttpSessionStore, pub do_while_context: Option<DoWhileContext>, pub for_each_context: Option<ForEachContext>, pub loop_depth: usize }
 // cwd: captured at Session::new() time via std::env::current_dir(); used by {{ session.cwd }} template variable.
 // do_while_context: set during do_while loop body execution, enables {{ do_while.iteration }} and {{ do_while.max_iterations }} template variables
-// loop_depth: current nesting depth of do_while loops, checked against MAX_LOOP_DEPTH (8)
+// for_each_context: set during for_each loop body execution, enables {{ for_each.item }}/{{ for_each.<as_name> }}, {{ for_each.index }}, {{ for_each.total }} template variables
+// loop_depth: current nesting depth of loop constructs (do_while, for_each), checked against MAX_LOOP_DEPTH (8)
 // Note: the "Allow for session" tool allowlist (SPEC §13.2, §13.4) lives in the `ail` binary crate
 // (control_bridge::AllowlistArc), not on Session — session allowlisting is a binary-layer concern.
 // TurnEntry carries prompt-step fields (response, runner_session_id, thinking, tool_events) and context-step fields (stdout, stderr, exit_code)
 // tool_events: Vec<ToolEvent> — populated from RunResult.tool_events for prompt steps; empty for context/action/sub-pipeline steps
 pub struct DoWhileContext { pub loop_id: String, pub iteration: u64, pub max_iterations: u64 }
 // DoWhileContext: active loop context — set during do_while body execution, cleared after loop exits (SPEC §27)
+pub struct ForEachContext { pub loop_id: String, pub index: u64, pub total: u64, pub item: String, pub as_name: String }
+// ForEachContext: active loop context — set during for_each body execution, cleared after loop exits (SPEC §28)
+pub enum OnMaxItems { Continue, AbortPipeline }
+// OnMaxItems: behavior when for_each array exceeds max_items (SPEC §28.2)
 
 // Error
 pub struct AilError { pub error_type: &'static str, pub title: &'static str, pub detail: String, pub context: Option<ErrorContext> }

--- a/ail-core/src/config/domain.rs
+++ b/ail-core/src/config/domain.rs
@@ -270,6 +270,29 @@ pub enum StepBody {
         /// Inner steps executed each iteration.
         steps: Vec<Step>,
     },
+    /// Collection iteration (SPEC §28). Runs inner steps once per item in a
+    /// validated array from a prior step's `output_schema: type: array`.
+    ForEach {
+        /// Template expression resolving to a validated JSON array.
+        over: String,
+        /// Local name for the current item (default: `item`).
+        as_name: String,
+        /// Optional hard cap on items processed.
+        max_items: Option<u64>,
+        /// What happens when the array exceeds `max_items`.
+        on_max_items: OnMaxItems,
+        /// Inner steps executed once per item.
+        steps: Vec<Step>,
+    },
+}
+
+/// Behavior when a `for_each:` array exceeds `max_items` (SPEC §28.2).
+#[derive(Debug, Clone, PartialEq)]
+pub enum OnMaxItems {
+    /// Silently skip excess items (default).
+    Continue,
+    /// Treat excess items as a fatal error.
+    AbortPipeline,
 }
 
 #[derive(Debug, Clone)]

--- a/ail-core/src/config/dto.rs
+++ b/ail-core/src/config/dto.rs
@@ -92,8 +92,8 @@ pub struct StepDto {
     // "unknown field". Rejected at validation time until implemented.
     /// Bounded repeat-until loop (SPEC §27).
     pub do_while: Option<DoWhileDto>,
-    /// Reserved: collection iteration (SPEC §28). Rejected at validation time.
-    pub for_each: Option<serde_json::Value>,
+    /// Collection iteration (SPEC §28).
+    pub for_each: Option<ForEachDto>,
     /// Reserved: JSON Schema for step output validation (SPEC §26). Rejected at validation time.
     pub output_schema: Option<serde_json::Value>,
     /// Reserved: JSON Schema for step input validation (SPEC §26). Rejected at validation time.
@@ -126,6 +126,22 @@ pub struct DoWhileDto {
     /// Condition expression evaluated after each iteration; loop exits when true.
     pub exit_when: Option<String>,
     /// Inner steps executed each iteration.
+    pub steps: Option<Vec<StepDto>>,
+}
+
+/// DTO for `for_each:` collection iteration (SPEC §28).
+#[derive(Debug, Default, Deserialize)]
+pub struct ForEachDto {
+    /// Template expression resolving to a validated array (e.g. `{{ step.plan.items }}`).
+    pub over: Option<String>,
+    /// Local name for the current item within the loop body. Defaults to `item`.
+    #[serde(rename = "as")]
+    pub as_name: Option<String>,
+    /// Hard cap on items processed. Items beyond this limit are not processed.
+    pub max_items: Option<u64>,
+    /// What happens when the array contains more items than `max_items`.
+    pub on_max_items: Option<String>,
+    /// Inner steps executed once per item.
     pub steps: Option<Vec<StepDto>>,
 }
 

--- a/ail-core/src/config/validation/step_body.rs
+++ b/ail-core/src/config/validation/step_body.rs
@@ -2,7 +2,9 @@
 
 #![allow(clippy::result_large_err)]
 
-use crate::config::domain::{ActionKind, ContextSource, HitlHeadlessBehavior, StepBody};
+use crate::config::domain::{
+    ActionKind, ContextSource, HitlHeadlessBehavior, OnMaxItems, StepBody,
+};
 use crate::config::dto::StepDto;
 use crate::error::AilError;
 
@@ -17,14 +19,6 @@ pub(in crate::config) fn parse_step_body(
     step_dto: &mut StepDto,
     id_str: &str,
 ) -> Result<StepBody, AilError> {
-    // Reject reserved v0.3 fields that are accepted by serde but not yet implemented.
-    if step_dto.for_each.is_some() {
-        return Err(cfg_err!(
-            "Step '{id_str}' uses 'for_each' which is reserved for a future \
-             version and not yet implemented"
-        ));
-    }
-
     // When pipeline: is set, prompt: is treated as the child invocation override,
     // not a primary field — so don't count it in the primary field selector.
     let primary_count = [
@@ -34,6 +28,7 @@ pub(in crate::config) fn parse_step_body(
         step_dto.action.is_some(),
         step_dto.context.is_some(),
         step_dto.do_while.is_some(),
+        step_dto.for_each.is_some(),
     ]
     .iter()
     .filter(|&&b| b)
@@ -42,7 +37,7 @@ pub(in crate::config) fn parse_step_body(
     if primary_count != 1 {
         return Err(cfg_err!(
             "Step '{id_str}' must have exactly one primary field \
-             (prompt, skill, pipeline, action, context, or do_while); found {primary_count}"
+             (prompt, skill, pipeline, action, context, do_while, or for_each); found {primary_count}"
         ));
     }
 
@@ -104,6 +99,8 @@ pub(in crate::config) fn parse_step_body(
         }
     } else if step_dto.do_while.is_some() {
         parse_do_while_body(step_dto.do_while.take().unwrap(), id_str)
+    } else if step_dto.for_each.is_some() {
+        parse_for_each_body(step_dto.for_each.take().unwrap(), id_str)
     } else {
         unreachable!("primary_count == 1 enforced above")
     }
@@ -172,6 +169,88 @@ fn parse_do_while_body(
     Ok(StepBody::DoWhile {
         max_iterations,
         exit_when,
+        steps: inner_steps,
+    })
+}
+
+/// Parse a `for_each:` step body, validating all required fields (SPEC §28).
+///
+/// Takes ownership of the `ForEachDto` because the inner `steps` list
+/// is passed by value to `validate_steps`.
+fn parse_for_each_body(
+    fe: crate::config::dto::ForEachDto,
+    id_str: &str,
+) -> Result<StepBody, AilError> {
+    let over = fe.over.ok_or_else(|| {
+        cfg_err!(
+            "Step '{id_str}' declares for_each: but 'over' is missing; \
+             over is required and must reference a step's .items (SPEC §28)"
+        )
+    })?;
+
+    if over.trim().is_empty() {
+        return Err(cfg_err!(
+            "Step '{id_str}' declares for_each.over: but the value is empty"
+        ));
+    }
+
+    let as_name = fe.as_name.unwrap_or_else(|| "item".to_string());
+
+    // Validate `as` is a valid identifier.
+    if as_name.is_empty()
+        || as_name.starts_with(|c: char| c.is_ascii_digit())
+        || !as_name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return Err(cfg_err!(
+            "Step '{id_str}' declares for_each.as: '{as_name}' which is not a valid identifier \
+             (must be letters, digits, underscores; cannot start with a digit)"
+        ));
+    }
+
+    if let Some(max_items) = fe.max_items {
+        if max_items < 1 {
+            return Err(cfg_err!(
+                "Step '{id_str}' specifies for_each.max_items: 0; \
+                 max_items must be at least 1"
+            ));
+        }
+    }
+
+    let on_max_items = match fe.on_max_items.as_deref() {
+        None | Some("continue") => OnMaxItems::Continue,
+        Some("abort_pipeline") => OnMaxItems::AbortPipeline,
+        Some(other) => {
+            return Err(cfg_err!(
+                "Step '{id_str}' specifies unknown for_each.on_max_items value '{other}'; \
+                 supported values are 'continue' and 'abort_pipeline'"
+            ));
+        }
+    };
+
+    let step_dtos = fe.steps.ok_or_else(|| {
+        cfg_err!(
+            "Step '{id_str}' declares for_each: but 'steps' is missing; \
+             at least one inner step is required (SPEC §28)"
+        )
+    })?;
+
+    if step_dtos.is_empty() {
+        return Err(cfg_err!(
+            "Step '{id_str}' declares for_each: with an empty 'steps' array; \
+             at least one inner step is required (SPEC §28)"
+        ));
+    }
+
+    let context_label = format!("for_each step '{id_str}'");
+    let inner_steps = validate_steps(step_dtos, &context_label)?;
+
+    Ok(StepBody::ForEach {
+        over,
+        as_name,
+        max_items: fe.max_items,
+        on_max_items,
         steps: inner_steps,
     })
 }

--- a/ail-core/src/executor/core.rs
+++ b/ail-core/src/executor/core.rs
@@ -8,13 +8,13 @@
 #![allow(clippy::result_large_err)]
 
 use crate::config::domain::{
-    ActionKind, Condition, ConditionExpr, ContextSource, OnError, ResultAction, Step, StepBody,
-    StepId, MAX_LOOP_DEPTH,
+    ActionKind, Condition, ConditionExpr, ContextSource, OnError, OnMaxItems, ResultAction, Step,
+    StepBody, StepId, MAX_LOOP_DEPTH,
 };
 use crate::error::AilError;
 use crate::runner::{InvokeOptions, RunResult, Runner};
 use crate::session::turn_log::TurnEntry;
-use crate::session::{DoWhileContext, Session};
+use crate::session::{DoWhileContext, ForEachContext, Session};
 
 use super::dispatch;
 use super::events::ExecuteOutcome;
@@ -410,6 +410,25 @@ fn execute_single_step<O: StepObserver>(
                 &step_id,
                 *max_iterations,
                 exit_when,
+                inner_steps,
+                session,
+                runner,
+                observer,
+                depth,
+            ),
+
+            StepBody::ForEach {
+                ref over,
+                ref as_name,
+                max_items,
+                ref on_max_items,
+                steps: ref inner_steps,
+            } => execute_for_each(
+                &step_id,
+                over,
+                as_name,
+                *max_items,
+                on_max_items,
                 inner_steps,
                 session,
                 runner,
@@ -911,6 +930,314 @@ fn execute_do_while_inner<O: StepObserver>(
         prompt: format!("do_while(max_iterations={max_iterations})"),
         response,
         index: Some(index),
+        ..Default::default()
+    })
+}
+
+// ── for_each execution (SPEC §28) ───────────────────────────────────────────
+
+/// Exit reason for a for_each loop, used for logging and result reporting.
+enum ForEachExitReason {
+    /// All items processed.
+    Completed,
+    /// A `break` action fired inside the loop body.
+    Break,
+}
+
+/// Execute a `for_each:` loop body (SPEC §28).
+///
+/// Resolves the `over` template to get a JSON array, then runs `inner_steps`
+/// once per item. The current item is available via `{{ for_each.<as_name> }}`
+/// (or `{{ for_each.item }}`), along with `{{ for_each.index }}` and
+/// `{{ for_each.total }}`.
+///
+/// Returns a summary `TurnEntry` for the for_each step itself.
+#[allow(clippy::too_many_arguments)]
+fn execute_for_each<O: StepObserver>(
+    loop_step_id: &str,
+    over: &str,
+    as_name: &str,
+    max_items: Option<u64>,
+    on_max_items: &OnMaxItems,
+    inner_steps: &[Step],
+    session: &mut Session,
+    runner: &dyn Runner,
+    observer: &mut O,
+    depth: usize,
+) -> Result<TurnEntry, AilError> {
+    // Depth guard (shared with do_while — SPEC §27.9, §28).
+    if session.loop_depth >= MAX_LOOP_DEPTH {
+        return Err(AilError::LoopDepthExceeded {
+            detail: format!(
+                "Step '{loop_step_id}' would exceed the maximum loop nesting depth \
+                 of {MAX_LOOP_DEPTH}"
+            ),
+            context: Some(crate::error::ErrorContext::for_step(
+                &session.run_id,
+                loop_step_id,
+            )),
+        });
+    }
+
+    // Resolve the `over` template to get the JSON array string.
+    let resolved_over = crate::template::resolve(over, session)?;
+
+    // Parse the resolved string as a JSON array.
+    let items_value: serde_json::Value = serde_json::from_str(&resolved_over).map_err(|e| {
+        AilError::for_each_source_invalid(format!(
+            "Step '{loop_step_id}' for_each.over resolved to a value that is not valid JSON: {e}"
+        ))
+    })?;
+
+    let items = items_value.as_array().ok_or_else(|| {
+        AilError::for_each_source_invalid(format!(
+            "Step '{loop_step_id}' for_each.over resolved to JSON that is not an array"
+        ))
+    })?;
+
+    let raw_count = items.len() as u64;
+
+    // Apply max_items cap.
+    let effective_count = if let Some(cap) = max_items {
+        if raw_count > cap {
+            match on_max_items {
+                OnMaxItems::AbortPipeline => {
+                    return Err(AilError::PipelineAborted {
+                        detail: format!(
+                            "Step '{loop_step_id}' for_each array has {raw_count} items \
+                             but max_items is {cap} and on_max_items is abort_pipeline"
+                        ),
+                        context: Some(crate::error::ErrorContext::for_step(
+                            &session.run_id,
+                            loop_step_id,
+                        )),
+                    });
+                }
+                OnMaxItems::Continue => cap,
+            }
+        } else {
+            raw_count
+        }
+    } else {
+        raw_count
+    };
+
+    session
+        .turn_log
+        .record_step_started(loop_step_id, &format!("for_each(items={effective_count})"));
+
+    let result = execute_for_each_inner(
+        loop_step_id,
+        as_name,
+        items,
+        effective_count,
+        inner_steps,
+        session,
+        runner,
+        observer,
+        depth,
+    );
+
+    match &result {
+        Ok(_) => observer.on_non_prompt_completed(loop_step_id),
+        Err(e) => observer.on_step_failed(loop_step_id, e.detail()),
+    }
+    result
+}
+
+/// Inner for_each loop logic, separated so the caller can attach observer hooks.
+#[allow(clippy::too_many_arguments)]
+fn execute_for_each_inner<O: StepObserver>(
+    loop_step_id: &str,
+    as_name: &str,
+    items: &[serde_json::Value],
+    effective_count: u64,
+    inner_steps: &[Step],
+    session: &mut Session,
+    runner: &dyn Runner,
+    observer: &mut O,
+    depth: usize,
+) -> Result<TurnEntry, AilError> {
+    // Save and restore outer for_each context for nested loops.
+    let prev_context = session.for_each_context.take();
+    session.loop_depth += 1;
+
+    let prefix = format!("{loop_step_id}::");
+    let total_inner = inner_steps.len();
+    let mut items_processed: u64 = 0;
+    let mut exit_reason = ForEachExitReason::Completed;
+
+    for (item_idx, item) in items.iter().take(effective_count as usize).enumerate() {
+        let one_based_index = (item_idx as u64) + 1;
+
+        // Clear previous item's inner step entries (SPEC §28.3 point 4 — item scope).
+        session.turn_log.remove_entries_with_prefix(&prefix);
+
+        // Format item as a string for template substitution.
+        // String values are unquoted; other JSON types keep their JSON representation.
+        let item_str = match item {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+
+        // Set loop context for template variable resolution.
+        session.for_each_context = Some(ForEachContext {
+            loop_id: loop_step_id.to_string(),
+            index: one_based_index,
+            total: effective_count,
+            item: item_str,
+            as_name: as_name.to_string(),
+        });
+
+        tracing::info!(
+            run_id = %session.run_id,
+            step_id = %loop_step_id,
+            index = one_based_index,
+            total = effective_count,
+            "for_each item started"
+        );
+
+        // Execute each inner step with a namespaced ID.
+        let mut loop_broken = false;
+        for (inner_idx, inner_step) in inner_steps.iter().enumerate() {
+            let namespaced_id = format!("{}{}", prefix, inner_step.id.as_str());
+            let mut namespaced_step = inner_step.clone();
+            namespaced_step.id = StepId(namespaced_id.clone());
+
+            // Evaluate condition for the inner step.
+            let condition_skip = if let Some(ref cond) = namespaced_step.condition {
+                !evaluate_condition(cond, session, &namespaced_id)?
+            } else {
+                false
+            };
+
+            match observer.before_step(&namespaced_id, inner_idx, condition_skip) {
+                BeforeStepAction::Run => {}
+                BeforeStepAction::Skip => continue,
+                BeforeStepAction::Stop => {
+                    loop_broken = true;
+                    break;
+                }
+            }
+
+            tracing::info!(
+                run_id = %session.run_id,
+                step_id = %namespaced_id,
+                item_index = one_based_index,
+                "executing for_each inner step"
+            );
+
+            let matched_action = execute_single_step(
+                &namespaced_step,
+                session,
+                runner,
+                observer,
+                depth,
+                total_inner,
+                inner_idx,
+            )?;
+
+            // Handle on_result actions within the loop (SPEC §28.3 point 5).
+            // `break` exits the loop, not the pipeline.
+            if let Some(action) = matched_action {
+                match action {
+                    ResultAction::Continue => {}
+                    ResultAction::Break => {
+                        tracing::info!(
+                            run_id = %session.run_id,
+                            step_id = %loop_step_id,
+                            inner_step = %namespaced_id,
+                            item_index = one_based_index,
+                            "on_result break inside for_each — exiting loop"
+                        );
+                        loop_broken = true;
+                        break;
+                    }
+                    ResultAction::AbortPipeline => {
+                        session.loop_depth -= 1;
+                        session.for_each_context = prev_context;
+                        let err = AilError::PipelineAborted {
+                            detail: format!(
+                                "Step '{namespaced_id}' on_result fired abort_pipeline \
+                                 inside for_each loop '{loop_step_id}'"
+                            ),
+                            context: Some(crate::error::ErrorContext::for_step(
+                                &session.run_id,
+                                loop_step_id,
+                            )),
+                        };
+                        observer.on_pipeline_error(&err);
+                        return Err(err);
+                    }
+                    ResultAction::PauseForHuman => {
+                        observer.on_result_pause(&namespaced_id, None);
+                    }
+                    ResultAction::Pipeline {
+                        ref path,
+                        ref prompt,
+                    } => {
+                        let pipeline_base_dir_buf: Option<std::path::PathBuf> = session
+                            .pipeline
+                            .source
+                            .as_deref()
+                            .and_then(|p| p.parent())
+                            .map(|p| p.to_path_buf());
+                        let pipeline_base_dir = pipeline_base_dir_buf.as_deref();
+                        let on_result_step_id = format!("{namespaced_id}__on_result");
+                        let sub_entry = dispatch::sub_pipeline::execute_sub_pipeline(
+                            path,
+                            prompt.as_deref(),
+                            &on_result_step_id,
+                            session,
+                            runner,
+                            depth,
+                            pipeline_base_dir,
+                        )
+                        .inspect_err(|e| observer.on_pipeline_error(e))?;
+                        session.turn_log.append(sub_entry);
+                    }
+                }
+            }
+        }
+
+        items_processed += 1;
+
+        if loop_broken {
+            exit_reason = ForEachExitReason::Break;
+            break;
+        }
+    }
+
+    // Restore state.
+    session.loop_depth -= 1;
+    session.for_each_context = prev_context;
+
+    tracing::info!(
+        run_id = %session.run_id,
+        step_id = %loop_step_id,
+        items_processed,
+        exit_reason = match exit_reason {
+            ForEachExitReason::Completed => "completed",
+            ForEachExitReason::Break => "break",
+        },
+        "for_each completed"
+    );
+
+    // Build summary TurnEntry. Response is the last inner step's response from
+    // the final item.
+    let response = session
+        .turn_log
+        .entries()
+        .iter()
+        .rev()
+        .filter(|e| e.step_id.starts_with(&prefix))
+        .find_map(|e| e.response.as_deref())
+        .map(|s| s.to_string());
+
+    Ok(TurnEntry {
+        step_id: loop_step_id.to_string(),
+        prompt: format!("for_each(items={effective_count})"),
+        response,
         ..Default::default()
     })
 }

--- a/ail-core/src/materialize.rs
+++ b/ail-core/src/materialize.rs
@@ -1,6 +1,6 @@
 use crate::config::domain::{
-    ActionKind, ConditionExpr, ConditionOp, ContextSource, ExitCodeMatch, OnError, Pipeline,
-    ResultAction, ResultMatcher, Step, StepBody,
+    ActionKind, ConditionExpr, ConditionOp, ContextSource, ExitCodeMatch, OnError, OnMaxItems,
+    Pipeline, ResultAction, ResultMatcher, Step, StepBody,
 };
 
 /// Escape a string for use inside a YAML double-quoted scalar.
@@ -46,6 +46,17 @@ fn chain_step_summary(body: &StepBody) -> String {
         } => {
             format!(
                 "do_while: (max_iterations: {max_iterations}, {} inner steps)",
+                steps.len()
+            )
+        }
+        StepBody::ForEach {
+            ref over,
+            ref as_name,
+            steps,
+            ..
+        } => {
+            format!(
+                "for_each: (over: {over}, as: {as_name}, {} inner steps)",
                 steps.len()
             )
         }
@@ -157,6 +168,27 @@ pub fn materialize(pipeline: &Pipeline) -> String {
                     "      exit_when: \"{}\"\n",
                     yaml_quote(&format_condition_expr(exit_when))
                 ));
+                out.push_str("      steps:\n");
+                for inner in steps {
+                    serialize_step(&mut out, inner, "        ", None);
+                }
+            }
+            StepBody::ForEach {
+                ref over,
+                ref as_name,
+                max_items,
+                ref on_max_items,
+                ref steps,
+            } => {
+                out.push_str("    for_each:\n");
+                out.push_str(&format!("      over: \"{}\"\n", yaml_quote(over)));
+                out.push_str(&format!("      as: {as_name}\n"));
+                if let Some(cap) = max_items {
+                    out.push_str(&format!("      max_items: {cap}\n"));
+                    if *on_max_items == OnMaxItems::AbortPipeline {
+                        out.push_str("      on_max_items: abort_pipeline\n");
+                    }
+                }
                 out.push_str("      steps:\n");
                 for inner in steps {
                     serialize_step(&mut out, inner, "        ", None);
@@ -312,6 +344,28 @@ fn serialize_step(out: &mut String, step: &Step, indent: &str, origin_comment: O
                 "{field_indent}  exit_when: \"{}\"\n",
                 yaml_quote(&format_condition_expr(exit_when))
             ));
+            out.push_str(&format!("{field_indent}  steps:\n"));
+            let inner_indent = format!("{field_indent}    ");
+            for inner in steps {
+                serialize_step(out, inner, &inner_indent, None);
+            }
+        }
+        StepBody::ForEach {
+            ref over,
+            ref as_name,
+            max_items,
+            ref on_max_items,
+            ref steps,
+        } => {
+            out.push_str(&format!("{field_indent}for_each:\n"));
+            out.push_str(&format!("{field_indent}  over: \"{}\"\n", yaml_quote(over)));
+            out.push_str(&format!("{field_indent}  as: {as_name}\n"));
+            if let Some(cap) = max_items {
+                out.push_str(&format!("{field_indent}  max_items: {cap}\n"));
+                if *on_max_items == OnMaxItems::AbortPipeline {
+                    out.push_str(&format!("{field_indent}  on_max_items: abort_pipeline\n"));
+                }
+            }
             out.push_str(&format!("{field_indent}  steps:\n"));
             let inner_indent = format!("{field_indent}    ");
             for inner in steps {

--- a/ail-core/src/runner/stub.rs
+++ b/ail-core/src/runner/stub.rs
@@ -120,6 +120,36 @@ impl Runner for RecordingStubRunner {
     }
 }
 
+/// A stub runner that returns responses from a pre-configured sequence.
+/// Each invocation returns the next response in order. If the sequence
+/// is exhausted, returns a "sequence exhausted" error.
+pub struct SequenceStubRunner {
+    responses: std::sync::Mutex<Vec<String>>,
+}
+
+impl SequenceStubRunner {
+    pub fn new(responses: Vec<String>) -> Self {
+        // Reverse so we can pop from the back efficiently.
+        let mut reversed = responses;
+        reversed.reverse();
+        SequenceStubRunner {
+            responses: std::sync::Mutex::new(reversed),
+        }
+    }
+}
+
+impl Runner for SequenceStubRunner {
+    fn invoke(&self, _prompt: &str, _options: InvokeOptions) -> Result<RunResult, AilError> {
+        let response = self
+            .responses
+            .lock()
+            .expect("mutex not poisoned")
+            .pop()
+            .unwrap_or_else(|| "[SequenceStubRunner: sequence exhausted]".to_string());
+        Ok(RunResult::stub(response, "sequence-stub-session-id"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ail-core/src/session/mod.rs
+++ b/ail-core/src/session/mod.rs
@@ -7,5 +7,5 @@ pub use log_provider::{
     cwd_hash, project_dir, CompositeProvider, JsonlProvider, LogProvider, NullProvider,
 };
 pub use sqlite_provider::SqliteProvider;
-pub use state::{DoWhileContext, Session};
+pub use state::{DoWhileContext, ForEachContext, Session};
 pub use turn_log::{TurnEntry, TurnLog};

--- a/ail-core/src/session/state.rs
+++ b/ail-core/src/session/state.rs
@@ -23,6 +23,23 @@ pub struct DoWhileContext {
     pub max_iterations: u64,
 }
 
+/// Active for_each loop context, set during loop body execution (SPEC §28).
+/// Enables `{{ for_each.item }}` / `{{ for_each.<as_name> }}`, `{{ for_each.index }}`,
+/// and `{{ for_each.total }}` template variables.
+#[derive(Debug, Clone)]
+pub struct ForEachContext {
+    /// The for_each step's ID (used as the `<loop_id>::` namespace prefix).
+    pub loop_id: String,
+    /// Current 1-based item index.
+    pub index: u64,
+    /// Total number of items (after max_items cap).
+    pub total: u64,
+    /// The current item value as a JSON string.
+    pub item: String,
+    /// The declared `as` name (default: `item`).
+    pub as_name: String,
+}
+
 pub struct Session {
     pub run_id: String,
     pub pipeline: Pipeline,
@@ -47,8 +64,12 @@ pub struct Session {
     /// cleared after the loop exits. Enables `{{ do_while.* }}` template variables
     /// and namespaced step ID resolution.
     pub do_while_context: Option<DoWhileContext>,
-    /// Current nesting depth of do_while loops. Checked against `MAX_LOOP_DEPTH`
-    /// to prevent runaway resource consumption from deeply nested loops.
+    /// Active for_each loop context (SPEC §28). Set during loop body execution,
+    /// cleared after the loop exits. Enables `{{ for_each.* }}` template variables
+    /// and namespaced step ID resolution.
+    pub for_each_context: Option<ForEachContext>,
+    /// Current nesting depth of loop constructs (do_while, for_each). Checked against
+    /// `MAX_LOOP_DEPTH` to prevent runaway resource consumption from deeply nested loops.
     pub loop_depth: usize,
 }
 
@@ -93,6 +114,7 @@ impl Session {
             headless: false,
             http_session_store: Arc::new(Mutex::new(HashMap::new())),
             do_while_context: None,
+            for_each_context: None,
             loop_depth: 0,
         }
     }

--- a/ail-core/src/template.rs
+++ b/ail-core/src/template.rs
@@ -80,7 +80,44 @@ fn resolve_variable(variable: &str, session: &Session) -> Result<String, AilErro
                 )
             }),
 
+        "for_each.index" => session
+            .for_each_context
+            .as_ref()
+            .map(|ctx| ctx.index.to_string())
+            .ok_or_else(|| {
+                unresolved("'{{ for_each.index }}' is only available inside a for_each: body")
+            }),
+
+        "for_each.total" => session
+            .for_each_context
+            .as_ref()
+            .map(|ctx| ctx.total.to_string())
+            .ok_or_else(|| {
+                unresolved("'{{ for_each.total }}' is only available inside a for_each: body")
+            }),
+
         other => {
+            // `for_each.<as_name>` — dynamic item access by the declared `as:` name (SPEC §28.4).
+            if let Some(name) = other.strip_prefix("for_each.") {
+                return session
+                    .for_each_context
+                    .as_ref()
+                    .and_then(|ctx| {
+                        if name == ctx.as_name || name == "item" {
+                            Some(ctx.item.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or_else(|| {
+                        unresolved(format!(
+                            "'{{{{ for_each.{name} }}}}' is not available — \
+                             either not inside a for_each: body or '{name}' does not match \
+                             the declared 'as:' name"
+                        ))
+                    });
+            }
+
             // `step.<id>.<field>` — split on last dot to get step_id and field.
             if let Some(rest) = other.strip_prefix("step.") {
                 if let Some(dot) = rest.rfind('.') {
@@ -95,8 +132,19 @@ fn resolve_variable(variable: &str, session: &Session) -> Result<String, AilErro
                     if result.is_ok() {
                         return result;
                     }
+                    // Try namespaced form for do_while context.
                     if let Some(ref ctx) = session.do_while_context {
-                        // Only try namespacing if step_id doesn't already contain `::`
+                        if !step_id.contains("::") {
+                            let namespaced = format!("{}::{}", ctx.loop_id, step_id);
+                            let ns_result =
+                                resolve_step_field(session, &namespaced, field, variable);
+                            if ns_result.is_ok() {
+                                return ns_result;
+                            }
+                        }
+                    }
+                    // Try namespaced form for for_each context.
+                    if let Some(ref ctx) = session.for_each_context {
                         if !step_id.contains("::") {
                             let namespaced = format!("{}::{}", ctx.loop_id, step_id);
                             let ns_result =

--- a/ail-core/tests/spec/s26_output_schema.rs
+++ b/ail-core/tests/spec/s26_output_schema.rs
@@ -358,9 +358,9 @@ pipeline:
         assert!(err.detail().contains("category"));
     }
 
-    /// s26 -- for_each is still rejected as reserved.
+    /// s26 -- for_each is mutually exclusive with prompt (SPEC §28.2).
     #[test]
-    fn for_each_still_reserved() {
+    fn for_each_mutually_exclusive_with_prompt() {
         let yaml = r#"
 version: "0.1"
 pipeline:
@@ -368,11 +368,14 @@ pipeline:
     prompt: "do things"
     for_each:
       over: "{{ step.plan.items }}"
+      steps:
+        - id: inner
+          prompt: "do"
 "#;
         let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
         std::fs::write(tmp.path(), yaml).unwrap();
         let result = config::load(tmp.path());
-        assert!(result.is_err(), "for_each must still be rejected");
+        assert!(result.is_err(), "for_each + prompt must be rejected");
         let err = result.unwrap_err();
         assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
         assert!(err.detail().contains("for_each"));

--- a/ail-core/tests/spec/s28_for_each.rs
+++ b/ail-core/tests/spec/s28_for_each.rs
@@ -1,39 +1,762 @@
-/// SPEC §28 — for_each is a reserved field rejected at parse time
-/// until implementation is complete.
+/// SPEC §28 — for_each collection iteration.
 
-mod reserved_field_rejection {
+// ── Parse-time validation (valid configs) ───────────────────────────────────
+
+mod parse_valid {
     use ail_core::config;
-    use ail_core::error::error_types;
+    use ail_core::config::domain::{OnMaxItems, StepBody};
 
-    /// §28 — for_each is rejected with a clear "reserved" error.
+    /// §28.1 — minimal valid for_each with defaults.
     #[test]
-    fn for_each_rejected_as_reserved() {
+    fn minimal_for_each_parses() {
         let yaml = r#"
 version: "0.1"
 pipeline:
-  - id: process_items
+  - id: loop
     for_each:
-      over: "{{ step.planner.items }}"
-      as: task
+      over: "{{ step.plan.items }}"
       steps:
-        - id: implement
-          prompt: "implement {{ for_each.task }}"
+        - id: work
+          prompt: "do {{ for_each.item }}"
 "#;
         let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
         std::fs::write(tmp.path(), yaml).unwrap();
-        let result = config::load(tmp.path());
-        assert!(result.is_err(), "for_each must be rejected");
-        let err = result.unwrap_err();
+        let pipeline = config::load(tmp.path()).expect("should parse");
+        let step = &pipeline.steps[0];
+        match &step.body {
+            StepBody::ForEach {
+                over,
+                as_name,
+                max_items,
+                on_max_items,
+                steps,
+            } => {
+                assert_eq!(over, "{{ step.plan.items }}");
+                assert_eq!(as_name, "item"); // default
+                assert_eq!(*max_items, None);
+                assert_eq!(*on_max_items, OnMaxItems::Continue); // default
+                assert_eq!(steps.len(), 1);
+                assert_eq!(steps[0].id.as_str(), "work");
+            }
+            other => panic!("expected ForEach, got {other:?}"),
+        }
+    }
+
+    /// §28.2 — for_each with all optional fields set.
+    #[test]
+    fn for_each_with_all_options() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+      as: task
+      max_items: 10
+      on_max_items: abort_pipeline
+      steps:
+        - id: impl
+          prompt: "implement {{ for_each.task }}"
+        - id: verify
+          prompt: "verify {{ for_each.task }}"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let pipeline = config::load(tmp.path()).expect("should parse");
+        let step = &pipeline.steps[0];
+        match &step.body {
+            StepBody::ForEach {
+                as_name,
+                max_items,
+                on_max_items,
+                steps,
+                ..
+            } => {
+                assert_eq!(as_name, "task");
+                assert_eq!(*max_items, Some(10));
+                assert_eq!(*on_max_items, OnMaxItems::AbortPipeline);
+                assert_eq!(steps.len(), 2);
+            }
+            other => panic!("expected ForEach, got {other:?}"),
+        }
+    }
+
+    /// §28.2 — on_max_items: continue is the explicit form of the default.
+    #[test]
+    fn on_max_items_continue_explicit() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+      max_items: 5
+      on_max_items: continue
+      steps:
+        - id: work
+          prompt: "do it"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let pipeline = config::load(tmp.path()).expect("should parse");
+        match &pipeline.steps[0].body {
+            StepBody::ForEach { on_max_items, .. } => {
+                assert_eq!(*on_max_items, OnMaxItems::Continue);
+            }
+            other => panic!("expected ForEach, got {other:?}"),
+        }
+    }
+}
+
+// ── Parse-time validation (invalid configs) ─────────────────────────────────
+
+mod parse_invalid {
+    use ail_core::config;
+    use ail_core::error::error_types;
+
+    /// §28.7 rule 1 — missing `over` is an error.
+    #[test]
+    fn missing_over() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      steps:
+        - id: work
+          prompt: "do it"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(err.detail().contains("over"), "got: {}", err.detail());
+    }
+
+    /// §28.7 rule 1 — missing `steps` is an error.
+    #[test]
+    fn missing_steps() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(err.detail().contains("steps"), "got: {}", err.detail());
+    }
+
+    /// §28.7 rule 1 — empty `steps` array is an error.
+    #[test]
+    fn empty_steps() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+      steps: []
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
         assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
         assert!(
-            err.detail().contains("for_each"),
-            "Error should mention the field name, got: {}",
+            err.detail().contains("empty"),
+            "should mention empty, got: {}",
             err.detail()
+        );
+    }
+
+    /// §28.7 rule 3 — for_each is mutually exclusive with prompt.
+    #[test]
+    fn mutually_exclusive_with_prompt() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    prompt: "hello"
+    for_each:
+      over: "{{ step.plan.items }}"
+      steps:
+        - id: work
+          prompt: "do it"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("primary field"),
+            "got: {}",
+            err.detail()
+        );
+    }
+
+    /// §28.7 rule 4 — invalid `as` identifier (starts with digit).
+    #[test]
+    fn invalid_as_identifier() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+      as: "1bad"
+      steps:
+        - id: work
+          prompt: "do it"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(err.detail().contains("identifier"), "got: {}", err.detail());
+    }
+
+    /// §28.7 rule 5 — max_items: 0 is an error.
+    #[test]
+    fn max_items_zero() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+      max_items: 0
+      steps:
+        - id: work
+          prompt: "do it"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(err.detail().contains("max_items"), "got: {}", err.detail());
+    }
+
+    /// §28.7 rule 6 — unknown on_max_items value is an error.
+    #[test]
+    fn unknown_on_max_items() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+      on_max_items: "skip"
+      steps:
+        - id: work
+          prompt: "do it"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("on_max_items"),
+            "got: {}",
+            err.detail()
+        );
+    }
+
+    /// §28.7 rule 7 — duplicate inner step IDs are rejected.
+    #[test]
+    fn duplicate_inner_step_ids() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+      steps:
+        - id: work
+          prompt: "first"
+        - id: work
+          prompt: "duplicate"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("work"),
+            "should mention duplicate id, got: {}",
+            err.detail()
+        );
+    }
+}
+
+// ── Executor tests ──────────────────────────────────────────────────────────
+
+mod executor {
+    use ail_core::config::domain::{OnMaxItems, Step, StepBody, StepId};
+    use ail_core::error::error_types;
+    use ail_core::test_helpers::{make_session, prompt_step};
+
+    fn for_each_step(id: &str, over: &str, as_name: &str, inner: Vec<Step>) -> Step {
+        Step {
+            id: StepId(id.to_string()),
+            body: StepBody::ForEach {
+                over: over.to_string(),
+                as_name: as_name.to_string(),
+                max_items: None,
+                on_max_items: OnMaxItems::Continue,
+                steps: inner,
+            },
+            ..Default::default()
+        }
+    }
+
+    /// §28.3 — for_each iterates over all items in the array.
+    #[test]
+    fn iterates_over_all_items() {
+        // Set up: a prior step whose response is a JSON array.
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = for_each_step(
+            "loop",
+            "{{ step.plan.items }}",
+            "task",
+            vec![prompt_step("work", "do {{ for_each.task }}")],
+        );
+        let array_runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"["alpha", "beta", "gamma"]"#.to_string(),
+            "done-alpha".to_string(),
+            "done-beta".to_string(),
+            "done-gamma".to_string(),
+        ]);
+        let mut session = make_session(vec![plan, fe]);
+        let result = ail_core::executor::execute(&mut session, &array_runner);
+        assert!(result.is_ok(), "execution should succeed: {result:?}");
+
+        // The plan step should have produced a JSON array response.
+        let plan_resp = session.turn_log.response_for_step("plan").unwrap();
+        assert_eq!(plan_resp, r#"["alpha", "beta", "gamma"]"#);
+
+        // The loop step summary should be in the turn log.
+        let loop_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "loop")
+            .expect("loop step entry should exist");
+        assert!(loop_entry.prompt.contains("for_each"));
+    }
+
+    /// §28.3 point 5 — break exits the loop, not the pipeline.
+    #[test]
+    fn break_exits_loop_not_pipeline() {
+        use ail_core::config::domain::{ResultAction, ResultBranch, ResultMatcher};
+
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let mut inner = prompt_step("work", "do it");
+        inner.on_result = Some(vec![ResultBranch {
+            matcher: ResultMatcher::Always,
+            action: ResultAction::Break,
+        }]);
+        let fe = for_each_step("loop", "{{ step.plan.items }}", "item", vec![inner]);
+        // Add a step after the loop to verify the pipeline continues.
+        let after = prompt_step("after", "final");
+
+        let array_runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"["a", "b", "c"]"#.to_string(),
+            "first-item-response".to_string(),
+            "after-response".to_string(),
+        ]);
+        let mut session = make_session(vec![plan, fe, after]);
+        let result = ail_core::executor::execute(&mut session, &array_runner);
+        assert!(result.is_ok(), "pipeline should complete: {result:?}");
+
+        // The "after" step should have executed (break exits the loop, not the pipeline).
+        assert!(
+            session.turn_log.response_for_step("after").is_some(),
+            "step after the loop should have executed"
+        );
+    }
+
+    /// §28.2 — max_items caps the number of items processed.
+    #[test]
+    fn max_items_caps_processing() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = Step {
+            id: StepId("loop".to_string()),
+            body: StepBody::ForEach {
+                over: "{{ step.plan.items }}".to_string(),
+                as_name: "item".to_string(),
+                max_items: Some(2),
+                on_max_items: OnMaxItems::Continue,
+                steps: vec![prompt_step("work", "do {{ for_each.item }}")],
+            },
+            ..Default::default()
+        };
+
+        let array_runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"["a", "b", "c", "d"]"#.to_string(),
+            "done-a".to_string(),
+            "done-b".to_string(),
+        ]);
+        let mut session = make_session(vec![plan, fe]);
+        let result = ail_core::executor::execute(&mut session, &array_runner);
+        assert!(result.is_ok(), "execution should succeed: {result:?}");
+
+        // Only 2 items should have been processed (runner called twice for inner steps).
+        // The loop summary entry should reflect this.
+        let loop_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "loop")
+            .expect("loop entry");
+        assert!(loop_entry.prompt.contains("items=2"));
+    }
+
+    /// §28.2 — on_max_items: abort_pipeline aborts when array exceeds max_items.
+    #[test]
+    fn on_max_items_abort_pipeline() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = Step {
+            id: StepId("loop".to_string()),
+            body: StepBody::ForEach {
+                over: "{{ step.plan.items }}".to_string(),
+                as_name: "item".to_string(),
+                max_items: Some(2),
+                on_max_items: OnMaxItems::AbortPipeline,
+                steps: vec![prompt_step("work", "do it")],
+            },
+            ..Default::default()
+        };
+
+        let array_runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"["a", "b", "c"]"#.to_string(), // 3 items, cap is 2
+        ]);
+        let mut session = make_session(vec![plan, fe]);
+        let result = ail_core::executor::execute(&mut session, &array_runner);
+        assert!(result.is_err(), "should abort");
+        let err = result.unwrap_err();
+        assert_eq!(err.error_type(), error_types::PIPELINE_ABORTED);
+        assert!(err.detail().contains("max_items"), "got: {}", err.detail());
+    }
+
+    /// §28.3 — for_each with a non-array source produces a template error
+    /// (the .items accessor in template resolution rejects non-arrays).
+    #[test]
+    fn non_array_source_errors() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = for_each_step(
+            "loop",
+            "{{ step.plan.items }}",
+            "item",
+            vec![prompt_step("work", "do it")],
+        );
+
+        let runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"{"not": "an array"}"#.to_string(),
+        ]);
+        let mut session = make_session(vec![plan, fe]);
+        let result = ail_core::executor::execute(&mut session, &runner);
+        assert!(result.is_err(), "should fail");
+        let err = result.unwrap_err();
+        // The .items template accessor catches non-arrays before for_each runs.
+        assert_eq!(err.error_type(), error_types::TEMPLATE_UNRESOLVED);
+    }
+
+    /// §28.3 — for_each with non-JSON source produces a template error
+    /// (the .items accessor in template resolution rejects non-JSON).
+    #[test]
+    fn non_json_source_errors() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = for_each_step(
+            "loop",
+            "{{ step.plan.items }}",
+            "item",
+            vec![prompt_step("work", "do it")],
+        );
+
+        let runner =
+            ail_core::runner::stub::SequenceStubRunner::new(vec!["not json at all".to_string()]);
+        let mut session = make_session(vec![plan, fe]);
+        let result = ail_core::executor::execute(&mut session, &runner);
+        assert!(result.is_err(), "should fail");
+        let err = result.unwrap_err();
+        // The .items template accessor catches non-JSON before for_each runs.
+        assert_eq!(err.error_type(), error_types::TEMPLATE_UNRESOLVED);
+    }
+
+    /// §28.3 — empty array produces no iterations and completes cleanly.
+    #[test]
+    fn empty_array_completes() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = for_each_step(
+            "loop",
+            "{{ step.plan.items }}",
+            "item",
+            vec![prompt_step("work", "do it")],
+        );
+
+        let runner = ail_core::runner::stub::SequenceStubRunner::new(vec!["[]".to_string()]);
+        let mut session = make_session(vec![plan, fe]);
+        let result = ail_core::executor::execute(&mut session, &runner);
+        assert!(result.is_ok(), "empty array should succeed: {result:?}");
+    }
+
+    /// §28.3 point 2 — for_each step IDs are namespaced.
+    #[test]
+    fn inner_steps_are_namespaced() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = for_each_step(
+            "loop",
+            "{{ step.plan.items }}",
+            "item",
+            vec![prompt_step("work", "do it")],
+        );
+
+        let runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"["x"]"#.to_string(),
+            "done".to_string(),
+        ]);
+        let mut session = make_session(vec![plan, fe]);
+        ail_core::executor::execute(&mut session, &runner).unwrap();
+
+        // The inner step should appear with a namespaced ID.
+        let has_namespaced = session
+            .turn_log
+            .entries()
+            .iter()
+            .any(|e| e.step_id == "loop::work");
+        assert!(
+            has_namespaced,
+            "inner step should be namespaced as loop::work"
+        );
+    }
+}
+
+// ── Template variable tests ─────────────────────────────────────────────────
+
+mod template {
+    use ail_core::config::domain::{OnMaxItems, Step, StepBody, StepId};
+    use ail_core::test_helpers::{make_session, prompt_step};
+
+    fn for_each_step(id: &str, over: &str, as_name: &str, inner: Vec<Step>) -> Step {
+        Step {
+            id: StepId(id.to_string()),
+            body: StepBody::ForEach {
+                over: over.to_string(),
+                as_name: as_name.to_string(),
+                max_items: None,
+                on_max_items: OnMaxItems::Continue,
+                steps: inner,
+            },
+            ..Default::default()
+        }
+    }
+
+    /// §28.4 — for_each.index is 1-based.
+    #[test]
+    fn for_each_index_is_one_based() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = for_each_step(
+            "loop",
+            "{{ step.plan.items }}",
+            "item",
+            vec![prompt_step("work", "index={{ for_each.index }}")],
+        );
+
+        // The inner step prompt will contain the resolved index.
+        // SequenceStubRunner echoes prompts if we run out of items, but let's use
+        // a runner that returns fixed responses. The prompt itself is what we care about.
+        let runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"["a", "b"]"#.to_string(),
+            "resp1".to_string(),
+            "resp2".to_string(),
+        ]);
+        let mut session = make_session(vec![plan, fe]);
+        ail_core::executor::execute(&mut session, &runner).unwrap();
+
+        // The last inner step entry should have been for the second item (index=2).
+        // Due to item scope (entries cleared between items), only the last item's
+        // entries remain. Check the prompt of the remaining entry.
+        let work_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "loop::work")
+            .expect("should find work entry");
+        assert!(
+            work_entry.prompt.contains("index=2"),
+            "last item should have index=2, got prompt: {}",
+            work_entry.prompt
+        );
+    }
+
+    /// §28.4 — for_each.total reflects the collection size.
+    #[test]
+    fn for_each_total() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = for_each_step(
+            "loop",
+            "{{ step.plan.items }}",
+            "item",
+            vec![prompt_step("work", "total={{ for_each.total }}")],
+        );
+
+        let runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"["a", "b", "c"]"#.to_string(),
+            "r1".to_string(),
+            "r2".to_string(),
+            "r3".to_string(),
+        ]);
+        let mut session = make_session(vec![plan, fe]);
+        ail_core::executor::execute(&mut session, &runner).unwrap();
+
+        let work_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "loop::work")
+            .expect("should find work entry");
+        assert!(
+            work_entry.prompt.contains("total=3"),
+            "total should be 3, got prompt: {}",
+            work_entry.prompt
+        );
+    }
+
+    /// §28.4 — for_each.<as_name> resolves to the current item value.
+    #[test]
+    fn for_each_custom_as_name() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = for_each_step(
+            "loop",
+            "{{ step.plan.items }}",
+            "task",
+            vec![prompt_step("work", "do: {{ for_each.task }}")],
+        );
+
+        let runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"["build it"]"#.to_string(),
+            "done".to_string(),
+        ]);
+        let mut session = make_session(vec![plan, fe]);
+        ail_core::executor::execute(&mut session, &runner).unwrap();
+
+        let work_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "loop::work")
+            .expect("should find work entry");
+        assert!(
+            work_entry.prompt.contains("do: build it"),
+            "item should resolve by as name, got prompt: {}",
+            work_entry.prompt
+        );
+    }
+
+    /// §28.4 — for_each.item always works (even when as: is set to something else).
+    #[test]
+    fn for_each_item_always_available() {
+        let plan = prompt_step("plan", "{{ step.invocation.prompt }}");
+        let fe = for_each_step(
+            "loop",
+            "{{ step.plan.items }}",
+            "task",
+            vec![prompt_step("work", "item={{ for_each.item }}")],
+        );
+
+        let runner = ail_core::runner::stub::SequenceStubRunner::new(vec![
+            r#"["hello"]"#.to_string(),
+            "done".to_string(),
+        ]);
+        let mut session = make_session(vec![plan, fe]);
+        ail_core::executor::execute(&mut session, &runner).unwrap();
+
+        let work_entry = session
+            .turn_log
+            .entries()
+            .iter()
+            .find(|e| e.step_id == "loop::work")
+            .expect("should find work entry");
+        assert!(
+            work_entry.prompt.contains("item=hello"),
+            "for_each.item should always work, got prompt: {}",
+            work_entry.prompt
+        );
+    }
+
+    /// §28.4 — for_each.* variables are not available outside the loop.
+    #[test]
+    fn for_each_vars_unavailable_outside_loop() {
+        let step = prompt_step("test", "{{ for_each.index }}");
+        let mut session = make_session(vec![step]);
+        let runner = ail_core::runner::stub::CountingStubRunner::new("unused");
+        let result = ail_core::executor::execute(&mut session, &runner);
+        assert!(result.is_err(), "should fail outside loop");
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.error_type(),
+            ail_core::error::error_types::TEMPLATE_UNRESOLVED
+        );
+    }
+}
+
+// ── Materialize tests ───────────────────────────────────────────────────────
+
+mod materialize {
+    use ail_core::config::domain::{OnMaxItems, Pipeline, ProviderConfig, Step, StepBody, StepId};
+    use std::path::PathBuf;
+
+    #[test]
+    fn for_each_appears_in_materialize_output() {
+        let pipeline = Pipeline {
+            steps: vec![Step {
+                id: StepId("loop".to_string()),
+                body: StepBody::ForEach {
+                    over: "{{ step.plan.items }}".to_string(),
+                    as_name: "task".to_string(),
+                    max_items: Some(10),
+                    on_max_items: OnMaxItems::AbortPipeline,
+                    steps: vec![Step {
+                        id: StepId("work".to_string()),
+                        body: StepBody::Prompt("do it".to_string()),
+                        ..Default::default()
+                    }],
+                },
+                ..Default::default()
+            }],
+            source: Some(PathBuf::from("test.ail.yaml")),
+            defaults: ProviderConfig::default(),
+            timeout_seconds: None,
+            default_tools: None,
+            named_pipelines: Default::default(),
+        };
+        let output = ail_core::materialize::materialize(&pipeline);
+        assert!(output.contains("for_each:"), "for_each: key missing");
+        assert!(
+            output.contains("over:"),
+            "over: key missing in output: {output}"
         );
         assert!(
-            err.detail().contains("reserved"),
-            "Error should mention 'reserved', got: {}",
-            err.detail()
+            output.contains("step.plan.items"),
+            "over value missing in output: {output}"
         );
+        assert!(output.contains("as: task"), "as: key missing: {output}");
+        assert!(
+            output.contains("max_items: 10"),
+            "max_items missing: {output}"
+        );
+        assert!(
+            output.contains("abort_pipeline"),
+            "on_max_items missing: {output}"
+        );
+        assert!(output.contains("steps:"), "steps: key missing: {output}");
+        assert!(output.contains("work"), "inner step missing: {output}");
+
+        // Should be valid YAML.
+        let result: Result<serde_yaml::Value, _> = serde_yaml::from_str(&output);
+        assert!(result.is_ok(), "Output was not valid YAML: {output}");
     }
 }

--- a/ail/src/dry_run.rs
+++ b/ail/src/dry_run.rs
@@ -60,6 +60,7 @@ pub fn run_dry_run(session: &mut ail_core::session::Session, runner: &dyn Runner
                 ail_core::config::domain::ContextSource::Shell(_),
             ) => "context:shell",
             ail_core::config::domain::StepBody::DoWhile { .. } => "do_while",
+            ail_core::config::domain::StepBody::ForEach { .. } => "for_each",
         };
 
         let condition_note = match &step.condition {
@@ -134,6 +135,25 @@ pub fn run_dry_run(session: &mut ail_core::session::Session, runner: &dyn Runner
                     format_condition_op(&exit_when.op),
                     exit_when.rhs
                 );
+                for (j, inner) in steps.iter().enumerate() {
+                    println!("    Inner step {}: {}", j + 1, inner.id.as_str());
+                }
+            }
+            ail_core::config::domain::StepBody::ForEach {
+                over,
+                as_name,
+                max_items,
+                steps,
+                ..
+            } => {
+                println!(
+                    "  for_each: over={over}, as={as_name}, {} inner step{}",
+                    steps.len(),
+                    if steps.len() == 1 { "" } else { "s" }
+                );
+                if let Some(cap) = max_items {
+                    println!("  max_items: {cap}");
+                }
                 for (j, inner) in steps.iter().enumerate() {
                     println!("    Inner step {}: {}", j + 1, inner.id.as_str());
                 }

--- a/spec/README.md
+++ b/spec/README.md
@@ -50,7 +50,7 @@ The AIL Pipeline Language Specification — for pipeline authors and implementer
 | [s24-log-command.md](core/s24-log-command.md) | §24–25 The `ail log` and `ail logs` Commands | §24: single-run inspection; `--format` and `--follow` flags; exit codes; project scoping. §25: multi-session listing; `--session`, `--query`, `--tail`, `--limit`, `--format`; FTS search; JSON output schema | **alpha** — both commands fully documented |
 | [s26-output-schema.md](core/s26-output-schema.md) | §26 Structured Step I/O Schemas | `output_schema` / `input_schema`; JSON Schema compliance (`$schema` field selects draft, defaults to Draft 7); file-path or inline block; parse-time compatibility check; `field:` + `equals:` in `on_result`; array access via `{{ step.<id>.items }}`; provider compatibility | **draft** |
 | [s27-do-while.md](core/s27-do-while.md) | §27 `do_while:` — Bounded Repeat-Until | Bounded generate→test→fix loop; `max_iterations` (required), `exit_when` (§12.2 syntax), `on_max_iterations`; step namespacing (`<loop_id>::<step_id>`); iteration scope; turn log events; executor events | **draft** |
-| [s28-for-each.md](core/s28-for-each.md) | §28 `for_each:` — Collection Iteration | Map steps over a validated array from a prior `output_schema: type: array` step; `over`, `as`, `max_items`, `on_max_items`; plan-execution pattern; requires §26 | **draft** |
+| [s28-for-each.md](core/s28-for-each.md) | §28 `for_each:` — Collection Iteration | Map steps over a validated array from a prior `output_schema: type: array` step; `over`, `as`, `max_items`, `on_max_items`; plan-execution pattern; requires §26 | **v0.3** |
 
 ---
 

--- a/spec/core/s28-for-each.md
+++ b/spec/core/s28-for-each.md
@@ -1,6 +1,6 @@
 ## 28. `for_each:` — Collection Iteration
 
-> **Implementation status:** Planned — v0.3 target (requires `output_schema` §26). `for_each:` is a reserved primary field. The parser will reject it with `CONFIG_VALIDATION_FAILED` until implementation is complete.
+> **Implementation status:** Fully implemented. `for_each:` — parse-time validation (`over`, `as`, `max_items`, `on_max_items`, `steps`), runtime array iteration with item scope, `{{ for_each.item }}` / `{{ for_each.<as_name> }}` / `{{ for_each.index }}` / `{{ for_each.total }}` template variables, `break` exits loop not pipeline, `max_items` cap with `on_max_items` behavior, step ID namespacing (`<loop_id>::<step_id>`), shared depth guard with `do_while:`. Controlled-mode executor events (§28.6) are deferred.
 
 A `for_each:` step runs a fixed set of inner steps once per item in a validated array produced by a prior step. Where `do_while:` (§27) repeats until a condition is met, `for_each:` maps a sub-pipeline across a known collection — the plan-execution pattern: generate a list of tasks, then implement each one.
 


### PR DESCRIPTION
## Summary

- Implement `for_each:` as a primary step body that iterates inner steps over a validated JSON array from a prior step's `output_schema: type: array` — completing the plan-execution pattern alongside `do_while:`
- Full parse-time validation (`over`, `as`, `max_items`, `on_max_items`, `steps`/`pipeline`), runtime array iteration with item scope, template variables (`{{ for_each.item }}`, `{{ for_each.<as_name> }}`, `{{ for_each.index }}`, `{{ for_each.total }}`), `break` exits loop not pipeline, `max_items` cap with `on_max_items` behavior, step ID namespacing (`<loop_id>::<step_id>`), shared depth guard with `do_while:`
- Both `for_each:` and `do_while:` now accept `pipeline: ./path.ail.yaml` as an alternative to inline `steps:` — the referenced file's steps become the loop body
- Fixed spec inconsistency: §28 `steps:` was shown as a sibling of `for_each:` but is now correctly nested inside the block (matching `do_while:` and the implementation)
- 32 new tests, 454 total passing

## Changes

| Area | Files | What |
|------|-------|------|
| DTO | `dto.rs` | `ForEachDto` struct; `pipeline` field on both `ForEachDto` and `DoWhileDto` |
| Domain | `domain.rs` | `StepBody::ForEach` variant, `OnMaxItems` enum |
| Session | `state.rs`, `mod.rs` | `ForEachContext` struct, `for_each_context` field |
| Validation | `step_body.rs` | `parse_for_each_body()`, `load_loop_pipeline_steps()`, `resolve_loop_pipeline_path()` — shared pipeline-file loading for both loop types |
| Validation | `mod.rs` | `pipeline_source` path threaded through validation chain for relative path resolution |
| Template | `template.rs` | `for_each.*` variable resolution + namespaced step refs |
| Executor | `core.rs` | `execute_for_each()` — depth guard, array resolution, item scope, break/abort |
| Materialize | `materialize.rs` | ForEach serialization in all render paths |
| Dry run | `dry_run.rs` | ForEach display case |
| Test infra | `stub.rs` | `SequenceStubRunner` for multi-response test sequences |
| Tests | `s28_for_each.rs` | 32 tests: parse (3+8), executor (8), template (5), materialize (1), pipeline-as-file (7) |
| Spec | `s27-do-while.md`, `s28-for-each.md`, `README.md` | Updated implementation status, fixed nesting, added pipeline: alternative |
| Docs | `CLAUDE.md`, `ail-core/CLAUDE.md` | Updated key types, module descriptions, template variable table |

## Test plan

- [x] All 454 tests pass (32 new)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Parse-time: valid configs parse correctly, invalid configs rejected with proper errors
- [x] Executor: iterates all items, break exits loop not pipeline, max_items caps, on_max_items aborts, non-array/non-JSON sources error, empty array completes, inner steps namespaced
- [x] Templates: index is 1-based, total reflects collection size, custom as name works, for_each.item always available, variables unavailable outside loop
- [x] Pipeline-as-file: for_each and do_while load steps from external pipeline files, relative paths resolve, mutual exclusivity enforced, missing file errors
- [x] Materialize: ForEach renders valid YAML with all fields

https://claude.ai/code/session_01PaaBU3rHSK6Vf8VpPTQYAH