### PR TITLE
Add CodexRunner for OpenAI Codex CLI integration

### DIFF
--- a/ail-core/CLAUDE.md
+++ b/ail-core/CLAUDE.md
@@ -40,6 +40,9 @@ Consumed by `ail` (the binary) and future language-server / SDK targets.
 | `runner/claude/mod.rs` | `ClaudeCliRunner` — orchestrates subprocess + decoder + permission listener |
 | `runner/claude/decoder.rs` | `ClaudeNdjsonDecoder` — stateful NDJSON stream decoder, no process coupling; unit-testable with raw byte strings |
 | `runner/claude/permission.rs` | `ClaudePermissionListener` — RAII guard for the tool-permission socket (hook settings file, accept loop, `__close__` sentinel, cleanup on drop) |
+| `runner/codex/mod.rs` | `CodexRunner` — orchestrates subprocess + decoder for `codex exec --json` |
+| `runner/codex/decoder.rs` | `CodexNdjsonDecoder` — stateful item-lifecycle NDJSON decoder; unit-testable with raw byte strings |
+| `runner/codex/wire_dto.rs` | Serde DTOs for the `codex exec --json` wire format |
 | `runner/factory.rs` | `RunnerFactory` — builds runners by name; honours `AIL_DEFAULT_RUNNER` env; checks plugin registry for unknown names |
 | `runner/plugin/mod.rs` | Plugin system entry point — re-exports `PluginRegistry`, `PluginManifest`, `ProtocolRunner` |
 | `runner/plugin/discovery.rs` | `discover_plugins()` — scans `~/.ail/runners/` for manifest files; returns `PluginRegistry` |

