### PR TITLE
feat(vscode-ail-chat): toggle side panel — run history + pipeline steps

### DIFF
--- a/vscode-ail-chat/package.json
+++ b/vscode-ail-chat/package.json
@@ -37,6 +37,25 @@
           "id": "ail-chat.chatView",
           "name": "Chat",
           "type": "webview"
+        },
+        {
+          "id": "ail-chat.historyView",
+          "name": "Run History",
+          "when": "ail-chat.panelVisible"
+        },
+        {
+          "id": "ail-chat.stepsView",
+          "name": "Pipeline Steps",
+          "when": "ail-chat.panelVisible"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "ail-chat.toggleInfoPanel",
+          "when": "view == ail-chat.chatView",
+          "group": "navigation"
         }
       ]
     },
@@ -74,6 +93,22 @@
       {
         "command": "ail-chat.openPipelineGraph",
         "title": "ail Chat: Open Pipeline Graph",
+        "category": "ail Chat"
+      },
+      {
+        "command": "ail-chat.toggleInfoPanel",
+        "title": "ail Chat: Toggle Run History & Steps Panel",
+        "category": "ail Chat",
+        "icon": "$(layout-sidebar-right)"
+      },
+      {
+        "command": "ail-chat.openRunLog",
+        "title": "ail Chat: Open Run Log",
+        "category": "ail Chat"
+      },
+      {
+        "command": "ail-chat.openStep",
+        "title": "ail Chat: Go to Step",
         "category": "ail Chat"
       }
     ]

--- a/vscode-ail-chat/src/chat-view-provider.ts
+++ b/vscode-ail-chat/src/chat-view-provider.ts
@@ -8,6 +8,8 @@ import { WebviewToHostMessage } from './types';
 import { PipelineGraphPanel } from './pipeline-graph/PipelineGraphPanel';
 import { AilOutputChannel } from './output-channel';
 import { createProcessKiller } from './process/process-killer-factory';
+import type { RunHistoryProvider } from './history-tree-provider';
+import type { PipelineStepsProvider } from './steps-tree-provider';
 
 const LAST_PIPELINE_KEY = 'ail-chat.lastPipeline';
 
@@ -23,11 +25,14 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     private readonly _context: vscode.ExtensionContext,
     private readonly _sessionManager: SessionManager,
     private readonly _outputChannel?: AilOutputChannel,
+    private readonly _historyProvider?: RunHistoryProvider,
+    private readonly _stepsProvider?: PipelineStepsProvider,
   ) {
     // Restore last pipeline from workspace state.
     const saved = this._context.workspaceState.get<string>(LAST_PIPELINE_KEY);
     if (saved && fs.existsSync(saved)) {
       this._currentPipeline = saved;
+      this._stepsProvider?.refresh(saved);
     }
   }
 
@@ -97,6 +102,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
           this._processManager = new AilProcessManager(binary.path, cwd, createProcessKiller(), this._outputChannel);
           this._processManager.onMessage((m) => {
             void this._view?.webview.postMessage(m);
+            if (m.type === 'pipelineCompleted') {
+              this._historyProvider?.refresh();
+            }
           });
         }
 
@@ -132,6 +140,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         if (uris && uris.length > 0) {
           this._currentPipeline = uris[0].fsPath;
           void this._context.workspaceState.update(LAST_PIPELINE_KEY, this._currentPipeline);
+          this._stepsProvider?.refresh(this._currentPipeline);
           this._sendPipelineChanged();
         }
         break;

--- a/vscode-ail-chat/src/extension.ts
+++ b/vscode-ail-chat/src/extension.ts
@@ -8,12 +8,14 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { clearBinaryCache } from './binary';
+import { clearBinaryCache, resolveBinary } from './binary';
 import { SessionManager } from './session-manager';
 import { ChatViewProvider } from './chat-view-provider';
 import { PipelineGraphPanel } from './pipeline-graph/PipelineGraphPanel';
 import { AilOutputChannel } from './output-channel';
 import { checkAndOfferInstall } from './install-wizard';
