### PR TITLE
feat: add pipeline: as alternative to inline steps in for_each and do_while

### DIFF
--- a/ail-core/CLAUDE.md
+++ b/ail-core/CLAUDE.md
@@ -11,7 +11,7 @@ Consumed by `ail` (the binary) and future language-server / SDK targets.
 | `config/dto.rs` | Serde-deserialised raw structs — derives `Deserialize` |
 | `config/domain.rs` | Validated domain types — no `Deserialize` derives |
 | `config/validation/mod.rs` | `validate()` entry point, `cfg_err!` macro, `tools_to_policy` helper |
-| `config/validation/step_body.rs` | `parse_step_body()` — primary field count check + body construction (including `parse_do_while_body`, `parse_for_each_body`) |
+| `config/validation/step_body.rs` | `parse_step_body()` — primary field count check + body construction (including `parse_do_while_body`, `parse_for_each_body`, `load_loop_pipeline_steps`) |
 | `config/validation/on_result.rs` | `parse_result_branches()` — DTO → domain for result matchers and actions |
 | `config/validation/system_prompt.rs` | `parse_append_system_prompt()` — DTO → domain for system prompt entries |
 | `config/inheritance.rs` | FROM inheritance — path resolution, cycle detection, DTO merging, hook operations (SPEC §7, §8) |

--- a/ail-core/src/config/dto.rs
+++ b/ail-core/src/config/dto.rs
@@ -125,8 +125,11 @@ pub struct DoWhileDto {
     pub max_iterations: Option<u64>,
     /// Condition expression evaluated after each iteration; loop exits when true.
     pub exit_when: Option<String>,
-    /// Inner steps executed each iteration.
+    /// Inner steps executed each iteration. Mutually exclusive with `pipeline`.
     pub steps: Option<Vec<StepDto>>,
+    /// Path to an external pipeline file whose steps become the loop body (SPEC §27.2).
+    /// Mutually exclusive with `steps`.
+    pub pipeline: Option<String>,
 }
 
 /// DTO for `for_each:` collection iteration (SPEC §28).
@@ -141,8 +144,11 @@ pub struct ForEachDto {
     pub max_items: Option<u64>,
     /// What happens when the array contains more items than `max_items`.
     pub on_max_items: Option<String>,
-    /// Inner steps executed once per item.
+    /// Inner steps executed once per item. Mutually exclusive with `pipeline`.
     pub steps: Option<Vec<StepDto>>,
+    /// Path to an external pipeline file whose steps become the loop body (SPEC §28.2).
+    /// Mutually exclusive with `steps`.
+    pub pipeline: Option<String>,
 }
 
 /// `on_result:` accepts two shapes (SPEC §5.4, §26.4):

--- a/ail-core/src/config/validation/mod.rs
+++ b/ail-core/src/config/validation/mod.rs
@@ -169,9 +169,12 @@ fn strip_quotes(s: &str) -> &str {
 /// Validate a list of step DTOs into domain `Step`s.
 /// `context_label` is used in error messages to indicate where these steps come from
 /// (e.g. "pipeline" or "named pipeline 'security_gates'").
+/// `pipeline_source` is the path of the pipeline file being validated — used to
+/// resolve relative file paths (e.g. `for_each.pipeline`, `do_while.pipeline`).
 pub(in crate::config) fn validate_steps(
     step_dtos: Vec<StepDto>,
     context_label: &str,
+    pipeline_source: &std::path::Path,
 ) -> Result<Vec<Step>, AilError> {
     let mut seen_ids: HashSet<String> = HashSet::new();
     let mut steps: Vec<Step> = Vec::with_capacity(step_dtos.len());
@@ -221,7 +224,7 @@ pub(in crate::config) fn validate_steps(
             ));
         }
 