--- a/ail-core/src/runner/codex/decoder.rs
+++ b/ail-core/src/runner/codex/decoder.rs
@@ -142,9 +142,9 @@ impl CodexNdjsonDecoder {
         }
         Ok(RunResult {
             response: self.response,
-            cost_usd: None,       // not available in codex --json wire format
+            cost_usd: None, // not available in codex --json wire format
             session_id: self.thread_id,
-            input_tokens: 0,      // not available in codex --json wire format
+            input_tokens: 0, // not available in codex --json wire format
             output_tokens: 0,
             thinking: if self.thinking.is_empty() {
                 None
@@ -226,10 +226,9 @@ impl CodexNdjsonDecoder {
                         .unwrap_or("");
 
                     // Accumulate the tool_call side
-                    let input =
-                        serde_json::json!({ "command": command });
-                    let content_json = serde_json::to_string(&input)
-                        .unwrap_or_else(|_| "{}".to_string());
+                    let input = serde_json::json!({ "command": command });
+                    let content_json =
+                        serde_json::to_string(&input).unwrap_or_else(|_| "{}".to_string());
                     self.tool_events.push(ToolEvent {
                         event_type: "tool_call".to_string(),
                         tool_name: "Bash".to_string(),
@@ -513,10 +512,13 @@ mod tests {
         dec.finalize().unwrap();
 
         let events: Vec<_> = rx.try_iter().collect();
-        assert!(events.iter().any(|e| matches!(e, RunnerEvent::ToolResult {
-            is_error: Some(true),
-            ..
-        })));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            RunnerEvent::ToolResult {
+                is_error: Some(true),
+                ..
+            }
+        )));
     }
 
     #[test]

--- a/ail-core/src/runner/codex/decoder.rs
+++ b/ail-core/src/runner/codex/decoder.rs
@@ -1,0 +1,593 @@
+//! Stateful decoder for the `codex exec --json` NDJSON wire format.
+//!
+//! [`CodexNdjsonDecoder`] accepts NDJSON lines from the Codex CLI one at a time via
+//! [`CodexNdjsonDecoder::feed`]. It emits [`RunnerEvent`]s for streaming consumers and
+//! accumulates state needed to build the final [`RunResult`] when the terminal
+//! `turn.completed` event arrives. Decoding is completely decoupled from process
+//! lifecycle — these functions can be tested with raw byte strings, with no subprocess
+//! involved.
+
+#![allow(clippy::result_large_err)]
+
+use std::sync::mpsc;
+
+use super::super::{RunResult, RunnerEvent, ToolEvent};
+use super::wire_dto::WireCodexEvent;
+use crate::error::AilError;
+
+// ── Internal parse action ─────────────────────────────────────────────────────────────────────
+
+/// Terminal outcome of processing a single NDJSON event.
+enum ParseAction {
+    /// Non-terminal event — any `RunnerEvent`s were already sent through `tx`.
+    Continue,
+    /// `turn.completed` — the stream finished successfully.
+    TurnCompleted,
+    /// `turn.failed` or `error` event arrived.
+    TurnError(String),
+}
+
+// ── Decoder ───────────────────────────────────────────────────────────────────────────────────
+
+/// Accumulates state from a stream of `codex exec --json` NDJSON events.
+///
+/// Call [`feed`](CodexNdjsonDecoder::feed) for each non-empty line from the Codex CLI
+/// stdout. When [`is_done`](CodexNdjsonDecoder::is_done) returns `true`, call
+/// [`finalize`](CodexNdjsonDecoder::finalize) to consume the decoder into a [`RunResult`].
+///
+/// If the stream ended with a `turn.failed` or `error` event, [`finalize`] returns
+/// [`AilError::RunnerInvocationFailed`]. If the stream ended without `turn.completed`,
+/// [`finalize`] also returns an error.
+///
+/// Token counts are not available in the `codex exec --json` wire format; `RunResult`
+/// fields `input_tokens` and `output_tokens` will always be `0`.
+#[derive(Default)]
+pub struct CodexNdjsonDecoder {
+    /// Final response text. Overwritten each time an `item.completed` / `agent_message`
+    /// event arrives (the last one wins, which is the correct final answer).
+    response: String,
+    /// `thread_id` from `thread.started` — becomes `session_id` in the `RunResult`.
+    thread_id: Option<String>,
+    /// Concatenated reasoning text accumulated from `reasoning` items.
+    thinking: String,
+    /// Ordered tool call and tool result events captured during this invocation.
+    tool_events: Vec<ToolEvent>,
+    /// Monotonically increasing sequence number within this invocation.
+    tool_seq: i64,
+    /// Set by a `turn.failed` / `error` event or a JSON parse failure.
+    error: Option<String>,
+    /// True when `turn.completed` (or a terminal error event) has been processed.
+    done: bool,
+}
+
+impl CodexNdjsonDecoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process one NDJSON line from the Codex CLI stdout.
+    ///
+    /// Emits zero or more [`RunnerEvent`]s on `tx` (when `Some`) for streaming consumers.
+    /// Sets [`is_done`](Self::is_done) to `true` when a terminal event is seen.
+    ///
+    /// On a JSON parse error the internal error is set, `is_done()` becomes `true`, and
+    /// no further calls to `feed` will have any effect.
+    ///
+    /// Returns `Err(detail)` only for JSON parse failures so the caller can decide whether
+    /// to break the read loop immediately. Terminal errors from the wire are stored
+    /// internally and surface via [`finalize`](Self::finalize).
+    pub fn feed(
+        &mut self,
+        line: &str,
+        tx: Option<&mpsc::Sender<RunnerEvent>>,
+    ) -> Result<(), String> {
+        if self.done {
+            return Ok(());
+        }
+
+        let event: WireCodexEvent = serde_json::from_str(line).map_err(|e| {
+            let detail = format!("Malformed JSON from codex CLI: {e}\nLine: {line}");
+            self.error = Some(detail.clone());
+            self.done = true;
+            detail
+        })?;
+
+        tracing::trace!(line = %line, "codex --json raw line");
+
+        match self.process_event(event, tx) {
+            ParseAction::Continue => {}
+            ParseAction::TurnCompleted => {
+                self.done = true;
+            }
+            ParseAction::TurnError(detail) => {
+                self.error = Some(detail);
+                self.done = true;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// True when `turn.completed` (or a terminal error) has been processed, or when a JSON
+    /// parse error has occurred. The caller should break the read loop when this returns `true`.
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    /// Take the error detail if the decoder encountered a terminal error or a JSON parse
+    /// failure. The value is moved out — subsequent calls return `None`.
+    pub fn take_error(&mut self) -> Option<String> {
+        self.error.take()
+    }
+
+    /// Consume the decoder into a [`RunResult`].
+    ///
+    /// Returns `Err` if the stream ended with an error event or without `turn.completed`.
+    ///
+    /// The caller should check [`take_error`](Self::take_error) and emit a
+    /// `RunnerEvent::Error` **before** calling `finalize` if they want streaming consumers
+    /// to see the error event.
+    pub fn finalize(self) -> Result<RunResult, AilError> {
+        if let Some(detail) = self.error {
+            return Err(AilError::RunnerInvocationFailed {
+                detail,
+                context: None,
+            });
+        }
+        if !self.done {
+            return Err(AilError::RunnerInvocationFailed {
+                detail: "Stream ended without a 'turn.completed' event".to_string(),
+                context: None,
+            });
+        }
+        Ok(RunResult {
+            response: self.response,
+            cost_usd: None,       // not available in codex --json wire format
+            session_id: self.thread_id,
+            input_tokens: 0,      // not available in codex --json wire format
+            output_tokens: 0,
+            thinking: if self.thinking.is_empty() {
+                None
+            } else {
+                Some(self.thinking)
+            },
+            model: None,
+            tool_events: self.tool_events,
+        })
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────────────────────
+
+    /// Dispatch a parsed NDJSON event: emit [`RunnerEvent`]s, accumulate state, and return
+    /// the [`ParseAction`] indicating whether the stream has reached a terminal state.
+    fn process_event(
+        &mut self,
+        event: WireCodexEvent,
+        tx: Option<&mpsc::Sender<RunnerEvent>>,
+    ) -> ParseAction {
+        match event.event_type.as_str() {
+            "thread.started" => {
+                self.thread_id = event.thread_id;
+                tracing::debug!(thread_id = ?self.thread_id, "codex thread.started");
+                ParseAction::Continue
+            }
+
+            "item.updated" => {
+                let item_type = event.item_type.as_deref().unwrap_or("");
+                let item = event.item.as_ref();
+                tracing::debug!(item_type, "codex item.updated");
+
+                match item_type {
+                    "agent_message" => {
+                        if let Some(text) = item.and_then(|i| i.text.as_deref()) {
+                            if !text.is_empty() {
+                                if let Some(tx) = tx {
+                                    let _ = tx.send(RunnerEvent::StreamDelta {
+                                        text: text.to_string(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    "reasoning" => {
+                        if let Some(text) = item.and_then(|i| i.text.as_deref()) {
+                            if !text.is_empty() {
+                                // Accumulate
+                                if !self.thinking.is_empty() {
+                                    self.thinking.push('\n');
+                                }
+                                self.thinking.push_str(text);
+                                // Emit
+                                if let Some(tx) = tx {
+                                    let _ = tx.send(RunnerEvent::Thinking {
+                                        text: text.to_string(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    other => {
+                        tracing::trace!(item_type = other, "codex item.updated: unhandled type");
+                    }
+                }
+                ParseAction::Continue
+            }
+
+            "item.started" => {
+                let item_type = event.item_type.as_deref().unwrap_or("");
+                tracing::debug!(item_type, "codex item.started");
+
+                if item_type == "command_execution" {
+                    let item_id = event.item_id.clone().unwrap_or_default();
+                    let command = event
+                        .item
+                        .as_ref()
+                        .and_then(|i| i.command.as_deref())
+                        .unwrap_or("");
+
+                    // Accumulate the tool_call side
+                    let input =
+                        serde_json::json!({ "command": command });
+                    let content_json = serde_json::to_string(&input)
+                        .unwrap_or_else(|_| "{}".to_string());
+                    self.tool_events.push(ToolEvent {
+                        event_type: "tool_call".to_string(),
+                        tool_name: "Bash".to_string(),
+                        tool_id: item_id.clone(),
+                        content_json,
+                        seq: self.tool_seq,
+                    });
+                    self.tool_seq += 1;
+
+                    // Emit
+                    if let Some(tx) = tx {
+                        let _ = tx.send(RunnerEvent::ToolUse {
+                            tool_name: "Bash".to_string(),
+                            tool_use_id: Some(item_id),
+                            input: Some(serde_json::json!({ "command": command })),
+                        });
+                    }
+                }
+                ParseAction::Continue
+            }
+
+            "item.completed" => {
+                let item_type = event.item_type.as_deref().unwrap_or("");
+                tracing::debug!(item_type, "codex item.completed");
+
+                match item_type {
+                    "command_execution" => {
+                        let item_id = event.item_id.clone().unwrap_or_default();
+                        let output = event
+                            .item
+                            .as_ref()
+                            .and_then(|i| i.aggregated_output.as_deref())
+                            .unwrap_or("");
+                        let exit_code = event.item.as_ref().and_then(|i| i.exit_code);
+                        let is_error = exit_code.map(|c| c != 0);
+
+                        // Accumulate the tool_result side
+                        self.tool_events.push(ToolEvent {
+                            event_type: "tool_result".to_string(),
+                            tool_name: String::new(),
+                            tool_id: item_id.clone(),
+                            content_json: output.to_string(),
+                            seq: self.tool_seq,
+                        });
+                        self.tool_seq += 1;
+
+                        // Emit
+                        if let Some(tx) = tx {
+                            let _ = tx.send(RunnerEvent::ToolResult {
+                                tool_name: "Bash".to_string(),
+                                tool_use_id: Some(item_id),
+                                content: Some(output.to_string()),
+                                is_error,
+                            });
+                        }
+                    }
+                    "agent_message" => {
+                        // Final text — overwrite the accumulated response
+                        let text = event
+                            .item
+                            .as_ref()
+                            .and_then(|i| i.text.as_deref())
+                            .unwrap_or("");
+                        self.response = text.to_string();
+                        tracing::debug!(
+                            response_len = self.response.len(),
+                            "codex agent_message completed"
+                        );
+                    }
+                    other => {
+                        tracing::trace!(item_type = other, "codex item.completed: unhandled type");
+                    }
+                }
+                ParseAction::Continue
+            }
+
+            "turn.completed" => {
+                tracing::debug!("codex turn.completed");
+                ParseAction::TurnCompleted
+            }
+
+            "turn.failed" => {
+                let detail = event
+                    .error
+                    .unwrap_or_else(|| "unknown error from codex CLI".to_string());
+                tracing::debug!(detail = %detail, "codex turn.failed");
+                ParseAction::TurnError(detail)
+            }
+
+            "error" => {
+                let detail = event
+                    .message
+                    .unwrap_or_else(|| "unknown error from codex CLI".to_string());
+                tracing::debug!(detail = %detail, "codex error event");
+                ParseAction::TurnError(detail)
+            }
+
+            other => {
+                tracing::trace!(event_type = other, "codex: unrecognized event type");
+                ParseAction::Continue
+            }
+        }
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn thread_started(thread_id: &str) -> String {
+        serde_json::json!({
+            "type": "thread.started",
+            "thread_id": thread_id
+        })
+        .to_string()
+    }
+
+    fn item_updated_agent(text: &str) -> String {
+        serde_json::json!({
+            "type": "item.updated",
+            "item_type": "agent_message",
+            "item": { "text": text }
+        })
+        .to_string()
+    }
+
+    fn item_completed_agent(text: &str) -> String {
+        serde_json::json!({
+            "type": "item.completed",
+            "item_type": "agent_message",
+            "item": { "text": text }
+        })
+        .to_string()
+    }
+
+    fn item_updated_reasoning(text: &str) -> String {
+        serde_json::json!({
+            "type": "item.updated",
+            "item_type": "reasoning",
+            "item": { "text": text }
+        })
+        .to_string()
+    }
+
+    fn item_started_command(item_id: &str, command: &str) -> String {
+        serde_json::json!({
+            "type": "item.started",
+            "item_type": "command_execution",
+            "item_id": item_id,
+            "item": { "command": command }
+        })
+        .to_string()
+    }
+
+    fn item_completed_command(item_id: &str, output: &str, exit_code: i32) -> String {
+        serde_json::json!({
+            "type": "item.completed",
+            "item_type": "command_execution",
+            "item_id": item_id,
+            "item": { "aggregated_output": output, "exit_code": exit_code }
+        })
+        .to_string()
+    }
+
+    fn turn_completed() -> String {
+        serde_json::json!({ "type": "turn.completed" }).to_string()
+    }
+
+    fn turn_failed(error: &str) -> String {
+        serde_json::json!({ "type": "turn.failed", "error": error }).to_string()
+    }
+
+    fn error_event(message: &str) -> String {
+        serde_json::json!({ "type": "error", "message": message }).to_string()
+    }
+
+    #[test]
+    fn thread_started_sets_session_id() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&thread_started("thread-abc"), None).unwrap();
+        dec.feed(&turn_completed(), None).unwrap();
+        let result = dec.finalize().unwrap();
+        assert_eq!(result.session_id.as_deref(), Some("thread-abc"));
+    }
+
+    #[test]
+    fn agent_message_updated_emits_stream_delta() {
+        let (tx, rx) = mpsc::channel();
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&item_updated_agent("hello world"), Some(&tx))
+            .unwrap();
+        dec.feed(&item_completed_agent("hello world"), Some(&tx))
+            .unwrap();
+        dec.feed(&turn_completed(), None).unwrap();
+
+        let result = dec.finalize().unwrap();
+        assert_eq!(result.response, "hello world");
+
+        let events: Vec<_> = rx.try_iter().collect();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, RunnerEvent::StreamDelta { text } if text == "hello world")));
+    }
+
+    #[test]
+    fn agent_message_completed_sets_response() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&item_completed_agent("final answer"), None)
+            .unwrap();
+        dec.feed(&turn_completed(), None).unwrap();
+        let result = dec.finalize().unwrap();
+        assert_eq!(result.response, "final answer");
+    }
+
+    #[test]
+    fn last_agent_message_wins() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&item_completed_agent("first"), None).unwrap();
+        dec.feed(&item_completed_agent("second"), None).unwrap();
+        dec.feed(&turn_completed(), None).unwrap();
+        let result = dec.finalize().unwrap();
+        assert_eq!(result.response, "second");
+    }
+
+    #[test]
+    fn reasoning_item_accumulated_to_thinking() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&item_updated_reasoning("step one"), None).unwrap();
+        dec.feed(&item_updated_reasoning("step two"), None).unwrap();
+        dec.feed(&turn_completed(), None).unwrap();
+        let result = dec.finalize().unwrap();
+        assert_eq!(result.thinking.as_deref(), Some("step one\nstep two"));
+    }
+
+    #[test]
+    fn command_execution_emits_tool_use_and_result() {
+        let (tx, rx) = mpsc::channel();
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&item_started_command("cmd-1", "ls -la"), Some(&tx))
+            .unwrap();
+        dec.feed(
+            &item_completed_command("cmd-1", "total 0\ndrwxr-xr-x", 0),
+            Some(&tx),
+        )
+        .unwrap();
+        dec.feed(&turn_completed(), None).unwrap();
+
+        let result = dec.finalize().unwrap();
+        assert_eq!(result.tool_events.len(), 2);
+        assert_eq!(result.tool_events[0].event_type, "tool_call");
+        assert_eq!(result.tool_events[0].tool_name, "Bash");
+        assert_eq!(result.tool_events[0].tool_id, "cmd-1");
+        assert_eq!(result.tool_events[1].event_type, "tool_result");
+        assert_eq!(result.tool_events[1].tool_id, "cmd-1");
+
+        let events: Vec<_> = rx.try_iter().collect();
+        assert!(events.iter().any(|e| matches!(e, RunnerEvent::ToolUse {
+            tool_name,
+            tool_use_id: Some(id),
+            ..
+        } if tool_name == "Bash" && id == "cmd-1")));
+        assert!(events.iter().any(|e| matches!(e, RunnerEvent::ToolResult {
+            tool_name,
+            tool_use_id: Some(id),
+            is_error: Some(false),
+            ..
+        } if tool_name == "Bash" && id == "cmd-1")));
+    }
+
+    #[test]
+    fn command_execution_non_zero_exit_marks_is_error() {
+        let (tx, rx) = mpsc::channel();
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&item_started_command("cmd-2", "false"), Some(&tx))
+            .unwrap();
+        dec.feed(&item_completed_command("cmd-2", "", 1), Some(&tx))
+            .unwrap();
+        dec.feed(&turn_completed(), None).unwrap();
+        dec.finalize().unwrap();
+
+        let events: Vec<_> = rx.try_iter().collect();
+        assert!(events.iter().any(|e| matches!(e, RunnerEvent::ToolResult {
+            is_error: Some(true),
+            ..
+        })));
+    }
+
+    #[test]
+    fn turn_completed_sets_done() {
+        let mut dec = CodexNdjsonDecoder::new();
+        assert!(!dec.is_done());
+        dec.feed(&turn_completed(), None).unwrap();
+        assert!(dec.is_done());
+    }
+
+    #[test]
+    fn turn_failed_sets_error() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&turn_failed("rate limit exceeded"), None).unwrap();
+        assert!(dec.is_done());
+        assert_eq!(dec.take_error().as_deref(), Some("rate limit exceeded"));
+    }
+
+    #[test]
+    fn error_event_sets_error() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&error_event("connection refused"), None).unwrap();
+        assert!(dec.is_done());
+        assert_eq!(dec.take_error().as_deref(), Some("connection refused"));
+    }
+
+    #[test]
+    fn no_turn_completed_finalize_fails() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&item_completed_agent("partial"), None).unwrap();
+        // Stream ends without turn.completed
+        let err = dec.finalize().unwrap_err();
+        assert!(err.detail().contains("turn.completed"));
+    }
+
+    #[test]
+    fn malformed_json_sets_error() {
+        let mut dec = CodexNdjsonDecoder::new();
+        let result = dec.feed("not json {{", None);
+        assert!(result.is_err());
+        assert!(dec.is_done());
+        assert!(dec.take_error().is_some());
+    }
+
+    #[test]
+    fn feed_after_done_is_noop() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&item_completed_agent("first"), None).unwrap();
+        dec.feed(&turn_completed(), None).unwrap();
+        assert!(dec.is_done());
+        // Second turn.completed should be silently ignored
+        dec.feed(&turn_completed(), None).unwrap();
+        let result = dec.finalize().unwrap();
+        assert_eq!(result.response, "first");
+    }
+
+    #[test]
+    fn token_counts_always_zero() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&turn_completed(), None).unwrap();
+        let result = dec.finalize().unwrap();
+        assert_eq!(result.input_tokens, 0);
+        assert_eq!(result.output_tokens, 0);
+        assert!(result.cost_usd.is_none());
+    }
+
+    #[test]
+    fn no_thread_started_session_id_is_none() {
+        let mut dec = CodexNdjsonDecoder::new();
+        dec.feed(&turn_completed(), None).unwrap();
+        let result = dec.finalize().unwrap();
+        assert!(result.session_id.is_none());
+    }
+}

