### PR TITLE
fix(vscode-ail-chat): ProcessKiller refactor + Windows process termination fix

### DIFF
--- a/vscode-ail-chat/src/ail-process-manager.ts
+++ b/vscode-ail-chat/src/ail-process-manager.ts
@@ -5,12 +5,14 @@
  * Key invariants:
  *   - CLAUDECODE env var is removed before spawn to avoid the nested-session guard.
  *   - Only one ail process may be active at a time; start() rejects if one is running.
- *   - cancel() sends SIGTERM, then SIGKILL after 5 seconds.
+ *   - cancel() eagerly clears _activeProcess, then delegates to ProcessKiller.
  */
 
 import { spawn, ChildProcess } from 'child_process';
 import { AilEvent, HostToWebviewMessage } from './types';
 import { parseNdjsonStream } from './ndjson';
+import { ProcessKiller } from './process/process-killer';
+import { createProcessKiller } from './process/process-killer-factory';
 
 export interface StartOptions {
   headless?: boolean;
@@ -21,12 +23,14 @@ type MessageHandler = (msg: HostToWebviewMessage) => void;
 export class AilProcessManager {
   private readonly _binaryPath: string;
   private readonly _cwd: string | undefined;
+  private readonly _killer: ProcessKiller;
   private _activeProcess: ChildProcess | undefined;
   private readonly _handlers = new Set<MessageHandler>();
 
-  constructor(binaryPath: string, cwd?: string) {
+  constructor(binaryPath: string, cwd?: string, killer: ProcessKiller = createProcessKiller()) {
     this._binaryPath = binaryPath;
     this._cwd = cwd;
+    this._killer = killer;
   }
 
   /** Register a handler that receives HostToWebviewMessages as they arrive. */
@@ -112,21 +116,14 @@ export class AilProcessManager {
     });
   }
 
-  /** Send SIGTERM, escalate to SIGKILL after 5 seconds. */
+  /** Kill the active process. Clears _activeProcess immediately before delegating to the killer. */
   cancel(): void {
-    if (!this._activeProcess) {
-      return;
-    }
+    if (!this._activeProcess) return;
     const proc = this._activeProcess;
-    proc.kill('SIGTERM');
-
-    const timeout = setTimeout(() => {
-      if (this._activeProcess === proc) {
-        proc.kill('SIGKILL');
-      }
-    }, 5000);
-
-    proc.once('close', () => clearTimeout(timeout));
+    this._activeProcess = undefined; // clear NOW, before async kill
+    void this._killer.kill(proc).catch((err: Error) => {
+      console.error(`[ail-chat] kill failed: ${err.message}`);
+    });
   }
 }
 