+import { RunHistoryProvider, registerRunLogCommand } from './history-tree-provider';
+import { PipelineStepsProvider } from './steps-tree-provider';
 
 let chatProvider: ChatViewProvider | undefined;
 
@@ -30,7 +32,40 @@ export function activate(context: vscode.ExtensionContext): void {
   const rawChannel = vscode.window.createOutputChannel('AIL');
   context.subscriptions.push(rawChannel);
   const outputChannel = new AilOutputChannel(rawChannel);
-  chatProvider = new ChatViewProvider(context, sessionManager, outputChannel);
+
+  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+  const historyProvider = new RunHistoryProvider('', cwd);
+  const stepsProvider = new PipelineStepsProvider();
+
+  // Resolve binary path lazily for tree providers (falls back gracefully if binary not found)
+  void resolveBinary(context).then((b) => {
+    historyProvider.setBinaryPath(b.path);
+    historyProvider.refresh();
+  }).catch(() => { /* binary not found — history tree stays empty */ });
+
+  context.subscriptions.push(
+    vscode.window.registerTreeDataProvider('ail-chat.historyView', historyProvider),
+    vscode.window.registerTreeDataProvider('ail-chat.stepsView', stepsProvider)
+  );
+
+  registerRunLogCommand(context, historyProvider);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ail-chat.openStep', (item) => {
+      stepsProvider.openStep(item);
+    })
+  );
+
+  let panelVisible = false;
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ail-chat.toggleInfoPanel', () => {
+      panelVisible = !panelVisible;
+      void vscode.commands.executeCommand('setContext', 'ail-chat.panelVisible', panelVisible);
+    })
+  );
+
+  chatProvider = new ChatViewProvider(context, sessionManager, outputChannel, historyProvider, stepsProvider);
 
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(ChatViewProvider.viewId, chatProvider, {

--- a/vscode-ail-chat/src/history-tree-provider.ts
+++ b/vscode-ail-chat/src/history-tree-provider.ts
@@ -1,0 +1,171 @@
+import * as vscode from 'vscode';
+import { spawn } from 'child_process';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface SessionSummary {
+  run_id: string;
+  pipeline_source?: string;
+  started_at?: number;
+  steps?: Array<{ step_id: string; prompt?: string }>;
+}
+
+export type RunLogFn = (binaryPath: string, args: string[], cwd?: string) => Promise<string>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function relativeTime(epochMs: number): string {
+  const diffSec = Math.floor((Date.now() - epochMs) / 1000);
+  if (diffSec < 60) return 'just now';
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  if (diffSec < 86400 * 7) return `${Math.floor(diffSec / 86400)}d ago`;
+  return new Date(epochMs).toLocaleDateString();
+}
+
+function invocationPrompt(session: SessionSummary): string {
+  const step = session.steps?.find((s) => s.step_id === 'invocation');
+  return step?.prompt ?? session.run_id;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + '…';
+}
+
+function defaultRunLogFn(binaryPath: string, args: string[], cwd?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(binaryPath, args, { cwd, env: { ...process.env, CLAUDECODE: undefined } });
+    const chunks: Buffer[] = [];
+    proc.stdout.on('data', (d: Buffer) => chunks.push(d));
+    proc.on('close', (code) => {
+      if (code === 0) resolve(Buffer.concat(chunks).toString());
+      else reject(new Error(`ail exited with code ${code}`));
+    });
+    proc.on('error', reject);
+  });
+}
+
+// ── Tree items ────────────────────────────────────────────────────────────────
+
+export class RunItem extends vscode.TreeItem {
+  constructor(
+    public readonly runId: string,
+    prompt: string,
+    timestamp: number,
+    public readonly binaryPath: string,
+    public readonly cwd?: string,
+    public readonly runLogFn?: RunLogFn
+  ) {
+    const label = truncate(prompt, 60);
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.description = timestamp > 0 ? relativeTime(timestamp * 1000) : undefined;
+    this.tooltip = prompt;
+    this.contextValue = 'ailRun';
+    this.iconPath = new vscode.ThemeIcon('history');
+    this.command = {
+      command: 'ail-chat.openRunLog',
+      title: 'Open Run Log',
+      arguments: [this],
+    };
+  }
+}
+
+class EmptyItem extends vscode.TreeItem {
+  constructor(message: string) {
+    super(message, vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon('info');
+    this.contextValue = 'ailRunEmpty';
+  }
+}
+
+// ── Provider ──────────────────────────────────────────────────────────────────
+
+export class RunHistoryProvider implements vscode.TreeDataProvider<RunItem | EmptyItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private _items: (RunItem | EmptyItem)[] = [new EmptyItem('No runs yet')];
+
+  constructor(
+    private _binaryPath: string,
+    private readonly _cwd?: string,
+    private readonly _runLogFn: RunLogFn = defaultRunLogFn
+  ) {}
+
+  setBinaryPath(binaryPath: string): void {
+    this._binaryPath = binaryPath;
+  }
+
+  refresh(): void {
+    if (!this._binaryPath) return;
+    void this._load();
+  }
+
+  getTreeItem(element: RunItem | EmptyItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): (RunItem | EmptyItem)[] {
+    return this._items;
+  }
+
+  async openRunLog(item: RunItem): Promise<void> {
+    let content: string;
+    try {
+      content = await item.runLogFn!(item.binaryPath, ['log', item.runId], item.cwd);
+    } catch (err) {
+      void vscode.window.showErrorMessage(`Failed to load run log: ${String(err)}`);
+      return;
+    }
+    const doc = await vscode.workspace.openTextDocument({ content, language: 'markdown' });
+    await vscode.window.showTextDocument(doc);
+  }
+
+  private async _load(): Promise<void> {
+    let raw: string;
+    try {
+      raw = await this._runLogFn(this._binaryPath, ['logs', '--format', 'json', '--limit', '100'], this._cwd);
+    } catch {
+      this._items = [new EmptyItem('Failed to load run history')];
+      this._onDidChangeTreeData.fire(undefined);
+      return;
+    }
+
+    const sessions: SessionSummary[] = raw
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        try { return JSON.parse(line) as SessionSummary; } catch { return null; }
+      })
+      .filter((s): s is SessionSummary => s !== null);
+
+    if (sessions.length === 0) {
+      this._items = [new EmptyItem('No runs yet — run a pipeline to see history')];
+    } else {
+      this._items = sessions.map(
+        (s) =>
+          new RunItem(
+            s.run_id,
+            invocationPrompt(s),
+            s.started_at ?? 0,
+            this._binaryPath,
+            this._cwd,
+            this._runLogFn
+          )
+      );
+    }
+    this._onDidChangeTreeData.fire(undefined);
+  }
+}
+
+export function registerRunLogCommand(
+  context: vscode.ExtensionContext,
+  provider: RunHistoryProvider
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ail-chat.openRunLog', (item: RunItem) => {
+      void provider.openRunLog(item);
+    })
+  );
+}
+