--- a/ail-core/src/runner/codex/mod.rs
+++ b/ail-core/src/runner/codex/mod.rs
@@ -1,0 +1,351 @@
+//! `CodexRunner` — drives `codex exec --json`.
+//!
+//! Wraps the OpenAI Codex CLI (`@openai/codex`, installed via `npm i -g @openai/codex`)
+//! in non-interactive mode. The CLI must be available in PATH or configured via the
+//! `AIL_CODEX_BIN` environment variable.
+//!
+//! `OPENAI_API_KEY` is read from the environment by the `codex` binary itself and is
+//! **not** set or modified by this runner.
+//!
+//! ## Unsupported `InvokeOptions` fields
+//!
+//! The Codex CLI does not expose a hook mechanism analogous to Claude's MCP bridge, and
+//! uses sandbox levels rather than named tool allowlists. The following fields are silently
+//! ignored (with a `warn!` log for tool policy, `trace!` for others):
+//!
+//! - `tool_policy` — logged at `WARN` level; Codex sandbox level is fixed by `--full-auto`
+//! - `system_prompt` / `append_system_prompt` — no CLI equivalent
+//! - `permission_responder` — no hook mechanism in the Codex CLI
+//!
+//! See `spec/runner/r06-codex-runner.md` for the full contract.
+
+#![allow(clippy::result_large_err)]
+
+mod wire_dto;
+pub mod decoder;
+
+use std::io::BufRead;
+use std::sync::mpsc;
+
+use decoder::CodexNdjsonDecoder;
+
+use super::subprocess::{SubprocessSession, SubprocessSpec};
+use super::{InvokeOptions, RunResult, Runner, RunnerEvent, ToolPermissionPolicy};
+use crate::error::AilError;
+
+// ── Config and runner struct ──────────────────────────────────────────────────────────────────
+
+/// Builder for [`CodexRunner`]. Encapsulates all Codex-specific construction parameters.
+///
+/// # Example
+/// ```ignore
+/// let runner = CodexRunnerConfig::default().headless(true).build();
+/// ```
+#[derive(Debug, Clone)]
+pub struct CodexRunnerConfig {
+    pub codex_bin: String,
+    /// When true, passes `--full-auto` to the codex CLI, enabling automated tool execution
+    /// without per-call confirmation. Equivalent to Claude's `--dangerously-skip-permissions`.
+    pub headless: bool,
+}
+
+impl Default for CodexRunnerConfig {
+    fn default() -> Self {
+        Self {
+            codex_bin: "codex".to_string(),
+            headless: false,
+        }
+    }
+}
+
+impl CodexRunnerConfig {
+    pub fn headless(mut self, headless: bool) -> Self {
+        self.headless = headless;
+        self
+    }
+
+    pub fn codex_bin(mut self, bin: impl Into<String>) -> Self {
+        self.codex_bin = bin.into();
+        self
+    }
+
+    pub fn build(self) -> CodexRunner {
+        CodexRunner {
+            codex_bin: self.codex_bin,
+            headless: self.headless,
+        }
+    }
+}
+
+/// Drives the Codex CLI in `codex exec --json` mode.
+///
+/// Construct via [`CodexRunnerConfig`]:
+/// ```ignore
+/// let runner = CodexRunnerConfig::default().headless(true).build();
+/// ```
+pub struct CodexRunner {
+    pub codex_bin: String,
+    /// When true, passes `--full-auto` to the codex CLI (automated sandbox execution).
+    pub headless: bool,
+}
+
+impl CodexRunner {
+    pub fn from_config(config: CodexRunnerConfig) -> Self {
+        config.build()
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────────────────────
+
+    /// Translate `InvokeOptions` into a [`SubprocessSpec`] ready to pass to
+    /// [`SubprocessSession::spawn`].
+    ///
+    /// Unsupported options are logged and ignored — see module-level doc for the full list.
+    fn build_subprocess_spec(&self, prompt: &str, options: &InvokeOptions) -> SubprocessSpec {
+        // Log unsupported options so operators can diagnose unexpected behaviour.
+        match &options.tool_policy {
+            ToolPermissionPolicy::RunnerDefault => {}
+            other => {
+                tracing::warn!(
+                    policy = ?other,
+                    "CodexRunner: tool_policy is not supported by the codex CLI; \
+                     the runner's default sandbox level will be used"
+                );
+            }
+        }
+        if options.system_prompt.is_some() || !options.append_system_prompt.is_empty() {
+            tracing::trace!(
+                "CodexRunner: system_prompt / append_system_prompt are not supported \
+                 by the codex CLI; ignoring"
+            );
+        }
+        if options.permission_responder.is_some() {
+            tracing::trace!(
+                "CodexRunner: permission_responder is not supported by the codex CLI; ignoring"
+            );
+        }
+
+        // Build the argument list.
+        // Invocation form:
+        //   codex exec [resume <thread_id>] --json [--model <model>] [--full-auto] <prompt>
+        let mut args: Vec<String> = vec!["exec".into()];
+
+        if let Some(ref sid) = options.resume_session_id {
+            args.push("resume".into());
+            args.push(sid.clone());
+        }
+
+        args.push("--json".into());
+
+        if let Some(ref model) = options.model {
+            args.push("--model".into());
+            args.push(model.clone());
+        }
+
+        if self.headless {
+            args.push("--full-auto".into());
+        }
+
+        args.push(prompt.to_string());
+
+        SubprocessSpec {
+            program: self.codex_bin.clone(),
+            args,
+            // No nested-session guard equivalent for codex.
+            env_remove: vec![],
+            // OPENAI_API_KEY is read by the codex binary from the ambient environment;
+            // this runner does not set or modify it.
+            env_set: vec![],
+        }
+    }
+}
+
+impl Default for CodexRunner {
+    fn default() -> Self {
+        CodexRunnerConfig::default().build()
+    }
+}
+
+impl Runner for CodexRunner {
+    fn invoke(&self, prompt: &str, options: InvokeOptions) -> Result<RunResult, AilError> {
+        let spec = self.build_subprocess_spec(prompt, &options);
+        let mut session = SubprocessSession::spawn(spec, None)?;
+        let stdout = session.take_stdout().expect("stdout taken once");
+        let mut decoder = CodexNdjsonDecoder::new();
+
+        for line in stdout.lines() {
+            let line = line.map_err(|e| AilError::RunnerInvocationFailed {
+                detail: e.to_string(),
+                context: None,
+            })?;
+            if line.is_empty() {
+                continue;
+            }
+            if let Err(detail) = decoder.feed(&line, None) {
+                // JSON parse error — still need to reap the child.
+                let _ = session.finish();
+                return Err(AilError::RunnerInvocationFailed {
+                    detail,
+                    context: None,
+                });
+            }
+            if decoder.is_done() {
+                break;
+            }
+        }
+
+        let outcome = session.finish()?;
+
+        if let Some(detail) = decoder.take_error() {
+            return Err(AilError::RunnerInvocationFailed {
+                detail,
+                context: None,
+            });
+        }
+
+        if !outcome.exit_status.success() {
+            let code = outcome
+                .exit_status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".to_string());
+            let detail = if outcome.stderr.trim().is_empty() {
+                format!("Process exited with {code}")
+            } else {
+                format!("Process exited with {code}: {}", outcome.stderr.trim())
+            };
+            tracing::error!(stderr = %outcome.stderr.trim(), "codex CLI exited non-zero");
+            return Err(AilError::RunnerInvocationFailed {
+                detail,
+                context: None,
+            });
+        }
+
+        decoder.finalize()
+    }
+
+    /// Streaming variant — parses Codex NDJSON events and emits `RunnerEvent`s.
+    ///
+    /// If `options.cancel_token` is set, a watchdog thread blocks on the token's event
+    /// listener (no polling). When `cancel()` is called, the child subprocess is killed and
+    /// the invocation returns `RUNNER_CANCELLED`.
+    fn invoke_streaming(
+        &self,
+        prompt: &str,
+        options: InvokeOptions,
+        tx: mpsc::Sender<RunnerEvent>,
+    ) -> Result<RunResult, AilError> {
+        let spec = self.build_subprocess_spec(prompt, &options);
+        let mut session = SubprocessSession::spawn(spec, options.cancel_token.clone())?;
+        let stdout = session.take_stdout().expect("stdout taken once");
+        let mut decoder = CodexNdjsonDecoder::new();
+
+        for line in stdout.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(e) => {
+                    // IO error reading stdout — stash it and break to reap child cleanly.
+                    decoder
+                        .feed(
+                            &serde_json::json!({
+                                "type": "error",
+                                "message": e.to_string()
+                            })
+                            .to_string(),
+                            None,
+                        )
+                        .ok();
+                    break;
+                }
+            };
+            if line.is_empty() {
+                continue;
+            }
+            decoder.feed(&line, Some(&tx)).ok();
+            if decoder.is_done() {
+                break;
+            }
+        }
+
+        let outcome = session.finish()?;
+
+        if outcome.was_cancelled {
+            tracing::info!("codex runner invocation cancelled by user");
+            let _ = tx.send(RunnerEvent::Error("cancelled".to_string()));
+            return Err(AilError::RunnerCancelled {
+                detail: "Runner subprocess was cancelled by user request".to_string(),
+                context: None,
+            });
+        }
+
+        if let Some(detail) = decoder.take_error() {
+            let _ = tx.send(RunnerEvent::Error(detail.clone()));
+            return Err(AilError::RunnerInvocationFailed {
+                detail,
+                context: None,
+            });
+        }
+
+        if !outcome.exit_status.success() {
+            let code = outcome
+                .exit_status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".to_string());
+            let detail = if outcome.stderr.trim().is_empty() {
+                format!("Process exited with {code}")
+            } else {
+                format!("Process exited with {code}: {}", outcome.stderr.trim())
+            };
+            tracing::error!(stderr = %outcome.stderr.trim(), "codex CLI exited non-zero");
+            let _ = tx.send(RunnerEvent::Error(detail.clone()));
+            return Err(AilError::RunnerInvocationFailed {
+                detail,
+                context: None,
+            });
+        }
+
+        let result = decoder.finalize()?;
+        let _ = tx.send(RunnerEvent::Completed(result.clone()));
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Requires: `codex` CLI in PATH, `OPENAI_API_KEY` set, run outside a Claude Code
+    /// session.
+    ///
+    /// Run with: cargo nextest run -- --ignored
+    #[test]
+    #[ignore]
+    fn codex_runner_returns_non_empty_response() {
+        let runner = CodexRunnerConfig::default().build();
+        let result = runner
+            .invoke(
+                "Reply with exactly the word: hello",
+                InvokeOptions::default(),
+            )
+            .unwrap();
+        assert!(!result.response.is_empty());
+        assert!(result.session_id.is_some());
+    }
+
+    #[test]
+    #[ignore]
+    fn codex_runner_response_contains_expected_text() {
+        let runner = CodexRunnerConfig::default().build();
+        let result = runner
+            .invoke(
+                "Reply with exactly one word: banana",
+                InvokeOptions::default(),
+            )
+            .unwrap();
+        assert!(
+            result.response.to_lowercase().contains("banana"),
+            "Expected 'banana' in response, got: {}",
+            result.response
+        );
+    }
+}