-        let body = step_body::parse_step_body(&mut step_dto, &id_str)?;
+        let body = step_body::parse_step_body(&mut step_dto, &id_str, pipeline_source)?;
 
         // Validate input_schema is a valid JSON Schema if present (SPEC §26.2).
         let input_schema = if let Some(ref schema) = step_dto.input_schema {
@@ -303,8 +306,8 @@ pub(in crate::config) fn validate_steps(
             ));
         }
 
-        let before = parse_chain_steps(step_dto.before, &id_str, "before")?;
-        let then = parse_chain_steps(step_dto.then, &id_str, "then")?;
+        let before = parse_chain_steps(step_dto.before, &id_str, "before", pipeline_source)?;
+        let then = parse_chain_steps(step_dto.then, &id_str, "then", pipeline_source)?;
 
         // Validate output_schema is a valid JSON Schema if present (SPEC §26).
         let output_schema = if let Some(ref schema) = step_dto.output_schema {
@@ -488,6 +491,7 @@ fn parse_chain_step(
     parent_id: &str,
     chain_kind: &str,
     index: usize,
+    pipeline_source: &std::path::Path,
 ) -> Result<Step, AilError> {
     let auto_id = format!("{parent_id}::{chain_kind}::{index}");
 
@@ -516,7 +520,7 @@ fn parse_chain_step(
             })
         }
         ChainStepDto::Full(mut step_dto) => {
-            let body = step_body::parse_step_body(&mut step_dto, &auto_id)?;
+            let body = step_body::parse_step_body(&mut step_dto, &auto_id, pipeline_source)?;
 
             let input_schema = step_dto.input_schema.take();
             let on_result_branches = step_dto
@@ -530,8 +534,8 @@ fn parse_chain_step(
                 .transpose()?;
 
             // Recursively parse nested before/then chains.
-            let before = parse_chain_steps(step_dto.before, &auto_id, "before")?;
-            let then = parse_chain_steps(step_dto.then, &auto_id, "then")?;
+            let before = parse_chain_steps(step_dto.before, &auto_id, "before", pipeline_source)?;
+            let then = parse_chain_steps(step_dto.then, &auto_id, "then", pipeline_source)?;
 
             Ok(Step {
                 id: StepId(auto_id),
@@ -560,13 +564,14 @@ fn parse_chain_steps(
     entries: Option<Vec<ChainStepDto>>,
     parent_id: &str,
     chain_kind: &str,
+    pipeline_source: &std::path::Path,
 ) -> Result<Vec<Step>, AilError> {
     match entries {
         None => Ok(vec![]),
         Some(entries) => entries
             .into_iter()
             .enumerate()
-            .map(|(i, entry)| parse_chain_step(entry, parent_id, chain_kind, i))
+            .map(|(i, entry)| parse_chain_step(entry, parent_id, chain_kind, i, pipeline_source))
             .collect(),
     }
 }
@@ -632,7 +637,7 @@ pub fn validate(dto: PipelineFileDto, source: PathBuf) -> Result<Pipeline, AilEr
         }
     }
 
-    let mut steps = validate_steps(step_dtos, "pipeline")?;
+    let mut steps = validate_steps(step_dtos, "pipeline", &source)?;
 
     // ── Validate named pipelines (SPEC §10) ─────────────────────────────────
     let mut named_pipelines = if let Some(named_dtos) = dto.pipelines {
@@ -647,7 +652,7 @@ pub fn validate(dto: PipelineFileDto, source: PathBuf) -> Result<Pipeline, AilEr
                 ));
             }
             let label = format!("named pipeline '{name}'");
-            let np_steps = validate_steps(np_step_dtos, &label)?;
+            let np_steps = validate_steps(np_step_dtos, &label, &source)?;
             named.insert(name, np_steps);
         }
         named