--- a/vscode-ail-chat/src/steps-tree-provider.ts
+++ b/vscode-ail-chat/src/steps-tree-provider.ts
@@ -1,0 +1,156 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import { parse as parseYaml } from 'yaml';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface ParsedStep {
+  id: string;
+  type: string;
+  line: number;
+}
+
+// ── YAML parsing ──────────────────────────────────────────────────────────────
+
+function stepType(raw: Record<string, unknown>): string {
+  if ('prompt' in raw) return 'prompt';
+  if ('context' in raw) return 'context';
+  if ('skill' in raw) return 'skill';
+  if ('pipeline' in raw) return 'sub-pipeline';
+  if ('action' in raw) return 'action';
+  if ('do_while' in raw) return 'do_while';
+  if ('for_each' in raw) return 'for_each';
+  return 'step';
+}
+
+function stepTypeIcon(type: string): vscode.ThemeIcon {
+  switch (type) {
+    case 'prompt': return new vscode.ThemeIcon('comment');
+    case 'context': return new vscode.ThemeIcon('terminal');
+    case 'skill': return new vscode.ThemeIcon('zap');
+    case 'sub-pipeline': return new vscode.ThemeIcon('references');
+    case 'action': return new vscode.ThemeIcon('play');
+    case 'do_while': return new vscode.ThemeIcon('refresh');
+    case 'for_each': return new vscode.ThemeIcon('list-ordered');
+    default: return new vscode.ThemeIcon('circle-outline');
+  }
+}
+
+function parseStepsFromYaml(pipelinePath: string): ParsedStep[] {
+  let content: string;
+  try {
+    content = fs.readFileSync(pipelinePath, 'utf8');
+  } catch {
+    return [];
+  }
+
+  let doc: unknown;
+  try {
+    doc = parseYaml(content);
+  } catch {
+    return [];
+  }
+
+  if (!doc || typeof doc !== 'object') return [];
+  const pipeline = (doc as Record<string, unknown>).pipeline;
+  if (!Array.isArray(pipeline)) return [];
+
+  const lines = content.split('\n');
+  const steps: ParsedStep[] = [];
+
+  for (const raw of pipeline) {
+    if (!raw || typeof raw !== 'object') continue;
+    const step = raw as Record<string, unknown>;
+    const id = typeof step.id === 'string' ? step.id : '(unnamed)';
+    const type = stepType(step);
+
+    // For sub-pipeline references, show the filename if available
+    const label =
+      type === 'sub-pipeline' && typeof step.pipeline === 'string'
+        ? `${id} → ${step.pipeline.split('/').pop()}`
+        : id;
+
+    // Find the line where this step's id appears
+    const lineIdx = lines.findIndex((l) => l.includes(`id: ${id}`) || l.includes(`id: "${id}"`));
+
+    steps.push({ id: label, type, line: lineIdx >= 0 ? lineIdx : 0 });
+  }
+  return steps;
+}
+
+// ── Tree items ────────────────────────────────────────────────────────────────
+
+export class StepItem extends vscode.TreeItem {
+  constructor(
+    public readonly stepId: string,
+    public readonly stepType: string,
+    public readonly pipelinePath: string,
+    public readonly stepLine: number
+  ) {
+    super(stepId, vscode.TreeItemCollapsibleState.None);
+    this.description = stepType;
+    this.tooltip = `${stepType}: ${stepId}`;
+    this.contextValue = 'ailStep';
+    this.iconPath = stepTypeIcon(stepType);
+    this.command = {
+      command: 'ail-chat.openStep',
+      title: 'Go to Step',
+      arguments: [this],
+    };
+  }
+}
+
+class ErrorItem extends vscode.TreeItem {
+  constructor(message: string) {
+    super(message, vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon('info');
+    this.contextValue = 'ailStepsError';
+  }
+}
+
+// ── Provider ──────────────────────────────────────────────────────────────────
+
+export class PipelineStepsProvider implements vscode.TreeDataProvider<StepItem | ErrorItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private _pipelinePath: string | null = null;
+
+  refresh(pipelinePath: string | null): void {
+    this._pipelinePath = pipelinePath;
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  getTreeItem(element: StepItem | ErrorItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): (StepItem | ErrorItem)[] {
+    if (!this._pipelinePath) {
+      return [new ErrorItem('No pipeline loaded')];
+    }
+
+    let steps: ParsedStep[];
+    try {
+      steps = parseStepsFromYaml(this._pipelinePath);
+    } catch {
+      return [new ErrorItem('Failed to parse pipeline YAML')];
+    }
+
+    if (steps.length === 0) {
+      return [new ErrorItem('No steps found in pipeline')];
+    }
+
+    return steps.map((s) => new StepItem(s.id, s.type, this._pipelinePath!, s.line));
+  }
+
+  openStep(item: StepItem): void {
+    const uri = vscode.Uri.file(item.pipelinePath);
+    void vscode.window.showTextDocument(uri).then((editor) => {
+      const pos = new vscode.Position(item.stepLine, 0);
+      editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+    });
+  }
+}
+
+export { parseStepsFromYaml };

--- a/vscode-ail-chat/test/history-tree-provider.test.ts
+++ b/vscode-ail-chat/test/history-tree-provider.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── vscode mock ───────────────────────────────────────────────────────────────
+
+vi.mock('vscode', () => ({
+  TreeItem: class TreeItem {
+    constructor(public label: string, public collapsibleState: number) {}
+  },
+  TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+  ThemeIcon: class ThemeIcon { constructor(public id: string) {} },
+  EventEmitter: class EventEmitter {
+    event = vi.fn();
+    fire = vi.fn();
+  },
+  window: {
+    showErrorMessage: vi.fn(() => Promise.resolve(undefined)),
+    showTextDocument: vi.fn(() => Promise.resolve(undefined)),
+  },
+  workspace: {
+    openTextDocument: vi.fn(() => Promise.resolve({ getText: () => '' })),
+  },
+  Uri: { file: (p: string) => ({ fsPath: p }) },
+  Position: class Position { constructor(public line: number, public character: number) {} },
+  Range: class Range { constructor(public start: unknown, public end: unknown) {} },
+  TextEditorRevealType: { InCenter: 2 },
+  commands: {
+    registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+}));
+
+// ── child_process mock ────────────────────────────────────────────────────────
+
+const { mockSpawn } = vi.hoisted(() => ({ mockSpawn: vi.fn() }));
+vi.mock('child_process', () => ({ spawn: mockSpawn }));
+
+// ── Import under test ─────────────────────────────────────────────────────────
+
+import { RunHistoryProvider, RunItem } from '../src/history-tree-provider';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRunLogFn(output: string, fail = false) {
+  return vi.fn(() => fail ? Promise.reject(new Error('failed')) : Promise.resolve(output));
+}
+
+function makeSession(overrides?: Partial<{
+  run_id: string;
+  started_at: number;
+  steps: Array<{ step_id: string; prompt?: string }>;
+}>) {
+  return JSON.stringify({
+    run_id: 'abc-123',
+    started_at: Math.floor(Date.now() / 1000) - 60,
+    steps: [{ step_id: 'invocation', prompt: 'hello world' }],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('RunHistoryProvider', () => {
+  describe('refresh', () => {
+    it('does not call runLogFn when binaryPath is empty', async () => {
+      const fn = makeRunLogFn('');
+      const provider = new RunHistoryProvider('', undefined, fn);
+      provider.refresh();
+      await Promise.resolve(); // flush microtasks
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it('calls ail logs with correct args after setBinaryPath', async () => {
+      const fn = makeRunLogFn(makeSession());
+      const provider = new RunHistoryProvider('', undefined, fn);
+      provider.setBinaryPath('/usr/local/bin/ail');
+      provider.refresh();
+      await new Promise((r) => setTimeout(r, 0));
+      expect(fn).toHaveBeenCalledWith('/usr/local/bin/ail', ['logs', '--format', 'json', '--limit', '100'], undefined);
+    });
+
+    it('populates tree items from NDJSON output', async () => {
+      const output = [makeSession({ run_id: 'r1' }), makeSession({ run_id: 'r2' })].join('\n');
+      const fn = makeRunLogFn(output);
+      const provider = new RunHistoryProvider('/bin/ail', undefined, fn);
+      provider.refresh();
+      await new Promise((r) => setTimeout(r, 0));
+      const items = provider.getChildren();
+      expect(items).toHaveLength(2);
+      expect(items[0]).toBeInstanceOf(RunItem);
+    });
+
+    it('uses invocation step prompt as label', async () => {
+      const fn = makeRunLogFn(makeSession({ steps: [{ step_id: 'invocation', prompt: 'fix the bug' }] }));
+      const provider = new RunHistoryProvider('/bin/ail', undefined, fn);
+      provider.refresh();
+      await new Promise((r) => setTimeout(r, 0));
+      const items = provider.getChildren();
+      expect((items[0] as RunItem).label).toContain('fix the bug');
+    });
+
+    it('truncates long prompts to 60 chars', async () => {
+      const longPrompt = 'a'.repeat(80);
+      const fn = makeRunLogFn(makeSession({ steps: [{ step_id: 'invocation', prompt: longPrompt }] }));
+      const provider = new RunHistoryProvider('/bin/ail', undefined, fn);
+      provider.refresh();
+      await new Promise((r) => setTimeout(r, 0));
+      const label = (provider.getChildren()[0] as RunItem).label as string;
+      expect(label.length).toBeLessThanOrEqual(61); // 60 + ellipsis
+    });
+
+    it('shows empty state when no sessions returned', async () => {
+      const fn = makeRunLogFn('');
+      const provider = new RunHistoryProvider('/bin/ail', undefined, fn);
+      provider.refresh();
+      await new Promise((r) => setTimeout(r, 0));
+      const items = provider.getChildren();
+      expect(items).toHaveLength(1);
+      expect((items[0] as RunItem).label).toContain('No runs');
+    });
+
+    it('shows error state when CLI call fails', async () => {
+      const fn = makeRunLogFn('', true);
+      const provider = new RunHistoryProvider('/bin/ail', undefined, fn);
+      provider.refresh();
+      await new Promise((r) => setTimeout(r, 0));
+      const items = provider.getChildren();
+      expect((items[0] as RunItem).label).toContain('Failed');
+    });
+
+    it('skips malformed NDJSON lines without throwing', async () => {
+      const output = ['not-json', makeSession({ run_id: 'good' })].join('\n');
+      const fn = makeRunLogFn(output);
+      const provider = new RunHistoryProvider('/bin/ail', undefined, fn);
+      provider.refresh();
+      await new Promise((r) => setTimeout(r, 0));
+      expect(provider.getChildren()).toHaveLength(1);
+    });
+  });
+
+  describe('openRunLog', () => {
+    it('calls ail log <runId> and opens a markdown document', async () => {
+      const logContent = '# Run abc-123\nsome content';
+      const fn = makeRunLogFn(logContent);
+      const provider = new RunHistoryProvider('/bin/ail', '/workspace', fn);
+      const item = new RunItem('abc-123', 'test prompt', Date.now() / 1000, '/bin/ail', '/workspace', fn);
+
+      await provider.openRunLog(item);
+
+      expect(fn).toHaveBeenCalledWith('/bin/ail', ['log', 'abc-123'], '/workspace');
+    });
+  });
+});

--- a/vscode-ail-chat/test/steps-tree-provider.test.ts
+++ b/vscode-ail-chat/test/steps-tree-provider.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ── vscode mock ───────────────────────────────────────────────────────────────
+
+vi.mock('vscode', () => ({
+  TreeItem: class TreeItem {
+    constructor(public label: string, public collapsibleState: number) {}
+  },
+  TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+  ThemeIcon: class ThemeIcon { constructor(public id: string) {} },
+  EventEmitter: class EventEmitter {
+    event = vi.fn();
+    fire = vi.fn();
+  },
+  window: {
+    showTextDocument: vi.fn(() => Promise.resolve({
+      revealRange: vi.fn(),
+    })),
+  },
+  Uri: { file: (p: string) => ({ fsPath: p }) },
+  Position: class Position { constructor(public line: number, public character: number) {} },
+  Range: class Range { constructor(public start: unknown, public end: unknown) {} },
+  TextEditorRevealType: { InCenter: 2 },
+}));
+
+// ── Import under test ─────────────────────────────────────────────────────────
+
+import { PipelineStepsProvider, StepItem, parseStepsFromYaml } from '../src/steps-tree-provider';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function writeTempYaml(content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ail-steps-test-'));
+  const filePath = path.join(dir, 'pipeline.yaml');
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('parseStepsFromYaml', () => {
+  it('returns one StepItem per top-level step', () => {
+    const p = writeTempYaml(`
+version: "0.0.1"
+pipeline:
+  - id: invocation
+    prompt: "{{ step.invocation.prompt }}"
+  - id: review
+    prompt: review it
+`);
+    const steps = parseStepsFromYaml(p);
+    expect(steps).toHaveLength(2);
+    expect(steps[0].id).toBe('invocation');
+    expect(steps[1].id).toBe('review');
+  });
+
+  it('detects step types correctly', () => {
+    const p = writeTempYaml(`
+pipeline:
+  - id: s1
+    prompt: hi
+  - id: s2
+    context:
+      shell: echo hi
+  - id: s3
+    skill: brainstorm
+`);
+    const steps = parseStepsFromYaml(p);
+    expect(steps[0].type).toBe('prompt');
+    expect(steps[1].type).toBe('context');
+    expect(steps[2].type).toBe('skill');
+  });
+
+  it('renders sub-pipeline reference as single node with filename label', () => {
+    const p = writeTempYaml(`
+pipeline:
+  - id: sub
+    pipeline: ./workflows/foo.ail.yaml
+`);
+    const steps = parseStepsFromYaml(p);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].id).toContain('foo.ail.yaml');
+    expect(steps[0].type).toBe('sub-pipeline');
+  });
+
+  it('returns empty array for malformed YAML without throwing', () => {
+    const p = writeTempYaml('this: is: not: valid: yaml: {{{{');
+    expect(() => parseStepsFromYaml(p)).not.toThrow();
+    const steps = parseStepsFromYaml(p);
+    expect(steps).toHaveLength(0);
+  });
+
+  it('returns empty array when pipeline key is missing', () => {
+    const p = writeTempYaml('version: "0.0.1"\nmeta:\n  name: test');
+    expect(parseStepsFromYaml(p)).toHaveLength(0);
+  });
+});
+
+describe('PipelineStepsProvider', () => {
+  it('returns error item when no pipeline is loaded', () => {
+    const provider = new PipelineStepsProvider();
+    const items = provider.getChildren();
+    expect(items).toHaveLength(1);
+    expect((items[0] as StepItem).label).toContain('No pipeline');
+  });
+
+  it('returns StepItems for a valid pipeline', () => {
+    const p = writeTempYaml(`
+pipeline:
+  - id: invocation
+    prompt: "{{ step.invocation.prompt }}"
+  - id: check
+    context:
+      shell: echo ok
+`);
+    const provider = new PipelineStepsProvider();
+    provider.refresh(p);
+    const items = provider.getChildren();
+    expect(items).toHaveLength(2);
+    expect(items[0]).toBeInstanceOf(StepItem);
+  });
+
+  it('returns error item for malformed YAML', () => {
+    const p = writeTempYaml('not: valid: yaml: {{{');
+    const provider = new PipelineStepsProvider();
+    provider.refresh(p);
+    const items = provider.getChildren();
+    expect(items).toHaveLength(1);
+  });
+
+  it('returns error item for null/passthrough pipeline', () => {
+    const provider = new PipelineStepsProvider();
+    provider.refresh(null);
+    const items = provider.getChildren();
+    expect((items[0] as StepItem).label).toContain('No pipeline');
+  });
+});


### PR DESCRIPTION
Closes #167. Depends on #172 (#166).

## Summary

- `RunHistoryProvider` — calls `ail logs --format json --limit 100` to list past runs; no direct file access; refresh triggered by `pipelineCompleted` event from `ChatViewProvider`; `openRunLog` command calls `ail log <runId>` and opens output as a markdown document
- `PipelineStepsProvider` — parses active pipeline YAML (via the existing `yaml` dep); top-level steps only; sub-pipeline references render as single node with filename; error node on missing/malformed YAML or passthrough mode; `openStep` reveals the `id:` line in the editor
- `toggleInfoPanel` command — flips `ail-chat.panelVisible` context key; `historyView` and `stepsView` are gated on this key in `package.json` so they appear/disappear without disposal; toggle button in chat view title bar via `menus["view/title"]`
- `ChatViewProvider` wired: calls `historyProvider.refresh()` on `pipelineCompleted`, `stepsProvider.refresh()` on pipeline change
- All binary calls are injectable for unit testing; no direct file system access for log data

## Test plan

- [ ] Toggle button in chat view title bar → Run History and Pipeline Steps panels appear; toggle again → disappear
- [ ] Run a prompt → Run History refreshes and shows the new entry
- [ ] Click a run entry → VS Code opens the run log as a markdown document
- [ ] Load a multi-step pipeline → Pipeline Steps shows top-level steps; click a step → YAML opens at that `id:` line
- [ ] Sub-pipeline reference → renders as single node with filename label
- [ ] Malformed YAML → error node, no throw
- [ ] No pipeline loaded → Pipeline Steps shows "No pipeline loaded" node
- [ ] `npm test` → 200 tests passing