--- a/ail-core/src/runner/codex/mod.rs
+++ b/ail-core/src/runner/codex/mod.rs
@@ -21,8 +21,8 @@
 
 #![allow(clippy::result_large_err)]
 
-mod wire_dto;
 pub mod decoder;
+mod wire_dto;
 
 use std::io::BufRead;
 use std::sync::mpsc;

--- a/ail-core/src/runner/codex/wire_dto.rs
+++ b/ail-core/src/runner/codex/wire_dto.rs
@@ -1,0 +1,50 @@
+//! Serde DTOs for the `codex exec --json` wire format.
+//!
+//! These types are used internally by [`super::decoder`] to deserialize NDJSON events
+//! in a single typed pass rather than using stringly-typed `serde_json::Value` indexing.
+//!
+//! The Codex CLI uses an item lifecycle model: each logical work item (agent message,
+//! command execution, reasoning) progresses through `item.started` → `item.updated` →
+//! `item.completed` events. The session is identified by `thread_id` from `thread.started`.
+
+use serde::Deserialize;
+
+/// A top-level NDJSON event line from `codex exec --json`.
+///
+/// Fields are `Option<T>` because different event types carry different subsets of fields.
+/// The `event_type` field determines which others are populated.
+#[derive(Debug, Deserialize)]
+pub(super) struct WireCodexEvent {
+    /// Discriminant field — one of: `thread.started`, `item.started`, `item.updated`,
+    /// `item.completed`, `turn.completed`, `turn.failed`, `error`.
+    #[serde(rename = "type")]
+    pub event_type: String,
+    /// Present on `thread.started`. Becomes `session_id` in [`RunResult`].
+    pub thread_id: Option<String>,
+    /// Present on all `item.*` events. Used as `tool_use_id` for command execution items.
+    pub item_id: Option<String>,
+    /// Item category — `"agent_message"`, `"command_execution"`, `"reasoning"`, etc.
+    /// Present on all `item.*` events.
+    pub item_type: Option<String>,
+    /// Item payload. Present on `item.started`, `item.updated`, `item.completed`.
+    pub item: Option<WireItem>,
+    /// Human-readable error. Present on `turn.failed`.
+    pub error: Option<String>,
+    /// Human-readable message. Present on the `error` event type.
+    pub message: Option<String>,
+}
+
+/// Contents of an item, as carried in `item.started` / `item.updated` / `item.completed`.
+///
+/// Different item types populate different fields; all are optional.
+#[derive(Debug, Deserialize)]
+pub(super) struct WireItem {
+    /// Narrative text. Present on `agent_message` and `reasoning` items.
+    pub text: Option<String>,
+    /// Shell command. Present on `command_execution` items at `item.started`.
+    pub command: Option<String>,
+    /// Combined stdout+stderr. Present on `command_execution` items at `item.completed`.
+    pub aggregated_output: Option<String>,
+    /// Shell exit code. Present on `command_execution` items at `item.completed`.
+    pub exit_code: Option<i32>,
+}