--- a/ail-core/src/config/validation/step_body.rs
+++ b/ail-core/src/config/validation/step_body.rs
@@ -18,6 +18,7 @@ use super::{cfg_err, parse_condition_expression, validate_steps};
 pub(in crate::config) fn parse_step_body(
     step_dto: &mut StepDto,
     id_str: &str,
+    pipeline_source: &std::path::Path,
 ) -> Result<StepBody, AilError> {
     // When pipeline: is set, prompt: is treated as the child invocation override,
     // not a primary field — so don't count it in the primary field selector.
@@ -98,12 +99,79 @@ pub(in crate::config) fn parse_step_body(
             )),
         }
     } else if step_dto.do_while.is_some() {
-        parse_do_while_body(step_dto.do_while.take().unwrap(), id_str)
+        parse_do_while_body(step_dto.do_while.take().unwrap(), id_str, pipeline_source)
     } else if step_dto.for_each.is_some() {
-        parse_for_each_body(step_dto.for_each.take().unwrap(), id_str)
+        parse_for_each_body(step_dto.for_each.take().unwrap(), id_str, pipeline_source)
     } else {
         unreachable!("primary_count == 1 enforced above")
     }
+}
+
+/// Resolve a relative path against the pipeline source file's parent directory.
+/// Returns the resolved path, or an error if the file cannot be found.
+fn resolve_loop_pipeline_path(
+    raw_path: &str,
+    id_str: &str,
+    loop_kind: &str,
+    pipeline_source: &std::path::Path,
+) -> Result<std::path::PathBuf, AilError> {
+    let base_dir = pipeline_source
+        .parent()
+        .unwrap_or(std::path::Path::new("."));
+
+    let resolved = if raw_path.starts_with('/')
+        || raw_path.starts_with('~')
+        || raw_path.starts_with("./")
+        || raw_path.starts_with("../")
+    {
+        if raw_path.starts_with('~') {
+            // Home-relative path.
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            std::path::PathBuf::from(home).join(&raw_path[2..])
+        } else if raw_path.starts_with('/') {
+            std::path::PathBuf::from(raw_path)
+        } else {
+            base_dir.join(raw_path)
+        }
+    } else {
+        // Bare relative path — resolve against pipeline source directory.
+        base_dir.join(raw_path)
+    };
+
+    if !resolved.exists() {
+        return Err(AilError::ConfigFileNotFound {
+            detail: format!(
+                "Step '{id_str}' {loop_kind}.pipeline references '{raw_path}' \
+                 which resolves to '{}' but the file does not exist",
+                resolved.display()
+            ),
+            context: None,
+        });
+    }
+
+    Ok(resolved)
+}
+
+/// Load inner steps from an external pipeline file for use as a loop body.
+/// Returns the validated step list from the referenced pipeline.
+fn load_loop_pipeline_steps(
+    raw_path: &str,
+    id_str: &str,
+    loop_kind: &str,
+    pipeline_source: &std::path::Path,
+) -> Result<Vec<crate::config::domain::Step>, AilError> {
+    let resolved = resolve_loop_pipeline_path(raw_path, id_str, loop_kind, pipeline_source)?;
+    let pipeline = crate::config::load(&resolved)?;
+
+    if pipeline.steps.is_empty() {
+        return Err(cfg_err!(
+            "Step '{id_str}' {loop_kind}.pipeline references '{}' \
+             but that pipeline has no steps",
+            resolved.display()
+        ));
+    }
+
+    Ok(pipeline.steps)
 }
 
 /// Parse a `do_while:` step body, validating all required fields (SPEC §27).