--- a/vscode-ail-chat/src/process/posix-process-killer.ts
+++ b/vscode-ail-chat/src/process/posix-process-killer.ts
@@ -1,0 +1,18 @@
+import { ChildProcess } from 'child_process';
+import { ProcessKiller } from './process-killer';
+
+export class PosixProcessKiller implements ProcessKiller {
+  kill(proc: ChildProcess): Promise<void> {
+    return new Promise((resolve) => {
+      proc.kill('SIGTERM');
+      const timeout = setTimeout(() => {
+        if (!proc.killed) proc.kill('SIGKILL');
+        resolve();
+      }, 5000);
+      proc.once('close', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+  }
+}

--- a/vscode-ail-chat/src/process/process-killer-factory.ts
+++ b/vscode-ail-chat/src/process/process-killer-factory.ts
@@ -1,0 +1,9 @@
+import { ProcessKiller } from './process-killer';
+import { PosixProcessKiller } from './posix-process-killer';
+import { WindowsProcessKiller } from './windows-process-killer';
+
+export function createProcessKiller(): ProcessKiller {
+  return process.platform === 'win32'
+    ? new WindowsProcessKiller()
+    : new PosixProcessKiller();
+}

--- a/vscode-ail-chat/src/process/process-killer.ts
+++ b/vscode-ail-chat/src/process/process-killer.ts
@@ -1,0 +1,6 @@
+import { ChildProcess } from 'child_process';
+
+export interface ProcessKiller {
+  /** Terminate the process and its descendants. */
+  kill(proc: ChildProcess): Promise<void>;
+}

--- a/vscode-ail-chat/src/process/windows-process-killer.ts
+++ b/vscode-ail-chat/src/process/windows-process-killer.ts
@@ -1,0 +1,13 @@
+import { ChildProcess, spawn } from 'child_process';
+import { ProcessKiller } from './process-killer';
+
+export class WindowsProcessKiller implements ProcessKiller {
+  kill(proc: ChildProcess): Promise<void> {
+    return new Promise((resolve) => {
+      if (proc.pid === undefined) { resolve(); return; }
+      const killer = spawn('taskkill', ['/F', '/T', '/PID', String(proc.pid)]);
+      killer.on('close', () => resolve());
+      killer.on('error', () => resolve());
+    });
+  }
+}

--- a/vscode-ail-chat/test/ail-process-manager.test.ts
+++ b/vscode-ail-chat/test/ail-process-manager.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { mapAilEventToMessages, AilEventMapper } from '../src/ail-process-manager';
+import { mapAilEventToMessages, AilEventMapper, AilProcessManager } from '../src/ail-process-manager';
 import { AilEvent } from '../src/types';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -242,5 +242,52 @@ describe('AilEventMapper', () => {
     mapper.map({ type: 'step_started', step_id: 'step2', step_index: 1, total_steps: 2, resolved_prompt: null } as AilEvent);
     msgs = mapper.map({ type: 'runner_event', event: { type: 'stream_delta', text: 'b' } } as AilEvent);
     expect(msgs[0]).toMatchObject({ stepId: 'step2' });
+  });
+});
+
+describe('cancel() with StubProcessKiller', () => {
+  it('clears _activeProcess immediately, before kill resolves', async () => {
+    let killCalled = false;
+    let resolveKill!: () => void;
+    const stubKiller = {
+      kill: (_proc: unknown) => {
+        killCalled = true;
+        return new Promise<void>(r => { resolveKill = r; });
+      }
+    };
+
+    const manager = new AilProcessManager('/nonexistent', undefined, stubKiller as any);
+    // Manually set _activeProcess via a cast to simulate a running process
+    (manager as any)._activeProcess = { pid: 999, kill: () => {}, killed: false } as any;
+
+    expect(manager.isRunning).toBe(true);
+    manager.cancel();
+
+    // Must be cleared immediately — before the kill promise resolves
+    expect(manager.isRunning).toBe(false);
+    expect(killCalled).toBe(true);
+
+    // Resolve the kill — no error
+    resolveKill();
+  });
+
+  it('start() succeeds after cancel() clears the pointer', async () => {
+    const stubKiller = {
+      kill: () => new Promise<void>(r => setTimeout(r, 100)), // slow kill
+    };
+
+    const manager = new AilProcessManager('/nonexistent', undefined, stubKiller as any);
+    (manager as any)._activeProcess = { pid: 999, kill: () => {}, killed: false } as any;
+
+    manager.cancel();
+    expect(manager.isRunning).toBe(false);
+
+    // start() should not throw "A pipeline is already running"
+    // (it will fail for other reasons since /nonexistent doesn't exist, but not the guard)
+    const startPromise = manager.start('hello');
+    // The guard passes — error will be spawn error, not the guard
+    await startPromise.catch((err: Error) => {
+      expect(err.message).not.toContain('A pipeline is already running');
+    });
   });
 });

--- a/vscode-ail-chat/test/process-killer-factory.test.ts
+++ b/vscode-ail-chat/test/process-killer-factory.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { createProcessKiller } from '../src/process/process-killer-factory';
+import { PosixProcessKiller } from '../src/process/posix-process-killer';
+import { WindowsProcessKiller } from '../src/process/windows-process-killer';
+
+describe('createProcessKiller', () => {
+  it('returns WindowsProcessKiller on win32', () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const killer = createProcessKiller();
+    expect(killer).toBeInstanceOf(WindowsProcessKiller);
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  });
+
+  it('returns PosixProcessKiller on linux', () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    const killer = createProcessKiller();
+    expect(killer).toBeInstanceOf(PosixProcessKiller);
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  });
+});

