### PR TITLE
design(#120): draft spec §30 and implementation plan for sampling parameter control

### DIFF
--- a/docs/design-120-sampling-parameters.md
+++ b/docs/design-120-sampling-parameters.md
@@ -1,0 +1,326 @@
+# Design: Sampling Parameter Control (#120)
+
+## Context
+
+This document captures the design decisions and implementation plan for
+per-step LLM sampling parameter control. The spec draft lives at
+`spec/core/s30-sampling-parameters.md`.
+
+## Design Decisions
+
+### D1: Which parameters to expose
+
+**Decision**: Six first-class fields: `temperature`, `top_p`, `top_k`,
+`max_tokens`, `stop_sequences`, `thinking`.
+
+**Rationale**: These cover the universal set (temperature/top_p/max_tokens),
+the important-but-not-universal set (top_k, stop_sequences), and the
+increasingly critical reasoning toggle (thinking). No `extra: HashMap`
+escape hatch in v1 — it adds complexity without clear demand. Can be added
+later as a backwards-compatible extension.
+
+**Alternative rejected**: Flat fields on Step (e.g., `step.temperature`).
+Pollutes the step namespace. A `sampling:` block groups related concerns.
+
+### D2: YAML syntax — `sampling:` block
+
+**Decision**: Nested `sampling:` block on both `defaults:` and per-step.
+
+```yaml
+defaults:
+  sampling:
+    temperature: 0.3
+pipeline:
+  - id: creative
+    prompt: "..."
+    sampling:
+      temperature: 0.9
+```
+
+**Rationale**: Groups sampling params cleanly. Parallels `tools:`, `on_result:`,
+`context:` as a nested block. Keeps the step's top-level namespace for
+behavioral fields (id, prompt, model, runner, condition, etc.).
+
+### D3: Runner pass-through — first-class on InvokeOptions
+
+**Decision**: Add `sampling: Option<SamplingConfig>` directly to `InvokeOptions`,
+NOT inside the extensions box.
+
+**Rationale**: Sampling parameters are universal — every runner understands
+temperature and max_tokens in concept. They aren't runner-specific like
+`base_url` or `auth_token`. Making them first-class on `InvokeOptions`
+means runners don't need to downcast. The extensions box remains for
+truly runner-specific data.
+
+### D4: Keep sampling separate from ProviderConfig
+
+**Decision**: New `SamplingConfig` struct, parallel to but separate from
+`ProviderConfig`.
+
+**Rationale**: `ProviderConfig` answers "where and how to connect" (model,
+base_url, auth_token, timeouts). `SamplingConfig` answers "how to generate"
+(temperature, top_p, max_tokens). They're conceptually distinct. Merging
+them would make `ProviderConfig` a grab-bag.
+
+Both structs follow the same `merge()` pattern: right-hand field wins,
+absent fields fall through.
+
+### D5: No CLI override for sampling
+
+**Decision**: No `--temperature` flag on `ail` CLI.
+
+**Rationale**: Sampling is a pipeline design concern. The pipeline author
+chose temperature=0.3 for a reason. Runtime overrides via CLI flags would
+undermine that intent. `--model` is the appropriate runtime knob — it changes
+the model, which has its own default sampling behavior.
+
+If demand emerges, `--sampling-override temperature=0.9` could be added later
+as an explicit "I know what I'm doing" escape hatch.
+
+### D6: Best-of-N is composition, not primitive
+
+**Decision**: No built-in best-of-N. Compose with `for_each:` + selection step.
+
+**Rationale**: Best-of-N is a pattern, not a primitive. It composes from
+`for_each:` (generate N), `output_schema:` (structured candidates), and a
+final selection step with `temperature: 0.0`. Adding a built-in would
+duplicate what the loop system already does.
+
+### D7: `thinking` subsumes HttpRunner's `think` field
+
+**Decision**: `sampling.thinking: bool` replaces the current
+`HttpRunnerConfig.think` as the per-step control. The config-level `think`
+remains as the runner's default.
+
+**Rationale**: The HttpRunner already has `think: Option<bool>`. Promoting
+this to a sampling parameter makes it accessible to pipeline authors
+without knowing runner internals. The merge is: `sampling.thinking`
+overrides `HttpRunnerConfig.think` for that step.
+
+### D8: Unsupported parameters warn, never error
+
+**Decision**: Runners emit `tracing::warn!` for unsupported sampling params.
+Never `AilError`.
+
+**Rationale**: The acceptance criteria explicitly require this. It enables
+pipeline portability — a pipeline authored for the HTTP runner (which supports
+all params) can run on ClaudeCliRunner (which supports none today) with
+warnings instead of failures.
+
+## Implementation Plan
+
+### Phase 1: Data model (DTO + Domain + Validation)
+
+**Files to change**:
+
+1. **`ail-core/src/config/dto.rs`**
+   - Add `SamplingDto` struct with all six fields (all `Option`)
+   - Add `sampling: Option<SamplingDto>` to `StepDto`
+   - Add `sampling: Option<SamplingDto>` to `DefaultsDto`
+
+2. **`ail-core/src/config/domain.rs`**
+   - Add `SamplingConfig` struct (Debug, Clone, Default) with all six fields
+   - Add `SamplingConfig::merge(self, other) -> SamplingConfig` method
+   - Add `sampling: Option<SamplingConfig>` to `Step`
+   - Add `sampling_defaults: Option<SamplingConfig>` to `Pipeline`
+
+3. **`ail-core/src/config/validation/mod.rs`**
+   - Add `validate_sampling(dto: Option<SamplingDto>) -> Result<Option<SamplingConfig>>`
+   - Range checks: temperature [0.0, 2.0], top_p [0.0, 1.0], top_k ≥ 1, max_tokens ≥ 1
+   - Warn if `sampling:` appears on context/action step
+   - Wire into `validate_steps()` step construction
+   - Wire into pipeline-level validation for `defaults.sampling`
+
+### Phase 2: Executor plumbing
+
+**Files to change**:
+
+4. **`ail-core/src/runner/mod.rs`**
+   - Add `sampling: Option<SamplingConfig>` to `InvokeOptions`
+   - Update `InvokeOptions::default()` (already None)
+
+5. **`ail-core/src/executor/helpers/runner_resolution.rs`**
+   - Add `resolve_step_sampling(session: &Session, step: &Step) -> Option<SamplingConfig>`
+   - Merge: `session.pipeline.sampling_defaults.merge(step.sampling)`
+
+6. **`ail-core/src/executor/dispatch/prompt.rs`**
+   - Call `resolve_step_sampling()` and set `options.sampling`
+
+7. **`ail-core/src/executor/dispatch/skill.rs`**
+   - Same as prompt.rs — skill steps also invoke the runner
+
+### Phase 3: Runner implementations
+
+**Files to change**:
+
+8. **`ail-core/src/runner/claude/mod.rs`**
+   - In `build_subprocess_spec()`: if `options.sampling` has any `Some` field,
+     emit `tracing::warn!("ClaudeCliRunner: sampling parameter '{name}' is not \
+     supported by the claude CLI; ignoring")`
+   - No CLI args added (claude CLI doesn't support them)
+
+9. **`ail-core/src/runner/http.rs`**
+   - Add sampling fields to `ChatRequest`: `temperature`, `top_p`, `top_k`,
+     `max_tokens`, `stop` (mapped from `stop_sequences`)
+   - In `invoke()`: read from `options.sampling`, populate `ChatRequest` fields
+   - `sampling.thinking` overrides `self.config.think` for that invocation
+   - Warn on `top_k` if the endpoint is not known to support it (optional)
+
+10. **`ail-core/src/runner/plugin/protocol_runner.rs`**
+    - Include `sampling` in the `invoke` JSON-RPC params
+
+11. **`ail-core/src/runner/codex/mod.rs`**
+    - Warn on sampling params (codex CLI doesn't support them)
+
+12. **`ail-core/src/runner/dry_run.rs`**
+    - No change needed (ignores all options)
+
+### Phase 4: Session / Turn log
+
+**Files to change**:
+
+13. **`ail-core/src/session/state.rs`** (or `turn_log.rs`)
+    - Add `sampling: Option<SamplingConfig>` to `TurnEntry`
+    - Serialize only non-None fields in NDJSON output
+
+### Phase 5: Materialize
+
+**Files to change**:
+
+14. **`ail-core/src/materialize.rs`**
+    - Render `sampling:` block with `# origin` comments
+
+### Phase 6: Tests
+
+**Files to create/change**:
+
+15. **`ail-core/tests/spec/s30_sampling.rs`**
+    - Parse-time: valid sampling configs parse correctly
+    - Parse-time: out-of-range values produce validation errors
+    - Parse-time: sampling on context step produces warning
+    - Merge: pipeline defaults + step override merges correctly
+    - Executor: sampling flows through to InvokeOptions (use RecordingStubRunner)
+    - Executor: absent sampling means None on InvokeOptions
+
+16. **`ail-core/tests/fixtures/`**
+    - Add `sampling_basic.yaml`, `sampling_override.yaml` fixtures
+
+### Phase 7: Spec and docs
+
+17. **`spec/core/s30-sampling-parameters.md`** — already drafted (this PR)
+18. **`spec/README.md`** — add §30 row to the table
+19. **`ail-core/CLAUDE.md`** — update Key Types for SamplingConfig, Step, Pipeline, InvokeOptions
+20. **`CLAUDE.md`** — update template variable table if needed (no new vars expected)
+
+## Struct Sketches
+
+```rust
+// ── DTO (dto.rs) ──────────────────────────────────────────────────────
+#[derive(Debug, Default, Deserialize)]
+pub struct SamplingDto {
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub top_k: Option<u64>,
+    pub max_tokens: Option<u64>,
+    pub stop_sequences: Option<Vec<String>>,
+    pub thinking: Option<bool>,
+}
+
+// ── Domain (domain.rs) ────────────────────────────────────────────────
+#[derive(Debug, Clone, Default)]
+pub struct SamplingConfig {
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub top_k: Option<u64>,
+    pub max_tokens: Option<u64>,
+    pub stop_sequences: Option<Vec<String>>,
+    pub thinking: Option<bool>,
+}
+
+impl SamplingConfig {
+    /// Merge `other` on top of `self`. `other` fields take precedence.
+    pub fn merge(self, other: SamplingConfig) -> SamplingConfig {
+        SamplingConfig {
+            temperature: other.temperature.or(self.temperature),
+            top_p: other.top_p.or(self.top_p),
+            top_k: other.top_k.or(self.top_k),
+            max_tokens: other.max_tokens.or(self.max_tokens),
+            stop_sequences: other.stop_sequences.or(self.stop_sequences),
+            thinking: other.thinking.or(self.thinking),
+        }
+    }
+
+    /// Returns true if all fields are None.
+    pub fn is_empty(&self) -> bool {
+        self.temperature.is_none()
+            && self.top_p.is_none()
+            && self.top_k.is_none()
+            && self.max_tokens.is_none()
+            && self.stop_sequences.is_none()
+            && self.thinking.is_none()
+    }
+}
+
+// ── InvokeOptions addition (runner/mod.rs) ────────────────────────────
+pub struct InvokeOptions {
+    // ... existing fields ...
+    pub sampling: Option<SamplingConfig>,
+}
+
+// ── HttpRunner ChatRequest addition (runner/http.rs) ──────────────────
+#[derive(Debug, Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: &'a [ChatMessage],
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    think: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_k: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop: Option<Vec<String>>,
+}
+```
+
+## Open Questions for Review
+
+1. **Should `stop_sequences` merge or replace?** Current design: step-level
+   `stop_sequences` *replaces* (not appends to) pipeline default. This is
+   simpler and avoids surprising accumulation. But append could be useful.
+   **Proposed**: replace (matches how `tools:` works — step overrides pipeline).
+
+2. **Should `thinking` support a `budget_tokens` variant?** The Anthropic API
+   allows `thinking: { type: "enabled", budget_tokens: 10000 }`. We could model
+   this as `thinking: true` (boolean) or `thinking: { budget_tokens: 10000 }`
+   (struct). **Proposed**: boolean for v1, struct variant for later. The YAML
+   syntax `thinking: true` is forwards-compatible — a future `thinking:
+   budget_tokens: 10000` syntax doesn't conflict.
+
+3. **`max_tokens` vs `max_output_tokens`?** Anthropic API uses `max_tokens`,
+   OpenAI recently switched to `max_completion_tokens`. We use `max_tokens`
+   because it's shorter and more widely recognized. Runners map to the
+   provider's preferred name.
+
+4. **Validation strictness**: Should we error or warn when `temperature` and
+   `top_p` are both set? Some providers recommend using one or the other.
+   **Proposed**: allow both — let the provider decide. No ail-level conflict
+   check.
+
+## Dependency Graph
+
+```
+Phase 1 (data model) ──┬── Phase 2 (executor) ──── Phase 3 (runners)
+                       │                            Phase 4 (turn log)
+                       └── Phase 5 (materialize)
+Phase 6 (tests) depends on all above
+Phase 7 (docs) can proceed in parallel
+```
+
+Phases 1→2→3 are the critical path. Phases 4, 5, 7 can be done in parallel
+once Phase 1 is done.

--- a/spec/core/s30-sampling-parameters.md
+++ b/spec/core/s30-sampling-parameters.md
@@ -1,0 +1,261 @@
+# 30. Sampling Parameter Control
+
+> **Status**: draft — design proposal for #120
+
+## 30.1 Purpose
+
+Different pipeline steps have fundamentally different generation needs.
+A code-writing step benefits from low temperature (deterministic, precise),
+while a brainstorming step benefits from high temperature (creative, diverse).
+Extended thinking matters for complex reasoning steps but wastes tokens on simple ones.
+
+This section specifies how pipeline authors control LLM sampling parameters
+at the pipeline level (defaults) and per step (overrides).
+
+## 30.2 The `sampling:` Block
+
+A `sampling:` block may appear in two places:
+
+1. **Pipeline defaults** — `defaults.sampling:` sets baseline parameters for all steps.
+2. **Per step** — `sampling:` on any `prompt:` or `skill:` step overrides the pipeline default.
+
+Context steps (`context: shell:`) and action steps (`action:`) bypass the runner
+entirely, so `sampling:` is ignored on those step types (validation warning).
+
+### 30.2.1 Supported Fields
+
+| Field | Type | Range | Description |
+|---|---|---|---|
+| `temperature` | float | 0.0–2.0 | Controls randomness. 0.0 = deterministic, higher = more creative. |
+| `top_p` | float | 0.0–1.0 | Nucleus sampling — consider tokens comprising the top P probability mass. |
+| `top_k` | integer | ≥ 1 | Consider only the top K most likely tokens. Not supported by all providers. |
+| `max_tokens` | integer | ≥ 1 | Maximum number of tokens in the response. |
+| `stop_sequences` | list of strings | — | Stop generation when any of these strings is produced. |
+| `thinking` | boolean | — | Enable/disable extended thinking (chain-of-thought). |
+
+All fields are optional. Absent fields inherit from the pipeline default;
+if absent there too, the runner's own default applies.
+
+### 30.2.2 Syntax
+
+```yaml
+# Pipeline-level defaults
+defaults:
+  model: claude-sonnet-4-20250514
+  sampling:
+    temperature: 0.3
+    max_tokens: 4096
+
+pipeline:
+  # Inherits defaults: temperature=0.3, max_tokens=4096
+  - id: analyze
+    prompt: "Analyze the codebase for security issues"
+    sampling:
+      thinking: true          # override: enable thinking for this step
+
+  # Full override
+  - id: brainstorm
+    prompt: "Brainstorm 10 creative solutions"
+    sampling:
+      temperature: 0.9
+      top_p: 0.95
+      max_tokens: 8192
+
+  # No sampling block — uses pipeline defaults as-is
+  - id: summarize
+    prompt: "Summarize the above findings"
+```
+
+## 30.3 Merge Semantics
+
+Sampling parameters merge at the **field level**, not block level.
+A step's `sampling:` block overrides individual fields from the pipeline default;
+unspecified fields fall through.
+
+```
+effective = pipeline.defaults.sampling.merge(step.sampling)
+```
+
+Where `merge(other)` applies: `other.field.unwrap_or(self.field)` per field.
+
+This is identical to the `ProviderConfig.merge()` semantics already used for
+model/provider resolution (§15).
+
+**Merge chain**: `defaults.sampling` → step `sampling:` → (no CLI override for sampling).
+
+There is intentionally no `--temperature` CLI flag. Sampling is a pipeline
+design concern, not a runtime override. The `--model` CLI flag remains the
+appropriate runtime knob for switching model behavior.
+
+## 30.4 Runner Responsibilities
+
+### 30.4.1 Core Contract
+
+When `InvokeOptions.sampling` is `Some(config)`:
+
+1. The runner MUST apply any parameters it supports.
+2. The runner MUST emit a `tracing::warn!` for parameters it does not support.
+   The warning includes the parameter name and the runner name.
+3. The runner MUST NOT error on unsupported parameters — warnings only.
+
+This ensures pipelines are portable across runners with graceful degradation.
+
+### 30.4.2 Claude CLI Runner (`claude`)
+
+The Claude CLI does not currently expose sampling parameter flags.
+The ClaudeCliRunner therefore **warns on all sampling parameters** in the
+initial implementation. When Claude CLI adds `--temperature`, `--max-tokens`,
+or similar flags, the runner will map them.
+
+> **Implementation note**: The `--model` flag already flows through. If Anthropic
+> adds sampling flags to the CLI, adding support is a one-line change in
+> `build_subprocess_spec()`.
+
+### 30.4.3 HTTP Runner (`http`, `ollama`)
+
+The HTTP runner controls the API request body directly and supports:
+
+| Sampling field | Maps to | Notes |
+|---|---|---|
+| `temperature` | `"temperature"` in request body | |
+| `top_p` | `"top_p"` in request body | |
+| `top_k` | `"top_k"` in request body | Anthropic API; ignored by OpenAI-compat if unsupported |
+| `max_tokens` | `"max_tokens"` in request body | |
+| `stop_sequences` | `"stop"` in request body | OpenAI format; Anthropic uses `"stop_sequences"` |
+| `thinking` | `"think"` in request body | Existing `HttpRunnerConfig.think` field; sampling overrides it |
+
+### 30.4.4 Plugin Runners (JSON-RPC)
+
+The `invoke` request includes a `sampling` object in `params`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "invoke",
+  "id": 1,
+  "params": {
+    "prompt": "...",
+    "model": "...",
+    "sampling": {
+      "temperature": 0.9,
+      "max_tokens": 4096
+    }
+  }
+}
+```
+
+Plugin runners apply or ignore fields at their discretion. No error for
+unrecognized fields.
+
+## 30.5 Interaction with Other Features
+
+### 30.5.1 Provider Strings (§15)
+
+Sampling parameters are orthogonal to provider strings. The provider string
+selects *which model*; sampling controls *how the model generates*.
+
+```yaml
+- id: creative_step
+  model: anthropic/claude-sonnet-4-20250514
+  sampling:
+    temperature: 0.9
+```
+
+### 30.5.2 Sub-pipelines (§9)
+
+Sub-pipelines inherit their parent's `defaults.sampling` only if the child
+pipeline does not declare its own `defaults.sampling`. This follows the
+existing sub-pipeline isolation rule — child sessions are independent.
+
+### 30.5.3 Pipeline Inheritance / FROM (§7)
+
+`defaults.sampling` participates in FROM inheritance with the same merge
+semantics as `defaults.model`. The child's `defaults.sampling` overrides the
+parent's at the field level.
+
+### 30.5.4 Loops — `do_while:` (§27) and `for_each:` (§28)
+
+Steps inside loop bodies use `sampling:` normally. The sampling config is
+resolved per invocation, not cached for the loop.
+
+### 30.5.5 Best-of-N Sampling
+
+Best-of-N (generate N candidates, select the best) is NOT a built-in primitive.
+It composes naturally from existing features:
+
+```yaml
+pipeline:
+  - id: setup
+    context:
+      shell: "echo '[1,2,3]'"
+    output_schema:
+      type: array
+      items: { type: integer }
+
+  - id: candidates
+    for_each:
+      over: "{{ step.setup.items }}"
+      steps:
+        - id: generate
+          prompt: "Propose a solution for: {{ step.invocation.prompt }}"
+          sampling:
+            temperature: 0.9
+
+  - id: select
+    prompt: |
+      Pick the best solution from the candidates above.
+      Explain why it's best.
+    sampling:
+      temperature: 0.0
+      thinking: true
+```
+
+This keeps the sampling spec simple and orthogonal.
+
+## 30.6 Validation
+
+### 30.6.1 Parse-time
+
+- `temperature` must be in [0.0, 2.0] if present.
+- `top_p` must be in [0.0, 1.0] if present.
+- `top_k` must be ≥ 1 if present.
+- `max_tokens` must be ≥ 1 if present.
+- `stop_sequences` must be a non-empty list of non-empty strings if present.
+- `thinking` must be a boolean if present.
+- `sampling:` on a `context:` or `action:` step emits a validation warning.
+
+### 30.6.2 Runtime
+
+No runtime validation beyond what the runner enforces. If the provider
+rejects a value (e.g., temperature=2.0 on a provider that caps at 1.0),
+the runner's error propagates as `ail:runner/invocation-failed`.
+
+## 30.7 Materialize Output
+
+`ail materialize` renders `sampling:` blocks with `# origin` comments:
+
+```yaml
+- id: brainstorm
+  prompt: "Generate ideas"
+  sampling:                    # origin: .ail.yaml:12
+    temperature: 0.9           # origin: .ail.yaml:13
+    max_tokens: 8192           # origin: .ail.yaml:14
+```
+
+## 30.8 Turn Log
+
+Sampling parameters are recorded in the `TurnEntry` for observability:
+
+```json
+{
+  "step_id": "brainstorm",
+  "sampling": {
+    "temperature": 0.9,
+    "max_tokens": 8192
+  },
+  ...
+}
+```
+
+Only non-default (explicitly set) fields appear. If no sampling was
+configured, the `"sampling"` field is omitted.


### PR DESCRIPTION
Adds spec/core/s30-sampling-parameters.md (spec draft) and
docs/design-120-sampling-parameters.md (design decisions + implementation plan)
covering per-step temperature, top_p, top_k, max_tokens, stop_sequences,
and thinking control with pipeline-level defaults and field-level merge.

https://claude.ai/code/session_01X6n98LEacswEqtmWXU2C8Z