@@ -113,6 +181,7 @@ pub(in crate::config) fn parse_step_body(
 fn parse_do_while_body(
     dw: crate::config::dto::DoWhileDto,
     id_str: &str,
+    pipeline_source: &std::path::Path,
 ) -> Result<StepBody, AilError> {
     let max_iterations = dw.max_iterations.ok_or_else(|| {
         cfg_err!(
@@ -149,22 +218,34 @@ fn parse_do_while_body(
         }
     };
 
-    let step_dtos = dw.steps.ok_or_else(|| {
-        cfg_err!(
-            "Step '{id_str}' declares do_while: but 'steps' is missing; \
-             at least one inner step is required (SPEC §27)"
-        )
-    })?;
+    // steps and pipeline are mutually exclusive (SPEC §27.2).
+    let has_steps = dw.steps.is_some();
+    let has_pipeline = dw.pipeline.is_some();
 
-    if step_dtos.is_empty() {
+    if has_steps && has_pipeline {
         return Err(cfg_err!(
-            "Step '{id_str}' declares do_while: with an empty 'steps' array; \
-             at least one inner step is required (SPEC §27)"
+            "Step '{id_str}' declares both do_while.steps and do_while.pipeline; \
+             these are mutually exclusive — use one or the other (SPEC §27.2)"
         ));
     }
 
-    let context_label = format!("do_while step '{id_str}'");
-    let inner_steps = validate_steps(step_dtos, &context_label)?;
+    let inner_steps = if let Some(step_dtos) = dw.steps {
+        if step_dtos.is_empty() {
+            return Err(cfg_err!(
+                "Step '{id_str}' declares do_while: with an empty 'steps' array; \
+                 at least one inner step is required (SPEC §27)"
+            ));
+        }
+        let context_label = format!("do_while step '{id_str}'");
+        validate_steps(step_dtos, &context_label, pipeline_source)?
+    } else if let Some(ref pipeline_path) = dw.pipeline {
+        load_loop_pipeline_steps(pipeline_path, id_str, "do_while", pipeline_source)?
+    } else {
+        return Err(cfg_err!(
+            "Step '{id_str}' declares do_while: but neither 'steps' nor 'pipeline' is set; \
+             one of them is required (SPEC §27)"
+        ));
+    };
 
     Ok(StepBody::DoWhile {
         max_iterations,
@@ -180,6 +261,7 @@ fn parse_do_while_body(
 fn parse_for_each_body(
     fe: crate::config::dto::ForEachDto,
     id_str: &str,
+    pipeline_source: &std::path::Path,
 ) -> Result<StepBody, AilError> {
     let over = fe.over.ok_or_else(|| {
         cfg_err!(
@@ -229,22 +311,34 @@ fn parse_for_each_body(
         }
     };
 
-    let step_dtos = fe.steps.ok_or_else(|| {
-        cfg_err!(
-            "Step '{id_str}' declares for_each: but 'steps' is missing; \
-             at least one inner step is required (SPEC §28)"
-        )
-    })?;
+    // steps and pipeline are mutually exclusive (SPEC §28.2).
+    let has_steps = fe.steps.is_some();
+    let has_pipeline = fe.pipeline.is_some();
 
-    if step_dtos.is_empty() {
+    if has_steps && has_pipeline {
         return Err(cfg_err!(
-            "Step '{id_str}' declares for_each: with an empty 'steps' array; \
-             at least one inner step is required (SPEC §28)"
+            "Step '{id_str}' declares both for_each.steps and for_each.pipeline; \
+             these are mutually exclusive — use one or the other (SPEC §28.2)"
         ));
     }
 
-    let context_label = format!("for_each step '{id_str}'");
-    let inner_steps = validate_steps(step_dtos, &context_label)?;
+    let inner_steps = if let Some(step_dtos) = fe.steps {
+        if step_dtos.is_empty() {
+            return Err(cfg_err!(
+                "Step '{id_str}' declares for_each: with an empty 'steps' array; \
+                 at least one inner step is required (SPEC §28)"
+            ));
+        }
+        let context_label = format!("for_each step '{id_str}'");
+        validate_steps(step_dtos, &context_label, pipeline_source)?
+    } else if let Some(ref pipeline_path) = fe.pipeline {
+        load_loop_pipeline_steps(pipeline_path, id_str, "for_each", pipeline_source)?
+    } else {
+        return Err(cfg_err!(
+            "Step '{id_str}' declares for_each: but neither 'steps' nor 'pipeline' is set; \
+             one of them is required (SPEC §28)"
+        ));
+    };
 
     Ok(StepBody::ForEach {
         over,

--- a/ail-core/tests/spec/s28_for_each.rs
+++ b/ail-core/tests/spec/s28_for_each.rs
@@ -760,3 +760,244 @@ mod materialize {
         assert!(result.is_ok(), "Output was not valid YAML: {output}");
     }
 }
+
+// ── Pipeline-as-file tests ──────────────────────────────────────────────────
+
+mod pipeline_as_file {
+    use ail_core::config;
+    use ail_core::config::domain::StepBody;
+    use ail_core::error::error_types;
+
+    /// §28.2 — for_each accepts pipeline: as alternative to inline steps.
+    #[test]
+    fn for_each_pipeline_file_loads_steps() {
+        // Create the sub-pipeline file.
+        let sub_dir = tempfile::tempdir().unwrap();
+        let sub_path = sub_dir.path().join("loop-body.ail.yaml");
+        std::fs::write(
+            &sub_path,
+            r#"
+version: "0.1"
+pipeline:
+  - id: inner_work
+    prompt: "do the work"
+"#,
+        )
+        .unwrap();
+
+        // Create the main pipeline that references it.
+        let main_yaml = format!(
+            r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{{{ step.plan.items }}}}"
+      pipeline: {}
+"#,
+            sub_path.display()
+        );
+        let main_path = sub_dir.path().join("main.ail.yaml");
+        std::fs::write(&main_path, main_yaml).unwrap();
+
+        let pipeline = config::load(&main_path).expect("should parse");
+        let step = &pipeline.steps[0];
+        match &step.body {
+            StepBody::ForEach { steps, .. } => {
+                assert_eq!(steps.len(), 1);
+                assert_eq!(steps[0].id.as_str(), "inner_work");
+            }
+            other => panic!("expected ForEach, got {other:?}"),
+        }
+    }
+
+    /// §28.2 — for_each with relative pipeline path resolves against source dir.
+    #[test]
+    fn for_each_pipeline_relative_path() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create sub-pipeline in a subdirectory.
+        let sub_dir = dir.path().join("subs");
+        std::fs::create_dir(&sub_dir).unwrap();
+        std::fs::write(
+            sub_dir.join("body.ail.yaml"),
+            r#"
+version: "0.1"
+pipeline:
+  - id: task
+    prompt: "handle it"
+"#,
+        )
+        .unwrap();
+
+        // Main pipeline uses relative path.
+        std::fs::write(
+            dir.path().join("main.ail.yaml"),
+            r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+      pipeline: ./subs/body.ail.yaml
+"#,
+        )
+        .unwrap();
+
+        let pipeline =
+            config::load(&dir.path().join("main.ail.yaml")).expect("should resolve relative path");
+        match &pipeline.steps[0].body {
+            StepBody::ForEach { steps, .. } => {
+                assert_eq!(steps[0].id.as_str(), "task");
+            }
+            other => panic!("expected ForEach, got {other:?}"),
+        }
+    }
+
+    /// §28.7 rule 1 — declaring both steps and pipeline is an error.
+    #[test]
+    fn for_each_steps_and_pipeline_mutually_exclusive() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("body.ail.yaml"),
+            "version: \"0.1\"\npipeline:\n  - id: x\n    prompt: hi\n",
+        )
+        .unwrap();
+        let yaml = format!(
+            r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{{{ step.plan.items }}}}"
+      pipeline: {}
+      steps:
+        - id: work
+          prompt: "do it"
+"#,
+            dir.path().join("body.ail.yaml").display()
+        );
+        let main_path = dir.path().join("main.ail.yaml");
+        std::fs::write(&main_path, yaml).unwrap();
+        let err = config::load(&main_path).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("mutually exclusive"),
+            "got: {}",
+            err.detail()
+        );
+    }
+
+    /// §28.7 rule 1 — declaring neither steps nor pipeline is an error.
+    #[test]
+    fn for_each_neither_steps_nor_pipeline() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(err.detail().contains("neither"), "got: {}", err.detail());
+    }
+
+    /// §28.7 rule 8 — missing pipeline file is a CONFIG_FILE_NOT_FOUND error.
+    #[test]
+    fn for_each_pipeline_file_not_found() {
+        let yaml = r#"
+version: "0.1"
+pipeline:
+  - id: loop
+    for_each:
+      over: "{{ step.plan.items }}"
+      pipeline: ./nonexistent.ail.yaml
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".ail.yaml").unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = config::load(tmp.path()).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_FILE_NOT_FOUND);
+    }
+
+    /// §27.2 — do_while also accepts pipeline: as alternative to inline steps.
+    #[test]
+    fn do_while_pipeline_file_loads_steps() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("loop-body.ail.yaml"),
+            r#"
+version: "0.1"
+pipeline:
+  - id: fix
+    prompt: "fix the code"
+  - id: test
+    context:
+      shell: "echo ok"
+"#,
+        )
+        .unwrap();
+
+        let main_yaml = format!(
+            r#"
+version: "0.1"
+pipeline:
+  - id: fix_loop
+    do_while:
+      max_iterations: 5
+      exit_when: "{{{{ step.test.exit_code }}}} == 0"
+      pipeline: {}
+"#,
+            dir.path().join("loop-body.ail.yaml").display()
+        );
+        let main_path = dir.path().join("main.ail.yaml");
+        std::fs::write(&main_path, main_yaml).unwrap();
+
+        let pipeline = config::load(&main_path).expect("should parse");
+        match &pipeline.steps[0].body {
+            StepBody::DoWhile { steps, .. } => {
+                assert_eq!(steps.len(), 2);
+                assert_eq!(steps[0].id.as_str(), "fix");
+                assert_eq!(steps[1].id.as_str(), "test");
+            }
+            other => panic!("expected DoWhile, got {other:?}"),
+        }
+    }
+
+    /// §27.2 — do_while: declaring both steps and pipeline is an error.
+    #[test]
+    fn do_while_steps_and_pipeline_mutually_exclusive() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("body.ail.yaml"),
+            "version: \"0.1\"\npipeline:\n  - id: x\n    prompt: hi\n",
+        )
+        .unwrap();
+        let yaml = format!(
+            r#"
+version: "0.1"
+pipeline:
+  - id: fix_loop
+    do_while:
+      max_iterations: 3
+      exit_when: "{{{{ step.test.exit_code }}}} == 0"
+      pipeline: {}
+      steps:
+        - id: test
+          context:
+            shell: "echo ok"
+"#,
+            dir.path().join("body.ail.yaml").display()
+        );
+        let main_path = dir.path().join("main.ail.yaml");
+        std::fs::write(&main_path, yaml).unwrap();
+        let err = config::load(&main_path).unwrap_err();
+        assert_eq!(err.error_type(), error_types::CONFIG_VALIDATION_FAILED);
+        assert!(
+            err.detail().contains("mutually exclusive"),
+            "got: {}",
+            err.detail()
+        );
+    }
+}