--- a/ail-core/src/runner/factory.rs
+++ b/ail-core/src/runner/factory.rs
@@ -16,6 +16,7 @@
 
 use super::{
     claude::{ClaudeCliRunner, ClaudeCliRunnerConfig},
+    codex::CodexRunnerConfig,
     http::{HttpRunner, HttpRunnerConfig, HttpSessionStore},
     plugin::{PluginRegistry, ProtocolRunner},
     stub::StubRunner,
@@ -39,6 +40,8 @@ impl RunnerFactory {
     ///
     /// Recognised names (case-insensitive, whitespace-trimmed):
     /// - `"claude"` — `ClaudeCliRunner` with the given headless flag
+    /// - `"codex"` — `CodexRunner`; reads `AIL_CODEX_BIN` (default: `"codex"`) from the
+    ///   environment. Requires `OPENAI_API_KEY` set in the ambient environment.
     /// - `"http"` or `"ollama"` — `HttpRunner`; reads `AIL_HTTP_BASE_URL` (default:
     ///   `http://localhost:11434/v1`), `AIL_HTTP_TOKEN`, `AIL_HTTP_MODEL`, `AIL_HTTP_THINK`
     ///   from the environment.
@@ -74,13 +77,22 @@ impl RunnerFactory {
         provider: &ProviderConfig,
         registry: &PluginRegistry,
     ) -> Result<Box<dyn Runner + Send>, AilError> {
-        let _ = headless; // consumed by claude only
         let normalized = runner_name.trim().to_lowercase();
         match normalized.as_str() {
             "claude" => {
                 let runner: ClaudeCliRunner =
                     ClaudeCliRunnerConfig::default().headless(headless).build();
                 Ok(Box::new(runner))
+            }
+            "codex" => {
+                let codex_bin = std::env::var("AIL_CODEX_BIN")
+                    .unwrap_or_else(|_| "codex".to_string());
+                Ok(Box::new(
+                    CodexRunnerConfig::default()
+                        .codex_bin(codex_bin)
+                        .headless(headless)
+                        .build(),
+                ))
             }
             "http" | "ollama" => {
                 // ProviderConfig values take precedence over env vars.
@@ -118,7 +130,7 @@ impl RunnerFactory {
                     return Ok(Box::new(ProtocolRunner::new(manifest.clone())));
                 }
 
-                let mut known: Vec<&str> = vec!["claude", "http", "ollama", "stub"];
+                let mut known: Vec<&str> = vec!["claude", "codex", "http", "ollama", "stub"];
                 let plugin_names = registry.runner_names();
                 known.extend(plugin_names.iter().copied());
 

--- a/ail-core/src/runner/factory.rs
+++ b/ail-core/src/runner/factory.rs
@@ -85,8 +85,8 @@ impl RunnerFactory {
                 Ok(Box::new(runner))
             }
             "codex" => {
-                let codex_bin = std::env::var("AIL_CODEX_BIN")
-                    .unwrap_or_else(|_| "codex".to_string());
+                let codex_bin =
+                    std::env::var("AIL_CODEX_BIN").unwrap_or_else(|_| "codex".to_string());
                 Ok(Box::new(
                     CodexRunnerConfig::default()
                         .codex_bin(codex_bin)

--- a/ail-core/src/runner/mod.rs
+++ b/ail-core/src/runner/mod.rs
@@ -9,7 +9,9 @@
 //! - [`claude::ClaudeCliRunner`] — drives `claude --output-format stream-json --verbose -p`.
 //!   Handles Anthropic API, Ollama, Bedrock, and any provider the `claude` CLI supports,
 //!   because the CLI normalises upstream differences into one `stream-json` format.
-//! - Future runners would live here (e.g. `codex::CodexRunner`, `opencode::OpenCodeRunner`).
+//! - [`codex::CodexRunner`] — drives `codex exec --json` (OpenAI Codex CLI).
+//!   Uses an item-lifecycle NDJSON stream; `turn.completed` is the terminal signal.
+//! - Future runners would live here (e.g. `opencode::OpenCodeRunner`).
 //!
 //! Provider config (base URL, auth token, model) flows through [`InvokeOptions`] so the
 //! executor never names a specific provider. Model-specific output quirks — XML tool calls
@@ -23,6 +25,7 @@
 #![allow(clippy::result_large_err)]
 
 pub mod claude;
+pub mod codex;
 pub mod dry_run;
 pub mod factory;
 pub mod http;

--- a/spec/runner/r06-codex-runner.md
+++ b/spec/runner/r06-codex-runner.md
@@ -1,0 +1,184 @@
+## Codex Runner
+
+The Codex runner wraps the OpenAI Codex CLI (`@openai/codex`) in its non-interactive
+`codex exec --json` mode. It targets OpenAI models and is the second first-class runner
+in `ail` after the Claude CLI runner.
+
+---
+
+### 1. Purpose
+
+`CodexRunner` adapts the Codex CLI's item-lifecycle NDJSON stream to `ail`'s `Runner`
+trait. It provides streaming output, session continuity (via thread IDs), extended thinking
+(via reasoning items), and tool event capture — without requiring any changes to the executor
+or the pipeline language.
+
+---
+
+### 2. Invocation
+
+**CLI form:**
+```
+codex exec [resume <thread_id>] --json [--model <model>] [--full-auto] <prompt>
+```
+
+**Environment variables:**
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `OPENAI_API_KEY` | Authentication — read by the `codex` binary | *(must be set by operator)* |
+| `AIL_CODEX_BIN` | Path or name of the `codex` executable | `"codex"` |
+
+`OPENAI_API_KEY` is **not** set or modified by `ail`. It must be present in the ambient
+environment before `ail` is invoked.
+
+`AIL_CODEX_BIN` lets operators pin a specific version or path (`/usr/local/bin/codex-1.2.3`)
+without modifying `PATH`.
+
+**Install the Codex CLI:**
+```bash
+npm i -g @openai/codex
+```
+
+---
+
+### 3. Session Resumption
+
+When `InvokeOptions::resume_session_id` is set, the runner passes it as:
+```
+codex exec resume <thread_id> --json ...
+```
+
+The `thread_id` is obtained from the `thread.started` event in the previous invocation's
+stream and is stored as `RunResult::session_id`. It is the Codex equivalent of Claude's
+`--resume <session_id>`.
+
+---
+
+### 4. Wire Format
+
+`codex exec --json` produces a newline-delimited stream of JSON events (NDJSON) on stdout.
+The stream uses an **item lifecycle model**: each logical work unit (agent message, command
+execution, reasoning) progresses through `item.started` → `item.updated` → `item.completed`
+events.
+
+**Key event types:**
+
+```json
+// Session initialised
+{ "type": "thread.started", "thread_id": "thread_abc123" }
+
+// Text streaming (agent_message item in progress)
+{ "type": "item.updated", "item_type": "agent_message",
+  "item": { "text": "Here is my answer...", "status": "in_progress" } }
+
+// Shell command started
+{ "type": "item.started", "item_type": "command_execution",
+  "item_id": "cmd_xyz", "item": { "command": "ls -la", "status": "in_progress" } }
+
+// Shell command completed
+{ "type": "item.completed", "item_type": "command_execution",
+  "item_id": "cmd_xyz",
+  "item": { "aggregated_output": "total 8\ndrwxr-xr-x ...", "exit_code": 0,
+            "status": "completed" } }
+
+// Reasoning block in progress (extended thinking)
+{ "type": "item.updated", "item_type": "reasoning",
+  "item": { "text": "Let me consider...", "status": "in_progress" } }
+
+// Final agent message (response text)
+{ "type": "item.completed", "item_type": "agent_message",
+  "item": { "text": "The answer is 42.", "status": "completed" } }
+
+// Turn finished successfully
+{ "type": "turn.completed" }
+
+// Turn failed
+{ "type": "turn.failed", "error": "rate limit exceeded" }
+
+// Protocol-level error
+{ "type": "error", "message": "connection refused" }
+```
+
+**Completion signal:** `ail` considers a Codex invocation complete when it receives a
+`turn.completed` event. `turn.failed` or `error` → `on_error` handling fires.
+
+**Token counts:** The `codex exec --json` wire format does not expose per-turn token usage.
+`RunResult::input_tokens` and `RunResult::output_tokens` are always `0` for this runner.
+`RunResult::cost_usd` is always `None`.
+
+---
+
+### 5. Decoder Event Map
+
+`CodexNdjsonDecoder` processes the following events:
+
+| Wire `event_type` | `item_type` | Action |
+|---|---|---|
+| `thread.started` | — | Store `thread_id` → becomes `RunResult::session_id` |
+| `item.updated` | `agent_message` | Emit `StreamDelta { text }` |
+| `item.updated` | `reasoning` | Accumulate thinking; emit `Thinking { text }` |
+| `item.started` | `command_execution` | Emit `ToolUse { tool_name: "Bash", tool_use_id: item_id, input: {command} }`; push `tool_call` to `tool_events` |
+| `item.completed` | `command_execution` | Emit `ToolResult`; push `tool_result` to `tool_events` |
+| `item.completed` | `agent_message` | Overwrite `response` with final `item.text` |
+| `turn.completed` | — | Set `done = true` |
+| `turn.failed` | — | Set `error = event.error`, `done = true` |
+| `error` | — | Set `error = event.message`, `done = true` |
+| Anything else | — | `tracing::trace!`, continue |
+
+When multiple `item.completed` / `agent_message` events arrive in a single turn (unlikely
+but possible), the **last one wins** — its text becomes the final response.
+
+---
+
+### 6. Unsupported `InvokeOptions` Fields
+
+The Codex CLI does not expose the same hook and tool-policy mechanisms as the Claude CLI.
+The following `InvokeOptions` fields are ignored:
+
+| Field | Reason | Log level |
+|---|---|---|
+| `tool_policy` (non-default) | Codex uses sandbox levels, not named tool allowlists | `WARN` |
+| `system_prompt` | No CLI equivalent | `TRACE` |
+| `append_system_prompt` | No CLI equivalent | `TRACE` |
+| `permission_responder` | No hook mechanism in the Codex CLI | `TRACE` |
+
+`tool_policy: RunnerDefault` is silent (no log).
+
+Pipeline authors who need tool control with Codex should rely on Codex's native sandbox
+levels (controlled via `--full-auto` / headless mode) rather than `ail` tool policies.
+
+---
+
+### 7. Headless Mode
+
+When `CodexRunnerConfig::headless` is `true`, the runner adds `--full-auto` to the
+invocation:
+```
+codex exec --json --full-auto <prompt>
+```
+
+`--full-auto` enables Codex's automated execution sandbox: tool calls are approved without
+per-call prompts. This is the Codex equivalent of Claude's `--dangerously-skip-permissions`
+and is required for CI and other automated environments.
+
+When `headless` is `false` (the default), Codex runs in its default interactive sandbox
+mode — tool calls may require confirmation depending on the Codex version and configuration.
+
+---
+
+### 8. Factory Registration
+
+`CodexRunner` is registered in `RunnerFactory` under the name `"codex"` (case-insensitive):
+
+```yaml
+# .ail.yaml
+steps:
+  - id: my_step
+    runner: codex
+    prompt: "Describe the files in this directory."
+```
+
+The factory reads `AIL_CODEX_BIN` and the `headless` flag from the pipeline's execution
+context. All other Codex configuration is read from the ambient environment by the `codex`
+binary itself.


### PR DESCRIPTION
## Summary

Adds first-class support for the OpenAI Codex CLI (`@openai/codex`) as a new runner alongside the existing Claude CLI runner. The implementation includes a stateful NDJSON decoder, subprocess orchestration, and full streaming support with session resumption.

## Key Changes

- **New `CodexRunner` module** (`ail-core/src/runner/codex/`):
  - `mod.rs`: Main runner implementation with subprocess spawning, argument building, and invocation logic
  - `decoder.rs`: Stateful `CodexNdjsonDecoder` that parses the Codex CLI's item-lifecycle NDJSON wire format
  - `wire_dto.rs`: Serde DTOs for typed deserialization of Codex events

- **Decoder features**:
  - Processes `thread.started`, `item.started/updated/completed`, `turn.completed/failed`, and `error` events
  - Accumulates reasoning text into `RunResult::thinking`
  - Captures tool calls and results as `ToolEvent` sequences
  - Emits streaming `RunnerEvent`s (StreamDelta, Thinking, ToolUse, ToolResult)
  - Handles session resumption via `thread_id` → `session_id` mapping
  - Comprehensive unit tests covering all event types and error conditions

- **Runner implementation**:
  - Supports both blocking (`invoke`) and streaming (`invoke_streaming`) modes
  - Builds CLI arguments for `codex exec [resume <thread_id>] --json [--model <model>] [--full-auto] <prompt>`
  - Headless mode via `--full-auto` flag for automated tool execution
  - Cancellation support via `cancel_token` watchdog
  - Graceful error handling for JSON parse failures, process exit codes, and wire-level errors

- **Configuration**:
  - `CodexRunnerConfig` builder with `headless()` and `codex_bin()` methods
  - Reads `AIL_CODEX_BIN` environment variable (default: `"codex"`)
  - `OPENAI_API_KEY` read directly by the Codex binary (not set by `ail`)

- **Factory integration**:
  - Registered in `RunnerFactory` under name `"codex"` (case-insensitive)
  - Updated module documentation and CLAUDE.md

- **Specification**:
  - Added `spec/runner/r06-codex-runner.md` documenting the full contract, wire format, unsupported options, and session resumption

## Notable Implementation Details

- **Unsupported options** (`tool_policy`, `system_prompt`, `permission_responder`) are logged at appropriate levels (WARN for tool_policy, TRACE for others) rather than failing
- **Token counts** are always zero (not exposed by Codex CLI wire format)
- **Last-write-wins** semantics for multiple `agent_message` completions in a single turn
- **Decoupled decoding**: The decoder is completely independent of subprocess lifecycle, enabling thorough testing with raw byte strings
- **Streaming consumers** receive events via `mpsc::Sender<RunnerEvent>` before finalization, matching the Claude runner's pattern

https://claude.ai/code/session_01KCsLNVYGvxMzhwj9fjZ1ky