--- a/vscode-ail-chat/test/process/posix-process-killer.test.ts
+++ b/vscode-ail-chat/test/process/posix-process-killer.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+
+describe('PosixProcessKiller', () => {
+  it.skipIf(process.platform === 'win32')('sends SIGTERM then SIGKILL after timeout', async () => {
+    const { PosixProcessKiller } = await import('../../src/process/posix-process-killer');
+    const { spawn } = await import('child_process');
+
+    // Spawn a process that ignores SIGTERM (sleep is sufficient for timing test)
+    const proc = spawn('sleep', ['30']);
+    const killer = new PosixProcessKiller();
+
+    const start = Date.now();
+    await killer.kill(proc);
+    const elapsed = Date.now() - start;
+
+    // Process should be dead; either SIGTERM worked fast or SIGKILL fired
+    expect(proc.killed || proc.exitCode !== null).toBe(true);
+    // Should complete well under the 5s SIGKILL timeout (SIGTERM works on sleep)
+    expect(elapsed).toBeLessThan(4000);
+  });
+});

--- a/vscode-ail-chat/test/process/windows-process-killer.test.ts
+++ b/vscode-ail-chat/test/process/windows-process-killer.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+
+describe('WindowsProcessKiller', () => {
+  it('calls taskkill with /F /T /PID <pid>', async () => {
+    // Verify the argument construction — pid is always numeric so no injection possible.
+    // We inspect the source rather than spawning a real process to keep tests platform-safe.
+    const source = await import('fs').then(fs =>
+      fs.readFileSync(new URL('../../src/process/windows-process-killer.ts', import.meta.url).pathname, 'utf-8')
+    );
+    expect(source).toContain("'taskkill'");
+    expect(source).toContain("'/F'");
+    expect(source).toContain("'/T'");
+    expect(source).toContain("'/PID'");
+    expect(source).toContain('String(proc.pid)');
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: On Windows, `proc.kill('SIGTERM')` only terminates the immediate `ail` process. Child Claude CLI processes stay alive, holding stdio pipes open. The `close` event never fires, `_activeProcess` is never cleared, and the next prompt hits the "A pipeline is already running" guard.
- **Fix 1**: Introduce a `ProcessKiller` interface with `PosixProcessKiller` (SIGTERM → SIGKILL fallback after 5s) and `WindowsProcessKiller` (`taskkill /F /T /PID` to kill the full process tree).
- **Fix 2**: `cancel()` now eagerly clears `_activeProcess = undefined` **before** delegating to the killer, so `isRunning` returns false immediately and `start()` can proceed without waiting for the OS-level kill to complete.

Closes #164

## Files changed

- `src/process/process-killer.ts` — `ProcessKiller` interface
- `src/process/posix-process-killer.ts` — SIGTERM + SIGKILL escalation
- `src/process/windows-process-killer.ts` — `taskkill /F /T /PID` tree kill
- `src/process/process-killer-factory.ts` — platform-aware factory
- `src/ail-process-manager.ts` — inject killer, eager-clear in `cancel()`
- `test/process-killer-factory.test.ts` — factory platform switching
- `test/process/windows-process-killer.test.ts` — source inspection test
- `test/process/posix-process-killer.test.ts` — live process kill timing test
- `test/ail-process-manager.test.ts` — two new cancel() tests with StubProcessKiller

## Test output

```
 Test Files  16 passed (16)
      Tests  175 passed (175)
   Duration  1.57s
```

## Test plan

- [x] All 175 tests pass (16 test files)
- [x] `cancel()` clears `_activeProcess` before kill resolves (verified by StubProcessKiller test)
- [x] `start()` after `cancel()` does not hit "A pipeline is already running" guard
- [x] `createProcessKiller()` returns correct implementation per platform
- [x] `WindowsProcessKiller` uses `taskkill /F /T /PID` (source inspection test)
- [x] `PosixProcessKiller` terminates process via SIGTERM on Linux
- [x] ESLint passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)