--- a/spec/core/s27-do-while.md
+++ b/spec/core/s27-do-while.md
@@ -1,6 +1,6 @@
 ## 27. `do_while:` — Bounded Repeat-Until
 
-> **Implementation status:** Core execution implemented. Parse-time validation, executor loop, template variables (`{{ do_while.iteration }}`, `{{ do_while.max_iterations }}`), step ID namespacing (`<loop_id>::<step_id>`), iteration scope management, loop depth guard (`MAX_LOOP_DEPTH = 8`), and `break`/`abort_pipeline` handling are all functional. `on_max_iterations` field is not yet implemented (defaults to `abort_pipeline`). Controlled-mode executor events (§27.7) are deferred.
+> **Implementation status:** Core execution implemented. Parse-time validation, executor loop, template variables (`{{ do_while.iteration }}`, `{{ do_while.max_iterations }}`), step ID namespacing (`<loop_id>::<step_id>`), iteration scope management, loop depth guard (`MAX_LOOP_DEPTH = 8`), and `break`/`abort_pipeline` handling are all functional. `pipeline:` as alternative to inline `steps:` implemented. `on_max_iterations` field is not yet implemented (defaults to `abort_pipeline`). Controlled-mode executor events (§27.7) are deferred.
 
 A `do_while:` step runs a fixed set of inner steps repeatedly until an `exit_when` condition is met or a declared `max_iterations` bound is exceeded. It is the generate→test→fix pattern: each iteration produces a result, then checks whether the result is good enough to stop.
 

