### PR TITLE
feat(vscode-ail-chat): install wizard for empty workspaces

### DIFF
--- a/demo/starter/README.md
+++ b/demo/starter/README.md
@@ -1,0 +1,35 @@
+# Starter Pipeline
+
+A minimal AIL pipeline with a single explicit invocation step. Start here if you're new to AIL.
+
+## What's installed
+
+```
+.ail/
+└── default.yaml    ← your pipeline (discovered automatically by ail and the VS Code extension)
+```
+
+## Next steps
+
+1. **Run a prompt** — open the ail Chat sidebar and type anything. The pipeline runs transparently.
+2. **Inspect the log** — click a run in the "Run History" panel to see exactly what happened.
+3. **Add a step** — uncomment the example steps in `default.yaml` to see how chaining works.
+4. **Explore templates** — check out the [Oh My AIL](https://github.com/AlexChesser/ail/tree/main/demo/oh-my-ail) and [Superpowers](https://github.com/AlexChesser/ail/tree/main/demo/superpowers) demos for more advanced orchestration.
+
+## How AIL works
+
+```
+you type a prompt
+    └─▶ invocation step  (your prompt → agent → response)
+            └─▶ step 2   (optional — runs automatically)
+                    └─▶ step 3 ...
+                            └─▶ response returned to you
+```
+
+Every step in the pipeline runs before you see the final response. Steps can read files, run shell commands, call LLMs, or invoke skills — in any combination.
+
+## Reference
+
+- [AIL spec](https://github.com/AlexChesser/ail/tree/main/spec/core)
+- [Pipeline YAML reference](https://github.com/AlexChesser/ail/blob/main/spec/core/s03-pipeline-file.md)
+- [Template variables](https://github.com/AlexChesser/ail/blob/main/spec/core/s11-template.md)

--- a/demo/starter/default.yaml
+++ b/demo/starter/default.yaml
@@ -1,0 +1,66 @@
+version: "0.0.1"
+
+meta:
+  name: "Starter — Invocation-only pipeline"
+
+# Welcome to AIL (Artificial Intelligence Loops).
+#
+# A pipeline is a sequence of steps that run automatically after every prompt
+# you send. Steps can call LLMs, run shell commands, read files, invoke skills,
+# or chain into sub-pipelines — all before control returns to you.
+#
+# This starter pipeline has a single explicit step: the invocation. That's the
+# step that handles your prompt. Declaring it here (instead of leaving it
+# implicit) lets you customise the system prompt, tool permissions, and model.
+#
+# You can run this pipeline with:
+#   ail "your prompt here" --pipeline .ail/default.yaml
+#
+# Or just open the ail Chat sidebar in VS Code and start typing.
+
+pipeline:
+  - id: invocation
+    # The prompt field is passed to the agent verbatim.
+    # {{ step.invocation.prompt }} is filled in at runtime with what you typed.
+    prompt: "{{ step.invocation.prompt }}"
+
+    # Uncomment to override the model for this step:
+    # provider:
+    #   model: claude-opus-4-5
+
+    # Uncomment to restrict which tools the agent can use:
+    # tools:
+    #   allow:
+    #     - Read
+    #     - Edit
+    #     - Bash
+    #   deny:
+    #     - WebFetch
+
+    # Uncomment to inject project context before every response:
+    # append_system_prompt:
+    #   - shell: |
+    #       echo "=== Project structure ==="
+    #       find . -maxdepth 2 -type f | head -30
+
+# ─── Adding more steps ───────────────────────────────────────────────────────
+#
+# Steps run in order after the invocation. Common patterns:
+#
+#   - id: review
+#     prompt: |
+#       The agent just responded:
+#       {{ step.invocation.response }}
+#
+#       Review the response and suggest improvements.
+#     resume: true   # <-- resume: true continues the same session
+#
+#   - id: gather_context
+#     context:
+#       shell: |
+#         echo "=== Git status ==="
+#         git status --short
+#         echo "=== Recent commits ==="
+#         git log --oneline -5
+#
+# See the full spec at: https://github.com/AlexChesser/ail/tree/main/spec

--- a/docs/superpowers/specs/2026-04-21-install-wizard-side-panel-design.md
+++ b/docs/superpowers/specs/2026-04-21-install-wizard-side-panel-design.md
@@ -1,0 +1,159 @@
+# Design: Install Wizard (#166) + Toggle Side Panel (#167)
+
+**Date:** 2026-04-21
+**Issues:** [#166](https://github.com/AlexChesser/ail/issues/166), [#167](https://github.com/AlexChesser/ail/issues/167)
+**Approach:** Sequential branches, one PR per issue. 166 first; 167 branches from main after 166 merges.
+
+---
+
+## Issue 166 — Install Wizard for Empty Workspaces
+
+### Architecture
+
+`install-wizard.ts` exports a single async function `checkAndOfferInstall(context, chatProvider)`. Called from two sites in `extension.ts`:
+
+1. End of `activate()`
+2. Inside `onDidChangeWorkspaceFolders`
+
+Early-exit conditions (checked in order):
+1. `workspaceState.get('ail-chat.installPromptDismissed') === true` → return
+2. Any pipeline file found in workspace root (`.ail.yaml`, `.ail.yml`, `.ail/*.yaml`, `.ail/*.yml`) → return
+
+`ChatViewProvider` gains one new public method: `reloadPipeline()`. Re-runs the existing `_resolvedPipeline()` logic, persists the result to `workspaceState`, and calls `_sendPipelineChanged()`. The wizard calls this after copying a template so the chat view picks up the new pipeline immediately.
+
+### Templates & Build Integration
+
+All three template sets live under `demo/` as first-class demo directories:
+
+- `demo/starter/` — new, checked into repo. Contains `default.yaml` (single `invocation:` step, heavily commented) and `README.md`. Uses `{{ step.invocation.prompt }}` (canonical form, not the deprecated alias).
+- `demo/oh-my-ail/` — existing
+- `demo/superpowers/` — existing
+
+`scripts/sync-templates.js` (new Node script, no external deps) copies all three from `demo/` into `vscode-ail-chat/templates/` at build time. `vscode-ail-chat/templates/` is entirely `.gitignore`'d.
+
+`package.json` script changes:
+```json
+"build": "node scripts/sync-templates.js && node esbuild.js",
+"vscode:prepublish": "node scripts/sync-templates.js && node esbuild.js --production"
+```
+
+`esbuild.js` gets a `copyTemplates()` step copying `templates/**` into `dist/templates/`. The wizard reads from `context.extensionPath + '/dist/templates/<name>/'` at runtime and copies the chosen tree into `<workspaceRoot>/.ail/`.
+
+### QuickPick UX & Dismiss Semantics
+
+Four QuickPick items (three templates + dismiss):
+```
+① Starter — Invocation-only pipeline (recommended)
+② Oh My AIL — Intent-routed multi-agent orchestration
+③ Superpowers — Curated high-leverage workflows
+④ Dismiss
+```
+
+After a template is picked:
+1. Copy chosen template tree from `dist/templates/<name>/` into `<workspaceRoot>/.ail/`
+2. Call `chatProvider.reloadPipeline()`
+3. Open template `README.md` in markdown preview
+
+Dismiss semantics:
+- "Dismiss" item selected → `workspaceState.update('ail-chat.installPromptDismissed', true)` → no future prompts for this workspace
+- Escape/cancel (QuickPick returns `undefined`) → flag **not** set → re-prompts on next activation
+
+### Files
+
+**New:**
+- `demo/starter/default.yaml`
+- `demo/starter/README.md`
+- `vscode-ail-chat/src/install-wizard.ts`
+- `vscode-ail-chat/scripts/sync-templates.js`
+- `vscode-ail-chat/test/install-wizard.test.ts`
+
+**Modified:**
+- `vscode-ail-chat/src/extension.ts` — call wizard from `activate()` + `onDidChangeWorkspaceFolders`
+- `vscode-ail-chat/src/chat-view-provider.ts` — add public `reloadPipeline()`
+- `vscode-ail-chat/package.json` — script hooks for sync-templates
+- `vscode-ail-chat/esbuild.js` — template copy step
+- `vscode-ail-chat/.gitignore` — ignore `templates/`
+
+### Test Coverage
+
+- No-pipeline detection across all four path patterns — wizard fires when none exist
+- Wizard is a no-op when any pipeline already exists
+- Dismiss flag set only on "Dismiss" item, not on Escape/cancel
+- Template files copied to correct `.ail/` directory
+- `reloadPipeline()` called after successful install
+- Re-prompt suppressed after dismiss flag is set
+
+All tests use the existing `vscode-stub.js` mock.
+
+---
+
+## Issue 167 — Toggle Side Panel: Run History + Pipeline Steps
+
+*Branches from main after #166 merges.*
+
+### Architecture
+
+Two new tree data providers registered in `extension.ts`:
+
+**`RunHistoryProvider`** (`src/history-tree-provider.ts`):
+- Calls `ail logs --format json --limit 100` via `resolveBinary` to populate tree
+- No `workspaceState` persistence — CLI owns the storage
+- `refresh()` re-runs the CLI query; called by `ChatViewProvider` on run completion
+- Tree items: first 60 chars of prompt + relative timestamp
+- `ail-chat.openRunLog` command: calls `ail log <runId>`, opens result as VS Code text document (`language: 'markdown'`)
+- Binary call is injected as a testable function for unit tests
+
+**`PipelineStepsProvider`** (`src/steps-tree-provider.ts`):
+- Parses active pipeline YAML via the `yaml` package (already a dep)
+- Top-level steps only; sub-pipeline references render as single node with filename label
+- Error node (no expand) when pipeline missing, YAML malformed, or passthrough mode
+- Each item: step `id` + type icon (prompt/context/skill/sub-pipeline)
+- `ail-chat.openStep` command: opens YAML file, reveals `id:` line in viewport
+- `refresh(pipelinePath)` called by `ChatViewProvider` on pipeline change
+
+**Toggle mechanism:**
+```typescript
+let panelVisible = false;
+commands.registerCommand('ail-chat.toggleInfoPanel', () => {
+  panelVisible = !panelVisible;
+  void commands.executeCommand('setContext', 'ail-chat.panelVisible', panelVisible);
+});
+```
+Views use `"when": "ail-chat.panelVisible"` in `package.json`. Toggle button in chat view title bar via `menus["view/title"]` with `$(layout-sidebar-right)` icon.
+
+**`ChatViewProvider` changes:**
+- Calls `historyProvider.refresh()` on run completion (replaces the `addRun()` pattern)
+- Calls `stepsProvider.refresh(pipelinePath)` on pipeline change
+
+### Files
+
+**New:**
+- `vscode-ail-chat/src/history-tree-provider.ts`
+- `vscode-ail-chat/src/steps-tree-provider.ts`
+- `vscode-ail-chat/test/history-tree-provider.test.ts`
+- `vscode-ail-chat/test/steps-tree-provider.test.ts`
+
+**Modified:**
+- `vscode-ail-chat/src/extension.ts` — register both providers + toggle command
+- `vscode-ail-chat/src/chat-view-provider.ts` — call `historyProvider.refresh()` on run completion; `stepsProvider.refresh()` on pipeline change
+- `vscode-ail-chat/package.json` — new views (`when: ail-chat.panelVisible`), toggle command + icon, `openRunLog` and `openStep` commands
+
+### Test Coverage
+
+`history-tree-provider.test.ts`:
+- `refresh()` calls `ail logs --format json` and populates tree items
+- Results capped at 100 via `--limit 100` passed to the CLI
+- `getChildren()` returns entries reverse-chronological
+- `openRunLog` calls `ail log <runId>` and opens result as markdown document
+
+`steps-tree-provider.test.ts`:
+- Valid multi-step pipeline → one `StepItem` per top-level step
+- Sub-pipeline reference → single node with filename label
+- Malformed YAML → error node, no throw
+- Null/passthrough pipeline → empty tree
+
+All tests use the existing `vscode-stub.js` mock.
+
+### Related
+
+- Log search/fuzzy matching exploration tracked in [#171](https://github.com/AlexChesser/ail/issues/171)

--- a/vscode-ail-chat/.gitignore
+++ b/vscode-ail-chat/.gitignore
@@ -3,3 +3,4 @@ dist/
 out/
 *.vsix
 .vscode-test/
+templates/

--- a/vscode-ail-chat/esbuild.js
+++ b/vscode-ail-chat/esbuild.js
@@ -47,6 +47,23 @@ const graphWebviewOptions = {
   loader: { '.css': 'css' },
 };
 
+function copyTemplates() {
+  const src = path.join(__dirname, 'templates');
+  const dest = path.join(__dirname, 'dist', 'templates');
+  if (!fs.existsSync(src)) return;
+
+  function copyDir(s, d) {
+    fs.mkdirSync(d, { recursive: true });
+    for (const entry of fs.readdirSync(s, { withFileTypes: true })) {
+      const sp = path.join(s, entry.name);
+      const dp = path.join(d, entry.name);
+      if (entry.isDirectory()) copyDir(sp, dp);
+      else fs.copyFileSync(sp, dp);
+    }
+  }
+  copyDir(src, dest);
+}
+
 function copyCodiconAssets() {
   const dist = path.join(__dirname, 'dist');
   if (!fs.existsSync(dist)) fs.mkdirSync(dist, { recursive: true });
@@ -76,6 +93,7 @@ async function build() {
   }
 
   copyCodiconAssets();
+  copyTemplates();
 
   if (watch) {
     const [extCtx, webCtx, graphCtx] = await Promise.all([

--- a/vscode-ail-chat/package.json
+++ b/vscode-ail-chat/package.json
@@ -79,8 +79,8 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "node esbuild.js --production",
-    "build": "node esbuild.js",
+    "vscode:prepublish": "node scripts/sync-templates.js && node esbuild.js --production",
+    "build": "node scripts/sync-templates.js && node esbuild.js",
     "compile": "tsc -p ./",
     "watch": "node esbuild.js --watch",
     "test": "vitest run",

--- a/vscode-ail-chat/scripts/sync-templates.js
+++ b/vscode-ail-chat/scripts/sync-templates.js
@@ -1,0 +1,45 @@
+// @ts-check
+'use strict';
+
+/**
+ * Copies demo template directories into vscode-ail-chat/templates/ so they
+ * can be bundled into dist/ by esbuild. Run before every build.
+ *
+ * Source (tracked):  <repo-root>/demo/{starter,oh-my-ail,superpowers}/
+ * Destination (gitignored):  vscode-ail-chat/templates/{starter,oh-my-ail,superpowers}/
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const templatesDir = path.resolve(__dirname, '..', 'templates');
+const demoDir = path.resolve(repoRoot, 'demo');
+
+const TEMPLATES = ['starter', 'oh-my-ail', 'superpowers'];
+
+function copyDir(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+fs.mkdirSync(templatesDir, { recursive: true });
+
+for (const name of TEMPLATES) {
+  const src = path.join(demoDir, name);
+  const dest = path.join(templatesDir, name);
+  if (!fs.existsSync(src)) {
+    console.warn(`sync-templates: demo/${name} not found — skipping`);
+    continue;
+  }
+  copyDir(src, dest);
+  console.log(`sync-templates: demo/${name} → templates/${name}`);
+}

--- a/vscode-ail-chat/src/chat-view-provider.ts
+++ b/vscode-ail-chat/src/chat-view-provider.ts
@@ -60,6 +60,13 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     this._view?.show?.(true);
   }
 
+  reloadPipeline(): void {
+    const resolved = this._resolvedPipeline();
+    this._currentPipeline = resolved;
+    void this._context.workspaceState.update(LAST_PIPELINE_KEY, resolved ?? undefined);
+    this._sendPipelineChanged();
+  }
+
   private _sendPipelineChanged(): void {
     const p = this._currentPipeline;
     void this._view?.webview.postMessage({

--- a/vscode-ail-chat/src/extension.ts
+++ b/vscode-ail-chat/src/extension.ts
@@ -13,6 +13,7 @@ import { SessionManager } from './session-manager';
 import { ChatViewProvider } from './chat-view-provider';
 import { PipelineGraphPanel } from './pipeline-graph/PipelineGraphPanel';
 import { AilOutputChannel } from './output-channel';
+import { checkAndOfferInstall } from './install-wizard';
 
 let chatProvider: ChatViewProvider | undefined;
 
@@ -82,8 +83,14 @@ export function activate(context: vscode.ExtensionContext): void {
       if (pipelinePath) {
         PipelineGraphPanel.show(context.extensionPath, pipelinePath);
       }
+    }),
+
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      if (chatProvider) void checkAndOfferInstall(context, chatProvider);
     })
   );
+
+  void checkAndOfferInstall(context, chatProvider);
 }
 
 // Process manager cleanup is handled by the view's onDidDispose.

--- a/vscode-ail-chat/src/install-wizard.ts
+++ b/vscode-ail-chat/src/install-wizard.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ChatViewProvider } from './chat-view-provider';
+
+const DISMISSED_KEY = 'ail-chat.installPromptDismissed';
+
+const PIPELINE_PATTERNS = ['.ail.yaml', '.ail.yml'];
+const AIL_DIR_PATTERNS = ['.ail'];
+
+const TEMPLATES = [
+  {
+    label: '① Starter',
+    description: 'Invocation-only pipeline (recommended)',
+    detail: 'Single explicit invocation step. Heavily commented so you see exactly what AIL does.',
+    dir: 'starter',
+  },
+  {
+    label: '② Oh My AIL',
+    description: 'Intent-routed multi-agent orchestration',
+    detail: 'Sisyphus classifier (TRIVIAL/EXPLICIT/EXPLORATORY/AMBIGUOUS) + full agent/workflow tree.',
+    dir: 'oh-my-ail',
+  },
+  {
+    label: '③ Superpowers',
+    description: 'Curated high-leverage workflows',
+    detail: 'TDD, code-review, planning, brainstorming, parallel debug, plan execution, and more.',
+    dir: 'superpowers',
+  },
+  {
+    label: '$(x) Dismiss',
+    description: "Don't ask again for this workspace",
+    detail: '',
+    dir: '',
+  },
+] as const;
+
+function pipelineExistsInWorkspace(cwd: string): boolean {
+  for (const p of PIPELINE_PATTERNS) {
+    if (fs.existsSync(path.join(cwd, p))) return true;
+  }
+  for (const dir of AIL_DIR_PATTERNS) {
+    const ailDir = path.join(cwd, dir);
+    if (fs.existsSync(ailDir) && fs.statSync(ailDir).isDirectory()) {
+      try {
+        const entries = fs.readdirSync(ailDir);
+        if (entries.some((e) => e.endsWith('.yaml') || e.endsWith('.yml'))) return true;
+      } catch {
+        // ignore unreadable dirs
+      }
+    }
+  }
+  return false;
+}
+
+function copyDir(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const sp = path.join(src, entry.name);
+    const dp = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDir(sp, dp);
+    else fs.copyFileSync(sp, dp);
+  }
+}
+
+export async function checkAndOfferInstall(
+  context: vscode.ExtensionContext,
+  chatProvider: ChatViewProvider
+): Promise<void> {
+  if (context.workspaceState.get<boolean>(DISMISSED_KEY)) return;
+
+  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  if (!cwd) return;
+
+  if (pipelineExistsInWorkspace(cwd)) return;
+
+  const picked = await vscode.window.showQuickPick(
+    TEMPLATES.map((t) => ({ label: t.label, description: t.description, detail: t.detail, dir: t.dir })),
+    {
+      title: 'Set up an AIL pipeline for this workspace',
+      placeHolder: 'Choose a template to get started, or dismiss',
+      matchOnDescription: true,
+    }
+  );
+
+  if (!picked) return; // Escape — do not set flag, re-prompt next time
+
+  if (picked.dir === '') {
+    // Dismiss item
+    await context.workspaceState.update(DISMISSED_KEY, true);
+    return;
+  }
+
+  const templateSrc = path.join(context.extensionPath, 'dist', 'templates', picked.dir);
+  if (!fs.existsSync(templateSrc)) {
+    void vscode.window.showErrorMessage(`AIL: template "${picked.dir}" not found in extension bundle.`);
+    return;
+  }
+
+  const dest = path.join(cwd, '.ail');
+  try {
+    copyDir(templateSrc, dest);
+  } catch (err) {
+    void vscode.window.showErrorMessage(`AIL: failed to copy template — ${String(err)}`);
+    return;
+  }
+
+  chatProvider.reloadPipeline();
+
+  const readmePath = path.join(dest, 'README.md');
+  if (fs.existsSync(readmePath)) {
+    void vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(readmePath));
+  }
+}

--- a/vscode-ail-chat/test/install-wizard.test.ts
+++ b/vscode-ail-chat/test/install-wizard.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Hoisted mocks (available before vi.mock factories run) ────────────────────
+
+const { mockShowQuickPick, mockExecuteCommand, mockShowErrorMessage, workspaceStore } = vi.hoisted(() => {
+  const workspaceStore = new Map<string, unknown>();
+  return {
+    workspaceStore,
+    mockShowQuickPick: vi.fn<[unknown[], unknown], Promise<unknown>>(() => Promise.resolve(undefined)),
+    mockExecuteCommand: vi.fn(() => Promise.resolve(undefined)),
+    mockShowErrorMessage: vi.fn(() => Promise.resolve(undefined)),
+  };
+});
+
+// ── fs mock ──────────────────────────────────────────────────────────────────
+
+const { mockExistsSync, mockStatSync, mockReaddirSync, mockMkdirSync, mockCopyFileSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(() => false),
+  mockStatSync: vi.fn(() => ({ isDirectory: () => false })),
+  mockReaddirSync: vi.fn(() => [] as string[]),
+  mockMkdirSync: vi.fn(),
+  mockCopyFileSync: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: mockExistsSync,
+  statSync: mockStatSync,
+  readdirSync: mockReaddirSync,
+  mkdirSync: mockMkdirSync,
+  copyFileSync: mockCopyFileSync,
+}));
+
+// ── vscode mock ───────────────────────────────────────────────────────────────
+
+vi.mock('vscode', () => ({
+  window: {
+    showQuickPick: mockShowQuickPick,
+    showErrorMessage: mockShowErrorMessage,
+  },
+  workspace: {
+    workspaceFolders: [{ uri: { fsPath: '/workspace' } }],
+  },
+  commands: {
+    executeCommand: mockExecuteCommand,
+  },
+  Uri: {
+    file: (p: string) => ({ fsPath: p }),
+  },
+}));
+
+// ── Import under test ─────────────────────────────────────────────────────────
+
+import { checkAndOfferInstall } from '../src/install-wizard';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const mockWorkspaceState = {
+  get: (key: string) => workspaceStore.get(key),
+  update: async (key: string, value: unknown) => { workspaceStore.set(key, value); },
+  keys: () => [] as readonly string[],
+  setKeysForSync: () => {},
+};
+
+function makeContext() {
+  return {
+    workspaceState: mockWorkspaceState,
+    extensionPath: '/ext',
+  } as unknown as import('vscode').ExtensionContext;
+}
+
+function makeChatProvider() {
+  return { reloadPipeline: vi.fn() } as unknown as import('../src/chat-view-provider').ChatViewProvider;
+}
+
+function pickTemplate(label: string) {
+  mockShowQuickPick.mockImplementation((items: unknown[]) => {
+    const arr = items as Array<{ label: string; dir: string }>;
+    return Promise.resolve(arr.find((i) => i.label.includes(label)));
+  });
+}
+
+beforeEach(() => {
+  workspaceStore.clear();
+  vi.clearAllMocks();
+  mockExistsSync.mockReturnValue(false);
+  mockStatSync.mockReturnValue({ isDirectory: () => false });
+  mockReaddirSync.mockReturnValue([]);
+  mockShowQuickPick.mockResolvedValue(undefined);
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('checkAndOfferInstall', () => {
+  describe('early-exit conditions', () => {
+    it('does not show QuickPick when dismiss flag is set', async () => {
+      workspaceStore.set('ail-chat.installPromptDismissed', true);
+      await checkAndOfferInstall(makeContext(), makeChatProvider());
+      expect(mockShowQuickPick).not.toHaveBeenCalled();
+    });
+
+    it('does not show QuickPick when .ail.yaml exists', async () => {
+      mockExistsSync.mockImplementation((p: string) => p === '/workspace/.ail.yaml');
+      await checkAndOfferInstall(makeContext(), makeChatProvider());
+      expect(mockShowQuickPick).not.toHaveBeenCalled();
+    });
+
+    it('does not show QuickPick when .ail.yml exists', async () => {
+      mockExistsSync.mockImplementation((p: string) => p === '/workspace/.ail.yml');
+      await checkAndOfferInstall(makeContext(), makeChatProvider());
+      expect(mockShowQuickPick).not.toHaveBeenCalled();
+    });
+
+    it('does not show QuickPick when .ail/ dir contains a yaml file', async () => {
+      mockExistsSync.mockImplementation((p: string) => p === '/workspace/.ail');
+      mockStatSync.mockReturnValue({ isDirectory: () => true });
+      mockReaddirSync.mockReturnValue(['default.yaml']);
+      await checkAndOfferInstall(makeContext(), makeChatProvider());
+      expect(mockShowQuickPick).not.toHaveBeenCalled();
+    });
+
+    it('shows QuickPick when no pipeline files exist', async () => {
+      await checkAndOfferInstall(makeContext(), makeChatProvider());
+      expect(mockShowQuickPick).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('dismiss semantics', () => {
+    it('sets dismiss flag when Dismiss item is picked', async () => {
+      pickTemplate('Dismiss');
+      await checkAndOfferInstall(makeContext(), makeChatProvider());
+      expect(workspaceStore.get('ail-chat.installPromptDismissed')).toBe(true);
+    });
+
+    it('does NOT set dismiss flag when user escapes (undefined result)', async () => {
+      mockShowQuickPick.mockResolvedValue(undefined);
+      await checkAndOfferInstall(makeContext(), makeChatProvider());
+      expect(workspaceStore.has('ail-chat.installPromptDismissed')).toBe(false);
+    });
+
+    it('does not call reloadPipeline when Dismiss is picked', async () => {
+      pickTemplate('Dismiss');
+      const provider = makeChatProvider();
+      await checkAndOfferInstall(makeContext(), provider);
+      expect(provider.reloadPipeline).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('template installation', () => {
+    beforeEach(() => {
+      mockExistsSync.mockImplementation((p: string) => {
+        if (typeof p === 'string' && p.includes('dist/templates')) return true;
+        return false;
+      });
+      mockReaddirSync.mockReturnValue([]);
+    });
+
+    it('copies starter template to .ail/ directory', async () => {
+      pickTemplate('Starter');
+      await checkAndOfferInstall(makeContext(), makeChatProvider());
+      expect(mockMkdirSync).toHaveBeenCalledWith('/workspace/.ail', expect.objectContaining({ recursive: true }));
+    });
+
+    it('calls reloadPipeline after installing a template', async () => {
+      pickTemplate('Starter');
+      const provider = makeChatProvider();
+      await checkAndOfferInstall(makeContext(), provider);
+      expect(provider.reloadPipeline).toHaveBeenCalledOnce();
+    });
+
+    it('opens README in markdown preview after install when README exists', async () => {
+      pickTemplate('Starter');
+      mockExistsSync.mockImplementation((p: string) => {
+        if (typeof p === 'string' && (p.includes('dist/templates') || p.includes('README.md'))) return true;
+        return false;
+      });
+      await checkAndOfferInstall(makeContext(), makeChatProvider());
+      expect(mockExecuteCommand).toHaveBeenCalledWith('markdown.showPreview', expect.anything());
+    });
+
+    it('does not call reloadPipeline when template source is missing', async () => {
+      pickTemplate('Starter');
+      mockExistsSync.mockReturnValue(false);
+      const provider = makeChatProvider();
+      await checkAndOfferInstall(makeContext(), provider);
+      expect(provider.reloadPipeline).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/vscode-ail-chat/test/install-wizard.test.ts
+++ b/vscode-ail-chat/test/install-wizard.test.ts
@@ -6,21 +6,21 @@ const { mockShowQuickPick, mockExecuteCommand, mockShowErrorMessage, workspaceSt
   const workspaceStore = new Map<string, unknown>();
   return {
     workspaceStore,
-    mockShowQuickPick: vi.fn<[unknown[], unknown], Promise<unknown>>(() => Promise.resolve(undefined)),
+    mockShowQuickPick: vi.fn(),
     mockExecuteCommand: vi.fn(() => Promise.resolve(undefined)),
     mockShowErrorMessage: vi.fn(() => Promise.resolve(undefined)),
   };
 });
 
-// ── fs mock ──────────────────────────────────────────────────────────────────
-
 const { mockExistsSync, mockStatSync, mockReaddirSync, mockMkdirSync, mockCopyFileSync } = vi.hoisted(() => ({
-  mockExistsSync: vi.fn(() => false),
-  mockStatSync: vi.fn(() => ({ isDirectory: () => false })),
-  mockReaddirSync: vi.fn(() => [] as string[]),
+  mockExistsSync: vi.fn(),
+  mockStatSync: vi.fn(),
+  mockReaddirSync: vi.fn(),
   mockMkdirSync: vi.fn(),
   mockCopyFileSync: vi.fn(),
 }));
+
+// ── fs mock ──────────────────────────────────────────────────────────────────
 
 vi.mock('fs', () => ({
   existsSync: mockExistsSync,
@@ -73,10 +73,9 @@ function makeChatProvider() {
 }
 
 function pickTemplate(label: string) {
-  mockShowQuickPick.mockImplementation((items: unknown[]) => {
-    const arr = items as Array<{ label: string; dir: string }>;
-    return Promise.resolve(arr.find((i) => i.label.includes(label)));
-  });
+  mockShowQuickPick.mockImplementation((items: Array<{ label: string; dir: string }>) =>
+    Promise.resolve(items.find((i) => i.label.includes(label)))
+  );
 }
 
 beforeEach(() => {
@@ -99,19 +98,19 @@ describe('checkAndOfferInstall', () => {
     });
 
     it('does not show QuickPick when .ail.yaml exists', async () => {
-      mockExistsSync.mockImplementation((p: string) => p === '/workspace/.ail.yaml');
+      mockExistsSync.mockImplementation((p: unknown) => p === '/workspace/.ail.yaml');
       await checkAndOfferInstall(makeContext(), makeChatProvider());
       expect(mockShowQuickPick).not.toHaveBeenCalled();
     });
 
     it('does not show QuickPick when .ail.yml exists', async () => {
-      mockExistsSync.mockImplementation((p: string) => p === '/workspace/.ail.yml');
+      mockExistsSync.mockImplementation((p: unknown) => p === '/workspace/.ail.yml');
       await checkAndOfferInstall(makeContext(), makeChatProvider());
       expect(mockShowQuickPick).not.toHaveBeenCalled();
     });
 
     it('does not show QuickPick when .ail/ dir contains a yaml file', async () => {
-      mockExistsSync.mockImplementation((p: string) => p === '/workspace/.ail');
+      mockExistsSync.mockImplementation((p: unknown) => p === '/workspace/.ail');
       mockStatSync.mockReturnValue({ isDirectory: () => true });
       mockReaddirSync.mockReturnValue(['default.yaml']);
       await checkAndOfferInstall(makeContext(), makeChatProvider());
@@ -147,10 +146,9 @@ describe('checkAndOfferInstall', () => {
 
   describe('template installation', () => {
     beforeEach(() => {
-      mockExistsSync.mockImplementation((p: string) => {
-        if (typeof p === 'string' && p.includes('dist/templates')) return true;
-        return false;
-      });
+      mockExistsSync.mockImplementation((p: unknown) =>
+        typeof p === 'string' && p.includes('dist/templates')
+      );
       mockReaddirSync.mockReturnValue([]);
     });
 
@@ -169,10 +167,9 @@ describe('checkAndOfferInstall', () => {
 
     it('opens README in markdown preview after install when README exists', async () => {
       pickTemplate('Starter');
-      mockExistsSync.mockImplementation((p: string) => {
-        if (typeof p === 'string' && (p.includes('dist/templates') || p.includes('README.md'))) return true;
-        return false;
-      });
+      mockExistsSync.mockImplementation((p: unknown) =>
+        typeof p === 'string' && (p.includes('dist/templates') || p.includes('README.md'))
+      );
       await checkAndOfferInstall(makeContext(), makeChatProvider());
       expect(mockExecuteCommand).toHaveBeenCalledWith('markdown.showPreview', expect.anything());
     });


### PR DESCRIPTION
Closes #166.

## Summary

- `demo/starter/` — new template directory checked into repo alongside `oh-my-ail` and `superpowers`
- `scripts/sync-templates.js` — copies all three demo templates into `vscode-ail-chat/templates/` at build time (destination is gitignored)
- `esbuild.js` — bundles `templates/**` into `dist/templates/` so they're included in the VSIX
- `src/install-wizard.ts` — `checkAndOfferInstall()` fires when no pipeline file is found in the workspace; shows a QuickPick with Starter / Oh My AIL / Superpowers / Dismiss; copies chosen template into `.ail/`, calls `reloadPipeline()`, opens `README.md` in markdown preview
- Escape does **not** set the dismiss flag (re-prompts next activation); Dismiss item does
- `ChatViewProvider.reloadPipeline()` — new public method that re-resolves the pipeline and notifies the webview
- `extension.ts` — wires wizard at `activate()` and `onDidChangeWorkspaceFolders`

## Test plan

- [ ] Open an empty workspace → QuickPick fires
- [ ] Pick Starter → `.ail/default.yaml` created, README opens, chat view picks up pipeline
- [ ] Pick Oh My AIL → `.ail/` populated with oh-my-ail template tree
- [ ] Pick Superpowers → `.ail/` populated with superpowers template tree
- [ ] Escape QuickPick → no flag set, re-prompts on next activation
- [ ] Pick Dismiss → flag set, no re-prompt on next activation
- [ ] Open workspace that already has `.ail.yaml` → wizard is silent
- [ ] `npm run build` → `dist/templates/` contains all three template trees
- [ ] `npm test` → 194 tests passing