--- a/spec/core/s28-for-each.md
+++ b/spec/core/s28-for-each.md
@@ -1,6 +1,6 @@
 ## 28. `for_each:` — Collection Iteration
 
-> **Implementation status:** Fully implemented. `for_each:` — parse-time validation (`over`, `as`, `max_items`, `on_max_items`, `steps`), runtime array iteration with item scope, `{{ for_each.item }}` / `{{ for_each.<as_name> }}` / `{{ for_each.index }}` / `{{ for_each.total }}` template variables, `break` exits loop not pipeline, `max_items` cap with `on_max_items` behavior, step ID namespacing (`<loop_id>::<step_id>`), shared depth guard with `do_while:`. Controlled-mode executor events (§28.6) are deferred.
+> **Implementation status:** Fully implemented. `for_each:` — parse-time validation (`over`, `as`, `max_items`, `on_max_items`, `steps`/`pipeline`), runtime array iteration with item scope, `{{ for_each.item }}` / `{{ for_each.<as_name> }}` / `{{ for_each.index }}` / `{{ for_each.total }}` template variables, `break` exits loop not pipeline, `max_items` cap with `on_max_items` behavior, step ID namespacing (`<loop_id>::<step_id>`), shared depth guard with `do_while:`. `pipeline:` as alternative to inline `steps:` implemented. Controlled-mode executor events (§28.6) are deferred.
 
 A `for_each:` step runs a fixed set of inner steps once per item in a validated array produced by a prior step. Where `do_while:` (§27) repeats until a condition is met, `for_each:` maps a sub-pipeline across a known collection — the plan-execution pattern: generate a list of tasks, then implement each one.
 
@@ -25,16 +25,28 @@ A `for_each:` step runs a fixed set of inner steps once per item in a validated 
     as: task
     max_items: 20
     on_max_items: abort_pipeline
-  steps:
-    - id: implement
-      prompt: |
-        Task {{ for_each.index }} of {{ for_each.total }}: {{ for_each.task }}
-        Implement this task completely.
-      resume: true
-    - id: verify
-      context:
-        shell: "cargo test 2>&1"
+    steps:
+      - id: implement
+        prompt: |
+          Task {{ for_each.index }} of {{ for_each.total }}: {{ for_each.task }}
+          Implement this task completely.
+        resume: true
+      - id: verify
+        context:
+          shell: "cargo test 2>&1"
 ```
+
+The loop body can also reference an external pipeline file instead of inline steps:
+
+```yaml
+- id: implement_tasks
+  for_each:
+    over: "{{ step.plan.items }}"
+    as: task
+    pipeline: ./task-handler.ail.yaml
+```
+
+The referenced file's `pipeline:` steps become the loop body. Template variables (`{{ for_each.item }}`, `{{ for_each.index }}`, etc.) are available inside the referenced pipeline.
 
 ---
 
@@ -46,7 +58,10 @@ A `for_each:` step runs a fixed set of inner steps once per item in a validated 
 | `as` | Identifier string | No | `item` | Local name for the current item within the loop body. Accessed as `{{ for_each.<as> }}`. |
 | `max_items` | Integer ≥ 1 | No | None | Hard cap on items processed. Items beyond this limit are not processed. |
 | `on_max_items` | `abort_pipeline` / `continue` | No | `continue` | What happens when the array contains more items than `max_items`. `continue` silently skips excess items. `abort_pipeline` treats excess items as a fatal error. |
-| `steps` | Array of Step | **Yes** | None | Inner steps executed once per item. Same schema as top-level pipeline steps. |
+| `steps` | Array of Step | Conditional | None | Inner steps executed once per item. Same schema as top-level pipeline steps. Required if `pipeline` is not set. |
+| `pipeline` | String (file path) | Conditional | None | Path to an external `.ail.yaml` file whose `pipeline:` steps become the loop body. Resolved relative to the current pipeline file at parse time. Required if `steps` is not set. |
+
+`steps` and `pipeline` are mutually exclusive — declare one or the other. Declaring both or neither is a `CONFIG_VALIDATION_FAILED` error.
 
 ---
 
@@ -126,13 +141,14 @@ For pipelines running in `--output-format json` controlled mode (§4.5):
 
 ### 28.7 Validation Rules
 
-1. `for_each:` requires `over` and `steps` (non-empty). Missing → `CONFIG_VALIDATION_FAILED`.
+1. `for_each:` requires `over` and either `steps` (non-empty) or `pipeline`. Missing both or providing both → `CONFIG_VALIDATION_FAILED`.
 2. `over` must reference `{{ step.<id>.items }}` where step `<id>` declared `output_schema` with `type: array`. No schema, or non-array schema → `FOR_EACH_SOURCE_INVALID`.
 3. `for_each:` is mutually exclusive with all other primary fields. Combining them → `CONFIG_VALIDATION_FAILED`.
 4. `as` must be a valid identifier (letters, digits, underscores; does not start with a digit). Invalid → `CONFIG_VALIDATION_FAILED`.
 5. `max_items` must be an integer ≥ 1 if specified.
 6. `on_max_items` must be one of `abort_pipeline`, `continue`. Unknown value → `CONFIG_VALIDATION_FAILED`.
 7. Step IDs within `steps` must be unique within the loop.
+8. `pipeline` file path must be resolvable and the referenced file must be a valid pipeline. File not found → `CONFIG_FILE_NOT_FOUND`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Both `for_each:` and `do_while:` now accept `pipeline: ./path.ail.yaml` as an alternative to inline `steps:` — the referenced file's steps become the loop body, loaded and validated at parse time
- Fixed spec inconsistency: §28 `steps:` was shown as a sibling of `for_each:` but is now correctly nested inside the block (matching `do_while:`)
- Pipeline source path threaded through the full validation chain for relative path resolution

## Changes

| Area | Files | What |
|------|-------|------|
| DTO | `dto.rs` | `pipeline` field added to both `ForEachDto` and `DoWhileDto` |
| Validation | `step_body.rs` | `load_loop_pipeline_steps()`, `resolve_loop_pipeline_path()` — shared pipeline-file loading; mutual exclusivity checks for steps/pipeline |
| Validation | `mod.rs` | `pipeline_source: &Path` threaded through `validate_steps`, `parse_step_body`, `parse_chain_step(s)` |
| Tests | `s28_for_each.rs` | 7 new tests: for_each + do_while pipeline loading, relative paths, mutual exclusivity, missing file |
| Spec | `s27-do-while.md`, `s28-for-each.md` | Updated status; fixed §28 nesting; added pipeline: docs |
| Docs | `ail-core/CLAUDE.md` | Updated module description |

## Test plan

- [x] All 454 tests pass (7 new for pipeline-as-file)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] for_each and do_while load steps from external pipeline files
- [x] Relative paths resolve against pipeline source directory
- [x] steps + pipeline mutually exclusive (both present → error)
- [x] Neither steps nor pipeline → error
- [x] Missing pipeline file → CONFIG_FILE_NOT_FOUND

https://claude.ai/code/session_01PaaBU3rHSK6Vf8VpPTQYAH