### PR TITLE
feat(§31): compile spec into binary, add `ail spec` CLI and native pipeline injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,9 @@ ail/                        # binary crate — CLI entry point only
   src/main.rs               # --once, materialize, validate handlers
   src/cli.rs                # Cli, Commands (clap derive)
   src/command.rs            # CommandOutcome — command lifecycle types
+ail-spec/                   # library crate — embedded spec content
+  build.rs                  # scans spec/ at build time, generates include_str! code
+  src/lib.rs                # public API: section(), list_sections(), full_prose(), compact(), schema()
 ail-core/                   # library crate — all logic, no UI
   src/
     config/                 # discovery, dto, domain, validation, mod (load())
@@ -28,6 +31,8 @@ demo/                       # working demo pipeline (.ail.yaml + README)
 spec/                       # split spec files (primary published artifacts)
   core/s*.md                # AIL Pipeline Language Specification (one file per section)
   runner/r*.md              # Claude CLI runner contract (one file per section)
+  compressed/schema.yaml    # T1 — annotated YAML schema (~2-3K tokens)
+  compressed/compact.md     # T2 — compressed NL reference (~10-12K tokens)
   README.md                 # navigation index — start here
 SPEC.md                     # redirect stub → spec/core/
 RUNNER-SPEC.md              # redirect stub → spec/runner/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ name = "ail"
 version = "0.0.1"
 dependencies = [
  "ail-core",
+ "ail-spec",
  "assert_cmd",
  "clap",
  "dirs",
@@ -53,6 +54,7 @@ dependencies = [
 name = "ail-core"
 version = "0.0.1"
 dependencies = [
+ "ail-spec",
  "dirs",
  "event-listener",
  "interprocess",
@@ -69,6 +71,13 @@ dependencies = [
  "tracing",
  "ureq",
  "uuid",
+]
+
+[[package]]
+name = "ail-spec"
+version = "0.0.1"
+dependencies = [
+ "glob",
 ]
 
 [[package]]
@@ -604,6 +613,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["ail-core", "ail", "stub-llm"]
+members = ["ail-core", "ail", "ail-spec", "stub-llm"]
 resolver = "2"

--- a/ail-core/Cargo.toml
+++ b/ail-core/Cargo.toml
@@ -19,6 +19,7 @@ tempfile = "3"
 ureq = { version = "2", features = ["json"] }
 event-listener = "5"
 regex = "1"
+ail-spec = { path = "../ail-spec" }
 
 [dev-dependencies]
 stub-llm = { path = "../stub-llm" }

--- a/ail-core/src/config/domain.rs
+++ b/ail-core/src/config/domain.rs
@@ -10,6 +10,9 @@ pub enum SystemPromptEntry {
     File(PathBuf),
     /// Shell command whose stdout+stderr output is injected at step runtime.
     Shell(String),
+    /// Embedded spec query — resolved to spec content at step runtime (SPEC §31).
+    /// Value is a tier name (`compact`, `schema`, `prose`) or a section ID (`s05`, `r02`).
+    Spec(String),
 }
 
 /// Maximum depth for nested sub-pipeline calls. Prevents infinite recursion
@@ -386,6 +389,7 @@ pub enum OnMaxItems {
 #[derive(Debug, Clone)]
 pub enum ContextSource {
     Shell(String),
+    Spec(String),
 }
 
 #[derive(Debug, Clone)]

--- a/ail-core/src/config/dto.rs
+++ b/ail-core/src/config/dto.rs
@@ -174,6 +174,7 @@ pub enum ChainStepDto {
 #[derive(Debug, Default, Deserialize)]
 pub struct ContextDto {
     pub shell: Option<String>,
+    pub spec: Option<String>,
 }
 
 /// DTO for `do_while:` bounded repeat-until loop (SPEC §27).
@@ -291,4 +292,5 @@ pub struct AppendSystemPromptStructuredDto {
     pub text: Option<String>,
     pub file: Option<String>,
     pub shell: Option<String>,
+    pub spec: Option<String>,
 }

--- a/ail-core/src/config/validation/mod.rs
+++ b/ail-core/src/config/validation/mod.rs
@@ -1214,6 +1214,7 @@ mod tests {
             id: Some("ctx".to_string()),
             context: Some(ContextDto {
                 shell: Some("git status".to_string()),
+                ..Default::default()
             }),
             ..Default::default()
         }]);
@@ -1685,6 +1686,7 @@ mod tests {
                 text: Some("Be helpful".to_string()),
                 file: None,
                 shell: None,
+                spec: None,
             },
         )]);
         let dto = minimal_dto(vec![step]);
@@ -1704,6 +1706,7 @@ mod tests {
                 text: None,
                 file: Some("rules.txt".to_string()),
                 shell: None,
+                spec: None,
             },
         )]);
         let dto = minimal_dto(vec![step]);
@@ -1723,6 +1726,7 @@ mod tests {
                 text: None,
                 file: None,
                 shell: Some("cat rules.txt".to_string()),
+                spec: None,
             },
         )]);
         let dto = minimal_dto(vec![step]);
@@ -1742,6 +1746,7 @@ mod tests {
                 text: None,
                 file: None,
                 shell: None,
+                spec: None,
             },
         )]);
         let dto = minimal_dto(vec![step]);
@@ -1757,6 +1762,7 @@ mod tests {
                 text: Some("inline".to_string()),
                 file: Some("also-file.txt".to_string()),
                 shell: None,
+                spec: None,
             },
         )]);
         let dto = minimal_dto(vec![step]);

--- a/ail-core/src/config/validation/step_body.rs
+++ b/ail-core/src/config/validation/step_body.rs
@@ -101,11 +101,22 @@ pub(in crate::config) fn parse_step_body(
             )),
         }
     } else if let Some(ref context_dto) = step_dto.context {
-        match context_dto.shell {
-            Some(ref cmd) => Ok(StepBody::Context(ContextSource::Shell(cmd.clone()))),
-            None => Err(cfg_err!(
-                "Step '{id_str}' declares context: but no source (shell:, mcp:) is present"
-            )),
+        let source_count = [context_dto.shell.is_some(), context_dto.spec.is_some()]
+            .iter()
+            .filter(|&&b| b)
+            .count();
+        if source_count != 1 {
+            return Err(cfg_err!(
+                "Step '{id_str}' declares context: but must have exactly one source \
+                 (shell: or spec:); found {source_count}"
+            ));
+        }
+        if let Some(ref cmd) = context_dto.shell {
+            Ok(StepBody::Context(ContextSource::Shell(cmd.clone())))
+        } else if let Some(ref query) = context_dto.spec {
+            Ok(StepBody::Context(ContextSource::Spec(query.clone())))
+        } else {
+            unreachable!("source_count == 1")
         }
     } else if step_dto.do_while.is_some() {
         parse_do_while_body(step_dto.do_while.take().unwrap(), id_str, pipeline_source)

--- a/ail-core/src/config/validation/system_prompt.rs
+++ b/ail-core/src/config/validation/system_prompt.rs
@@ -18,22 +18,29 @@ pub(in crate::config) fn parse_append_system_prompt(
         .map(|(i, entry)| match entry {
             AppendSystemPromptEntryDto::Text(s) => Ok(SystemPromptEntry::Text(s)),
             AppendSystemPromptEntryDto::Structured(s) => {
-                let set_count = [s.text.is_some(), s.file.is_some(), s.shell.is_some()]
-                    .iter()
-                    .filter(|&&b| b)
-                    .count();
+                let set_count = [
+                    s.text.is_some(),
+                    s.file.is_some(),
+                    s.shell.is_some(),
+                    s.spec.is_some(),
+                ]
+                .iter()
+                .filter(|&&b| b)
+                .count();
                 if set_count != 1 {
                     return Err(cfg_err!(
                         "Step '{step_id}' append_system_prompt entry {i} must have exactly one \
-                         key (text, file, or shell); found {set_count}"
+                         key (text, file, shell, or spec); found {set_count}"
                     ));
                 }
                 if let Some(text) = s.text {
                     Ok(SystemPromptEntry::Text(text))
                 } else if let Some(file) = s.file {
                     Ok(SystemPromptEntry::File(std::path::PathBuf::from(file)))
+                } else if let Some(shell) = s.shell {
+                    Ok(SystemPromptEntry::Shell(shell))
                 } else {
-                    Ok(SystemPromptEntry::Shell(s.shell.expect("set_count == 1")))
+                    Ok(SystemPromptEntry::Spec(s.spec.expect("set_count == 1")))
                 }
             }
         })

--- a/ail-core/src/executor/core.rs
+++ b/ail-core/src/executor/core.rs
@@ -381,6 +381,10 @@ pub(super) fn execute_single_step<O: StepObserver>(
                 dispatch::context::execute_shell(cmd, session, &step_id, observer)
             }
 
+            StepBody::Context(ContextSource::Spec(query)) => {
+                dispatch::context::execute_spec(query, session, &step_id, observer)
+            }
+
             StepBody::Action(ActionKind::PauseForHuman) => {
                 unreachable!("PauseForHuman handled above")
             }

--- a/ail-core/src/executor/dispatch/context.rs
+++ b/ail-core/src/executor/dispatch/context.rs
@@ -1,4 +1,4 @@
-//! Context shell step dispatch — shell subprocess execution and TurnEntry construction.
+//! Context step dispatch — shell subprocess and spec query execution.
 
 #![allow(clippy::result_large_err)]
 
@@ -32,4 +32,54 @@ pub(in crate::executor) fn execute_shell<O: StepObserver>(
         stderr,
         exit_code,
     ))
+}
+
+/// Execute a spec context step: resolve the query and return embedded spec content.
+pub(in crate::executor) fn execute_spec<O: StepObserver>(
+    query: &str,
+    session: &mut Session,
+    step_id: &str,
+    observer: &mut O,
+) -> Result<TurnEntry, AilError> {
+    session
+        .turn_log
+        .record_step_started(step_id, &format!("spec:{query}"));
+    let content = resolve_spec_query(query).map_err(|detail| {
+        observer.on_step_failed(step_id, &detail);
+        AilError::config_validation(&detail)
+    })?;
+    tracing::info!(
+        run_id = %session.run_id,
+        step_id = %step_id,
+        query = %query,
+        "context spec step complete"
+    );
+    observer.on_non_prompt_completed(step_id);
+    Ok(TurnEntry::from_context(
+        step_id.to_string(),
+        format!("spec:{query}"),
+        content,
+        String::new(),
+        0,
+    ))
+}
+
+/// Resolve a spec query string to content.
+/// Accepts tier names (`compact`, `schema`, `prose`) or section IDs (`s05`, `r02`).
+pub(crate) fn resolve_spec_query(query: &str) -> Result<String, String> {
+    match query {
+        "compact" => Ok(ail_spec::compact().to_string()),
+        "schema" => Ok(ail_spec::schema().to_string()),
+        "prose" => Ok(ail_spec::full_prose()),
+        "core" => Ok(ail_spec::core_prose()),
+        "runner" => Ok(ail_spec::runner_prose()),
+        other => ail_spec::section(other)
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                format!(
+                    "Unknown spec query '{other}'. Use a tier (compact, schema, prose) \
+                     or a section ID (s05, r02). Run `ail spec --list` to see available sections."
+                )
+            }),
+    }
 }

--- a/ail-core/src/executor/helpers/system_prompt.rs
+++ b/ail-core/src/executor/helpers/system_prompt.rs
@@ -54,6 +54,15 @@ pub(in crate::executor) fn resolve_step_system_prompts(
                         run_shell_command(&session.run_id, step_id, &resolved_cmd)?;
                     stdout
                 }
+                SystemPromptEntry::Spec(query) => {
+                    crate::executor::dispatch::context::resolve_spec_query(query).map_err(
+                        |detail| {
+                            AilError::config_validation(format!(
+                                "Step '{step_id}' append_system_prompt spec: {detail}"
+                            ))
+                        },
+                    )?
+                }
             };
             resolved_append.push(text);
         }

--- a/ail-core/src/materialize.rs
+++ b/ail-core/src/materialize.rs
@@ -41,6 +41,9 @@ fn chain_step_summary(body: &StepBody) -> String {
         StepBody::Context(ContextSource::Shell(cmd)) => {
             format!("context: shell: \"{}\"", yaml_quote(cmd))
         }
+        StepBody::Context(ContextSource::Spec(query)) => {
+            format!("context: spec: {query}")
+        }
         StepBody::DoWhile {
             max_iterations,
             steps,
@@ -249,6 +252,9 @@ pub fn materialize(pipeline: &Pipeline) -> String {
                     yaml_quote(cmd)
                 ));
             }
+            StepBody::Context(ContextSource::Spec(query)) => {
+                out.push_str(&format!("    context:\n      spec: {query}\n"));
+            }
             StepBody::DoWhile {
                 max_iterations,
                 ref exit_when,
@@ -447,6 +453,11 @@ fn serialize_step(out: &mut String, step: &Step, indent: &str, origin_comment: O
             out.push_str(&format!(
                 "{field_indent}context:\n{field_indent}  shell: \"{}\"\n",
                 yaml_quote(cmd)
+            ));
+        }
+        StepBody::Context(ContextSource::Spec(query)) => {
+            out.push_str(&format!(
+                "{field_indent}context:\n{field_indent}  spec: {query}\n"
             ));
         }
         StepBody::DoWhile {

--- a/ail-spec/Cargo.toml
+++ b/ail-spec/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ail-spec"
+version = "0.0.1"
+edition = "2021"
+build = "build.rs"
+
+[build-dependencies]
+glob = "0.3"

--- a/ail-spec/build.rs
+++ b/ail-spec/build.rs
@@ -1,0 +1,180 @@
+use glob::glob;
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+struct SpecFile {
+    /// Section ID: "s05", "r02", etc.
+    id: String,
+    /// Title extracted from first ## heading
+    title: String,
+    /// Word count of the file
+    word_count: usize,
+    /// Path relative to workspace root (for include_str!)
+    rel_path: String,
+    /// "core" or "runner"
+    category: &'static str,
+}
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_path = PathBuf::from(&out_dir).join("embedded_specs.rs");
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let workspace_root = manifest_dir.parent().unwrap();
+
+    let mut specs = Vec::new();
+
+    for (pattern, category) in &[("spec/core/s*.md", "core"), ("spec/runner/r*.md", "runner")] {
+        let full_pattern = workspace_root.join(pattern).to_string_lossy().to_string();
+        let mut paths: Vec<PathBuf> = glob(&full_pattern)
+            .expect("Failed to read glob pattern")
+            .filter_map(Result::ok)
+            .collect();
+        paths.sort();
+
+        for path in paths {
+            let stem = path.file_stem().unwrap().to_string_lossy().to_string();
+            let id = stem.split('-').next().unwrap_or(&stem).to_string();
+
+            let content = fs::read_to_string(&path).unwrap_or_default();
+            let title = extract_title(&content);
+            let word_count = content.split_whitespace().count();
+            let rel_path = path
+                .strip_prefix(workspace_root)
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
+
+            specs.push(SpecFile {
+                id,
+                title,
+                word_count,
+                rel_path,
+                category,
+            });
+        }
+    }
+
+    let mut out = fs::File::create(&out_path).expect("Failed to create generated file");
+
+    writeln!(out, "pub struct SpecSection {{").unwrap();
+    writeln!(out, "    pub id: &'static str,").unwrap();
+    writeln!(out, "    pub title: &'static str,").unwrap();
+    writeln!(out, "    pub word_count: usize,").unwrap();
+    writeln!(out, "    pub category: &'static str,").unwrap();
+    writeln!(out, "}}").unwrap();
+    writeln!(out).unwrap();
+
+    // Per-section constants
+    for spec in &specs {
+        let const_name = spec.id.to_uppercase();
+        writeln!(
+            out,
+            "pub const SECTION_{}: &str = include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../{}\"));",
+            const_name, spec.rel_path
+        )
+        .unwrap();
+    }
+    writeln!(out).unwrap();
+
+    // Section registry
+    writeln!(out, "pub const SECTIONS: &[SpecSection] = &[").unwrap();
+    for spec in &specs {
+        let const_name = spec.id.to_uppercase();
+        writeln!(
+            out,
+            "    SpecSection {{ id: \"{}\", title: \"{}\", word_count: {}, category: \"{}\" }},",
+            spec.id,
+            spec.title.replace('"', "\\\""),
+            spec.word_count,
+            spec.category
+        )
+        .unwrap();
+        // Reference the constant so it's not unused
+        let _ = const_name;
+    }
+    writeln!(out, "];").unwrap();
+    writeln!(out).unwrap();
+
+    // Lookup function
+    writeln!(
+        out,
+        "pub fn section_content(id: &str) -> Option<&'static str> {{"
+    )
+    .unwrap();
+    writeln!(out, "    match id {{").unwrap();
+    for spec in &specs {
+        let const_name = spec.id.to_uppercase();
+        writeln!(
+            out,
+            "        \"{}\" => Some(SECTION_{}),",
+            spec.id, const_name
+        )
+        .unwrap();
+    }
+    writeln!(out, "        _ => None,").unwrap();
+    writeln!(out, "    }}").unwrap();
+    writeln!(out, "}}").unwrap();
+    writeln!(out).unwrap();
+
+    // Concatenated constants
+    write_concatenated(&mut out, "CORE_PROSE", &specs, "core");
+    write_concatenated(&mut out, "RUNNER_PROSE", &specs, "runner");
+    write_concatenated_all(&mut out, "FULL_PROSE", &specs);
+
+    // T1 schema
+    writeln!(
+        out,
+        "pub const SCHEMA: &str = include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../spec/compressed/schema.yaml\"));"
+    )
+    .unwrap();
+
+    // T2 compact
+    writeln!(
+        out,
+        "pub const COMPACT: &str = include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../spec/compressed/compact.md\"));"
+    )
+    .unwrap();
+
+    // Rerun triggers
+    println!("cargo:rerun-if-changed=../spec/core");
+    println!("cargo:rerun-if-changed=../spec/runner");
+    println!("cargo:rerun-if-changed=../spec/compressed");
+}
+
+fn extract_title(content: &str) -> String {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("## ") {
+            return trimmed.trim_start_matches('#').trim().to_string();
+        }
+    }
+    String::new()
+}
+
+fn write_concatenated(out: &mut fs::File, name: &str, specs: &[SpecFile], category: &str) {
+    writeln!(out, "pub fn {}_fn() -> String {{", name.to_lowercase()).unwrap();
+    writeln!(out, "    let mut s = String::new();").unwrap();
+    for spec in specs.iter().filter(|s| s.category == category) {
+        let const_name = spec.id.to_uppercase();
+        writeln!(out, "    s.push_str(SECTION_{});", const_name).unwrap();
+        writeln!(out, "    s.push_str(\"\\n\\n\");").unwrap();
+    }
+    writeln!(out, "    s").unwrap();
+    writeln!(out, "}}").unwrap();
+    writeln!(out).unwrap();
+}
+
+fn write_concatenated_all(out: &mut fs::File, name: &str, specs: &[SpecFile]) {
+    writeln!(out, "pub fn {}_fn() -> String {{", name.to_lowercase()).unwrap();
+    writeln!(out, "    let mut s = String::new();").unwrap();
+    for spec in specs {
+        let const_name = spec.id.to_uppercase();
+        writeln!(out, "    s.push_str(SECTION_{});", const_name).unwrap();
+        writeln!(out, "    s.push_str(\"\\n\\n\");").unwrap();
+    }
+    writeln!(out, "    s").unwrap();
+    writeln!(out, "}}").unwrap();
+    writeln!(out).unwrap();
+}

--- a/ail-spec/src/lib.rs
+++ b/ail-spec/src/lib.rs
@@ -1,0 +1,33 @@
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/embedded_specs.rs"));
+}
+
+pub use generated::SpecSection;
+
+pub fn section(id: &str) -> Option<&'static str> {
+    generated::section_content(id)
+}
+
+pub fn list_sections() -> &'static [SpecSection] {
+    generated::SECTIONS
+}
+
+pub fn full_prose() -> String {
+    generated::full_prose_fn()
+}
+
+pub fn core_prose() -> String {
+    generated::core_prose_fn()
+}
+
+pub fn runner_prose() -> String {
+    generated::runner_prose_fn()
+}
+
+pub fn compact() -> &'static str {
+    generated::COMPACT
+}
+
+pub fn schema() -> &'static str {
+    generated::SCHEMA
+}

--- a/ail/Cargo.toml
+++ b/ail/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 ail-core = { path = "../ail-core" }
+ail-spec = { path = "../ail-spec" }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde_json = "1"

--- a/ail/src/cli.rs
+++ b/ail/src/cli.rs
@@ -176,6 +176,29 @@ pub enum Commands {
         #[arg(long, value_name = "TOKEN")]
         provider_token: Option<String>,
     },
+    /// Print the AIL specification (embedded in the binary).
+    Spec {
+        /// Output format: `prose` (default, full spec), `compact` (compressed reference),
+        /// or `schema` (annotated YAML schema).
+        #[arg(long, default_value = "prose")]
+        format: String,
+
+        /// Print specific section(s) by ID (e.g. `s05`, `r02`). Comma-separated for multiple.
+        #[arg(long, value_delimiter = ',')]
+        section: Option<Vec<String>>,
+
+        /// List available section IDs with titles and word counts.
+        #[arg(long)]
+        list: bool,
+
+        /// Print only core spec sections (s-prefixed).
+        #[arg(long)]
+        core: bool,
+
+        /// Print only runner spec sections (r-prefixed).
+        #[arg(long)]
+        runner: bool,
+    },
     /// Delete a pipeline run from the history.
     Delete {
         /// Run ID to delete.

--- a/ail/src/dry_run.rs
+++ b/ail/src/dry_run.rs
@@ -63,6 +63,9 @@ pub fn run_dry_run(
             ail_core::config::domain::StepBody::Context(
                 ail_core::config::domain::ContextSource::Shell(_),
             ) => "context:shell",
+            ail_core::config::domain::StepBody::Context(
+                ail_core::config::domain::ContextSource::Spec(_),
+            ) => "context:spec",
             ail_core::config::domain::StepBody::DoWhile { .. } => "do_while",
             ail_core::config::domain::StepBody::ForEach { .. } => "for_each",
         };
@@ -104,6 +107,12 @@ pub fn run_dry_run(
             ) => {
                 println!("  Command: {cmd}");
                 println!("  (shell steps execute normally in dry-run mode)");
+            }
+            ail_core::config::domain::StepBody::Context(
+                ail_core::config::domain::ContextSource::Spec(query),
+            ) => {
+                println!("  Spec query: {query}");
+                println!("  (spec context resolves to embedded spec content)");
             }
             ail_core::config::domain::StepBody::SubPipeline { path, prompt: p } => {
                 println!("  Pipeline path: {path}");

--- a/ail/src/main.rs
+++ b/ail/src/main.rs
@@ -12,6 +12,7 @@ mod logs;
 mod materialize;
 mod once_json;
 mod once_text;
+mod spec;
 mod validate;
 
 use ail_core::runner::factory::RunnerFactory;
@@ -108,6 +109,23 @@ async fn main() {
             }
         }
         (None, Some(cmd)) => match cmd {
+            Commands::Spec {
+                format,
+                section,
+                list,
+                core,
+                runner,
+            } => {
+                let fmt = match spec::SpecFormat::parse(&format) {
+                    Ok(f) => f,
+                    Err(e) => {
+                        eprintln!("{e}");
+                        std::process::exit(1);
+                    }
+                };
+                let cmd = spec::SpecCommand::new(fmt, section, list, core, runner);
+                exit_with(cmd.execute());
+            }
             Commands::Delete {
                 run_id,
                 force,

--- a/ail/src/spec.rs
+++ b/ail/src/spec.rs
@@ -1,0 +1,115 @@
+use crate::command::CommandOutcome;
+
+pub struct SpecCommand {
+    format: SpecFormat,
+    sections: Option<Vec<String>>,
+    list: bool,
+    core_only: bool,
+    runner_only: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum SpecFormat {
+    #[default]
+    Prose,
+    Compact,
+    Schema,
+}
+
+impl SpecFormat {
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "prose" => Ok(SpecFormat::Prose),
+            "compact" => Ok(SpecFormat::Compact),
+            "schema" => Ok(SpecFormat::Schema),
+            other => Err(format!(
+                "unknown spec format: '{other}' (expected prose, compact, or schema)"
+            )),
+        }
+    }
+}
+
+impl SpecCommand {
+    pub fn new(
+        format: SpecFormat,
+        sections: Option<Vec<String>>,
+        list: bool,
+        core_only: bool,
+        runner_only: bool,
+    ) -> Self {
+        Self {
+            format,
+            sections,
+            list,
+            core_only,
+            runner_only,
+        }
+    }
+
+    pub fn execute(&self) -> CommandOutcome {
+        if self.list {
+            return self.run_list();
+        }
+
+        if let Some(ref sections) = self.sections {
+            return self.run_sections(sections);
+        }
+
+        self.run_full()
+    }
+
+    fn run_list(&self) -> CommandOutcome {
+        for s in ail_spec::list_sections() {
+            if self.core_only && s.category != "core" {
+                continue;
+            }
+            if self.runner_only && s.category != "runner" {
+                continue;
+            }
+            println!("{:<6} {:>6} words  {}", s.id, s.word_count, s.title);
+        }
+        CommandOutcome::Success
+    }
+
+    fn run_sections(&self, ids: &[String]) -> CommandOutcome {
+        let mut first = true;
+        for id in ids {
+            match ail_spec::section(id) {
+                Some(content) => {
+                    if !first {
+                        println!();
+                    }
+                    print!("{content}");
+                    first = false;
+                }
+                None => {
+                    eprintln!("Unknown spec section: '{id}'");
+                    eprintln!("Run `ail spec --list` to see available sections.");
+                    return CommandOutcome::ExitCode(1);
+                }
+            }
+        }
+        CommandOutcome::Success
+    }
+
+    fn run_full(&self) -> CommandOutcome {
+        match self.format {
+            SpecFormat::Schema => {
+                print!("{}", ail_spec::schema());
+            }
+            SpecFormat::Compact => {
+                print!("{}", ail_spec::compact());
+            }
+            SpecFormat::Prose => {
+                if self.core_only {
+                    print!("{}", ail_spec::core_prose());
+                } else if self.runner_only {
+                    print!("{}", ail_spec::runner_prose());
+                } else {
+                    print!("{}", ail_spec::full_prose());
+                }
+            }
+        }
+        CommandOutcome::Success
+    }
+}

--- a/spec/README.md
+++ b/spec/README.md
@@ -53,6 +53,7 @@ The AIL Pipeline Language Specification — for pipeline authors and implementer
 | [s28-for-each.md](core/s28-for-each.md) | §28 `for_each:` — Collection Iteration | Map steps over a validated array from a prior `output_schema: type: array` step; `over`, `as`, `max_items`, `on_max_items`; plan-execution pattern; requires §26 | **v0.3** |
 | [s29-parallel-execution.md](core/s29-parallel-execution.md) | §29 Parallel Step Execution | `async: true`, `depends_on:`, `action: join`; session fork model; structured join with `output_schema` namespacing; `on_error: fail_fast \| wait_for_all`; cancel signals; template scoping rules; turn log concurrent_group | **v0.3** — parallel dispatch, session forking, string+structured joins, all validation rules, 23 tests |
 | [s30-sampling-parameters.md](core/s30-sampling-parameters.md) | §30 Sampling Parameter Control | `sampling:` block at three scopes (pipeline / provider-attached / per-step); temperature, top_p, top_k, max_tokens, stop_sequences, thinking; field-level merge; stop_sequences replace semantics; runner-specific quantization of `thinking` (ClaudeCLI `--effort`, HTTP boolean, ail-native passthrough) | **v0.3** — spec + all runners + tests |
+| [s31-spec-access.md](core/s31-spec-access.md) | §31 Specification Access & Injection | Spec compiled into binary; `ail spec` CLI command; three compression tiers (schema/compact/prose); `context: spec:` source; `append_system_prompt: - spec:` entry; per-section access; `ail-spec` crate architecture | **v0.4** |
 
 ---
 

--- a/spec/compressed/compact.md
+++ b/spec/compressed/compact.md
@@ -1,0 +1,166 @@
+# AIL Specification — Compact Reference
+
+> **ail** — Artificial Intelligence Loops. YAML-orchestrated post-prompt pipeline runtime.
+> This is a compressed reference. For full prose: `ail spec --format prose`.
+
+## §1 Purpose
+
+ail is a **control plane** for LLM agent behavior. After each human prompt, ail fires a declared sequence of automated steps before returning control. Steps run in declared order; individual steps may be skipped or exit early via declared outcomes.
+
+**Core guarantee (§4.2):** Once `execute()` begins, all declared steps run in order. Early exit only via explicit declared outcomes — never silent failures.
+
+## §2 Vocabulary
+
+| Term | Definition |
+|---|---|
+| pipeline | Ordered sequence of steps in `.ail.yaml` |
+| step | Single unit: prompt, skill, context, sub-pipeline, do_while, for_each, or action |
+| invocation | Implicit first step — the human's triggering prompt |
+| session | One running instance of an underlying agent |
+| runner | Adapter calling the underlying agent (`claude`, `http`, `ollama`, plugin) |
+| turn log | Append-only NDJSON audit trail per run |
+| passthrough | No `.ail.yaml` found — ail is transparent |
+
+## §3 File Format
+
+**Discovery order** (first match wins): `--pipeline <path>` > `.ail.yaml` in CWD > `.ail/default.yaml` in CWD > `~/.config/ail/default.yaml` > passthrough.
+
+**Top-level fields:** `version` (req, string `"1"`), `FROM` (opt, path for inheritance §7), `defaults` (opt), `pipeline` (req, step array), `pipelines` (opt, named pipeline map §10), `meta` (opt, informational).
+
+**defaults:** `model`, `timeout_seconds`, `max_concurrency` (for async steps), `provider` (model, base_url, auth_token, sampling), `tools` ({allow, deny, disabled}), `sampling` (temperature, top_p, top_k, max_tokens, stop_sequences, thinking).
+
+## §4 Execution Model
+
+1. Discover and load pipeline (or passthrough)
+2. If no `invocation` step declared: run user prompt via `runner.invoke()`, record `TurnEntry(step_id="invocation")`
+3. Call `executor::execute()` for all declared steps in order
+4. Steps run isolated by default; `resume: true` continues prior session
+
+**Run log:** NDJSON at `~/.ail/projects/<sha1_cwd>/runs/<run_id>.jsonl`. Every step produces a `TurnEntry`.
+
+## §5 Step Types
+
+Six body types. Exactly one primary field per step. `id` is always required.
+
+| Type | Field | LLM call | Token cost |
+|---|---|---|---|
+| Prompt | `prompt:` | Yes | Yes |
+| Skill | `skill:` | Yes | Yes |
+| Context | `context:` | No | No |
+| Sub-pipeline | `pipeline:` | Delegated | Delegated |
+| Do-while | `do_while:` | Delegated | Delegated |
+| For-each | `for_each:` | Delegated | Delegated |
+
+### Common fields (all step types)
+
+`id` (req, string), `runner` (opt), `condition` (opt, §12), `on_error` (opt, `continue`|`retry`|`abort_pipeline`, dflt `abort_pipeline`), `max_retries` (opt, dflt 2), `disabled` (opt, bool), `resume` (opt, bool, dflt false), `model` (opt), `tools` (opt, {allow, deny, disabled}), `system_prompt` (opt, string|filepath), `append_system_prompt` (opt, [{text|file|shell|spec}]), `on_result` (opt), `output_schema` (opt, JSON Schema), `input_schema` (opt, JSON Schema), `sampling` (opt), `async` (opt, bool), `depends_on` (opt, [step_id]), `before` (opt, [chain_step]), `then` (opt, [chain_step]).
+
+### prompt: steps
+Inline text or file path (prefix `./`, `../`, `~/`, `/`). Supports template vars. File paths resolved relative to pipeline file.
+
+### skill: steps
+Path to directory containing SKILL.md, or `ail/<builtin>`. Built-ins: `ail/code_review`, `ail/test_writer`, `ail/security_audit`, `ail/janitor`.
+
+### context: steps
+`context: { shell: "<command>" }` — runs `/bin/sh -c`, captures stdout/stderr/exit_code. No LLM. Non-zero exit = result, not error.
+`context: { spec: "<query>" }` — injects embedded AIL spec content. Query: `compact`|`schema`|`prose`|section ID (`s05`,`r02`).
+
+### pipeline: steps
+Path to another `.ail.yaml`. Runs in isolated child session. Depth guard = 16. `prompt:` on same step overrides child invocation.
+
+### action: steps
+`pause_for_human` — HITL gate. `modify_output` — human edits step output. `join` — sync barrier for parallel deps. `reload_self` — hot-reload pipeline YAML.
+
+### Runner selection hierarchy
+Per-step `runner:` > `AIL_DEFAULT_RUNNER` env > `"claude"`.
+
+## §7 Pipeline Inheritance (FROM)
+
+`FROM: ./base.yaml` — inherit steps. Hook operations: `run_before: <id>`, `run_after: <id>`, `override: <id>`, `disable: <id>`. Chains must be acyclic.
+
+## §9 Sub-Pipelines
+
+Child session is isolated (fresh turn log). Failure in child propagates to parent. Depth guard: 16 levels. Template vars in `pipeline:` path resolved at execution time. `prompt:` field overrides child invocation prompt.
+
+## §10 Named Pipelines
+
+`pipelines:` section defines reusable step lists by name. Referenced via `pipeline: <name>`. Same isolation model as file-based sub-pipelines. Circular refs detected at parse time.
+
+## §11 Template Variables
+
+`{{ variable }}` syntax. Resolved at step execution time. **Unresolved = fatal error, never empty string.** Can only reference already-executed steps (no forward refs). Skipped step refs = parse error.
+
+| Variable | Value |
+|---|---|
+| `{{ step.invocation.prompt }}` | Original user prompt |
+| `{{ step.invocation.response }}` | Response before pipeline steps |
+| `{{ last_response }}` | Most recent step response |
+| `{{ step.<id>.response }}` | Named prompt/skill step response |
+| `{{ step.<id>.result }}` | Context step output (stdout+stderr for shell) |
+| `{{ step.<id>.stdout }}` | Shell context stdout |
+| `{{ step.<id>.stderr }}` | Shell context stderr |
+| `{{ step.<id>.exit_code }}` | Shell context exit code (string) |
+| `{{ step.<id>.items }}` | Array from output_schema type: array |
+| `{{ step.<id>.tool_calls }}` | Tool events as JSON array |
+| `{{ step.<id>.modified }}` | modify_output gate result |
+| `{{ pipeline.run_id }}` | UUID for this run |
+| `{{ session.tool }}` | Runner name |
+| `{{ session.cwd }}` | Working directory |
+| `{{ env.VAR }}` | Env var (fatal if unset) |
+| `{{ env.VAR \| default("x") }}` | Env var with fallback |
+| `{{ do_while.iteration }}` | Loop: 0-based iteration index |
+| `{{ do_while.max_iterations }}` | Loop: declared max |
+| `{{ for_each.item }}` | Iteration: current item |
+| `{{ for_each.<as> }}` | Iteration: item under `as:` name |
+| `{{ for_each.index }}` | Iteration: 1-based index |
+| `{{ for_each.total }}` | Iteration: total items |
+| `{{ step.<loop>::<step>.response }}` | Inner step from loop (final iteration) |
+| `{{ step.<join>.<dep>.response }}` | Structured join: dep output |
+
+## §12 Conditions
+
+`condition:` field on any step. Values: `always` (default), `never`, or expression string.
+
+**Expression operators:** `==`, `!=`, `contains`, `starts_with`, `ends_with`, `matches /PAT/FLAGS`. LHS is template var, RHS is literal. Regex flags: `i` (case), `m` (multiline), `s` (dotall).
+
+## §13 HITL Gates
+
+`action: pause_for_human` — blocks until human approves. `action: modify_output` — human edits prior step output; result in `{{ step.<id>.modified }}`. `on_headless:` controls behavior in `--once`/headless: `skip` (dflt), `abort`, `use_default`.
+
+## §16 Error Handling
+
+`on_error:` per step. `abort_pipeline` (dflt) — stop immediately. `continue` — log error, proceed. `retry` — retry up to `max_retries` (dflt 2) then abort. Non-zero shell exits are results, not errors (trigger `on_result`, not `on_error`).
+
+## §19 Runners
+
+Three-tier model: `ClaudeCliRunner` (reference), `HttpRunner` (OpenAI-compatible API), plugin runners (JSON-RPC over stdin/stdout).
+
+`RunnerFactory::build(name, headless)` resolves by name. Factory names: `claude`, `http`, `ollama`, or plugin discovered from `~/.ail/runners/`.
+
+## §26 Output/Input Schema
+
+`output_schema:` — JSON Schema validated against step response at runtime. Enables `{{ step.<id>.items }}` for array schemas. `input_schema:` — validated against preceding step output before step executes. `field:` + `equals:` in `on_result` requires `input_schema`.
+
+## §27 do_while
+
+Bounded repeat-until loop. `max_iterations` (req, >= 1), `exit_when` (req, §12 condition), `steps` or `pipeline` (req, mutually exclusive). Inner step IDs namespaced: `<loop_id>::<step_id>`. Shared depth guard with for_each (MAX_LOOP_DEPTH=8).
+
+## §28 for_each
+
+Collection iteration over validated array. `over` (req, template ref to `.items`), `as` (opt, dflt `item`), `max_items` (opt), `on_max_items` (opt, `continue`|`abort_pipeline`), `steps` or `pipeline` (req). Same depth guard as do_while.
+
+## §29 Parallel Execution
+
+`async: true` marks non-blocking step. `depends_on: [ids]` creates sync barrier. `action: join` merges outputs. String join: concatenated with `[id]:` headers. Structured join: if all deps have output_schema, merges into `{ dep_id: output }`. `on_error: fail_fast` (dflt) or `wait_for_all`. No forward refs, no cycles, no concurrent resume conflict.
+
+## §30 Sampling Parameters
+
+Three-scope merge: `defaults.sampling` < `defaults.provider.sampling` < step `sampling:`. Field-level merge; `stop_sequences` replaces (not appends). `thinking:` accepts float [0,1] or bool (true→1.0, false→0.0). Runner quantization: Claude CLI → `--effort` quartiles; HTTP → bool threshold 0.5.
+
+## §31 Spec Access
+
+Spec is compiled into the binary. Access via:
+- CLI: `ail spec`, `ail spec --format compact`, `ail spec --section s05`
+- Pipeline context: `context: { spec: compact }`, `context: { spec: s05 }`
+- System prompt: `append_system_prompt: [{ spec: compact }]`
+- Tiers: `schema` (~2K tokens, YAML structure), `compact` (this document, ~10K tokens), `prose` (full spec, ~80K tokens)

--- a/spec/compressed/schema.yaml
+++ b/spec/compressed/schema.yaml
@@ -1,0 +1,203 @@
+# AIL Pipeline Language — Annotated YAML Schema
+# Compact reference for writing correct .ail.yaml files.
+#
+# Discovery order (first match wins):
+#   1. --pipeline <path>  2. .ail.yaml (CWD)  3. .ail/default.yaml (CWD)  4. ~/.config/ail/default.yaml
+#   If nothing found: passthrough mode (agent behaves as if ail is absent).
+
+# ── TOP-LEVEL STRUCTURE ──
+
+version: "0.1"              # REQUIRED. Spec version.
+FROM: ./base.yaml            # Optional. Inherit steps; file paths only. Chains must be acyclic.
+
+meta:                        # Optional informational block.
+  name: "string"
+  description: "string"
+  author: "string"
+
+defaults:                    # Optional. Inherited by all steps unless overridden per-step.
+  model: claude-sonnet-4-5     # Model name passed as --model.
+  timeout_seconds: 120       # Per-step timeout. Default: 120.
+  max_concurrency: 4         # Max simultaneous async steps. Default: unlimited.
+  provider:
+    model: gemma3:1b         # Precedence over defaults.model.
+    base_url: http://localhost:11434  # ANTHROPIC_BASE_URL env.
+    auth_token: ollama               # ANTHROPIC_AUTH_TOKEN env.
+    sampling: { temperature: 0.3 }   # Provider-attached sampling defaults.
+  tools:                     # Pipeline-wide tool policy. Per-step tools: override entirely.
+    allow: [Read, Glob, LS]
+    deny: [WebFetch]
+  sampling:                  # Pipeline-wide sampling baseline. Field-level merge up the chain.
+    temperature: 0.3         # float 0.0-2.0.
+    top_p: 0.9               # float 0.0-1.0.
+    top_k: 40                # int >= 1.
+    max_tokens: 4096         # int >= 1.
+    stop_sequences: ["END"]  # Higher scope replaces, does NOT append.
+    thinking: 0.75           # float 0.0-1.0 (or true/false). Claude CLI maps to --effort quartiles.
+
+pipeline:                    # REQUIRED. Ordered list of steps.
+
+# ── HOOK OPERATIONS (only when FROM is set) ──
+# - run_before: <step_id>     # Insert before named step.
+# - run_after: <step_id>      # Insert after named step.
+# - override: <step_id>       # Replace step (must keep same id).
+# - disable: <step_id>        # Remove step entirely.
+# All target IDs must exist in resolved chain or parse error.
+
+# ── STEP TYPES — exactly one primary field per step ──
+
+# 1. prompt: (LLM call)
+- id: my_step                # REQUIRED on all steps. Snake_case. Treat as public API.
+  prompt: "inline text"      # String or file path (./  ../  ~/  / prefix = file).
+
+# 2. skill: (LLM via SKILL.md)
+- id: commit
+  skill: ./skills/commit/    # Dir with SKILL.md, or ail/<builtin> (e.g. ail/janitor).
+
+# 3. context: (deterministic, no LLM, zero tokens)
+- id: lint_output
+  context:
+    shell: "cargo clippy -- -D warnings"  # /bin/sh -c. Non-zero exit = result, not error.
+
+# 4. pipeline: (sub-pipeline, runs in isolation)
+- id: sub_task
+  pipeline: ./sub-pipeline.ail.yaml
+
+# 5. do_while: (bounded repeat-until)
+- id: fix_loop
+  do_while:
+    max_iterations: 5        # REQUIRED. int >= 1.
+    exit_when: "{{ step.test.exit_code }} == 0"  # REQUIRED. Condition expr. Checked AFTER each iteration.
+    on_max_iterations: abort_pipeline  # abort_pipeline | continue | pause_for_human. Default: abort_pipeline.
+    steps:                   # REQUIRED (XOR pipeline:). Inner step IDs namespaced as <loop_id>::<step_id>.
+      - id: fix
+        prompt: "Iteration {{ do_while.iteration }}. Fix: {{ step.test.result }}"
+        resume: true
+      - id: test
+        context:
+          shell: "cargo test 2>&1"
+    # pipeline: ./fix-body.ail.yaml   # Alternative to inline steps.
+
+# 6. for_each: (iterate validated array)
+- id: implement_tasks
+  for_each:
+    over: "{{ step.plan.items }}"  # REQUIRED. Source step must have output_schema type: array.
+    as: task                 # Optional. Default: "item". Access: {{ for_each.task }}.
+    max_items: 20            # Optional cap.
+    on_max_items: continue   # abort_pipeline | continue. Default: continue.
+    steps:                   # REQUIRED (XOR pipeline:).
+      - id: implement
+        prompt: "Task {{ for_each.index }}/{{ for_each.total }}: {{ for_each.task }}"
+        resume: true
+
+# ── COMMON STEP OPTIONS ──
+
+- id: example
+  prompt: "..."
+  runner: claude             # Optional. Overrides AIL_DEFAULT_RUNNER.
+  model: claude-opus-4-5       # Optional. Overrides defaults.model.
+  condition: "{{ step.build.exit_code }} == 0"  # Skip if false.
+  disabled: false            # true = always skip.
+  on_error: abort_pipeline   # abort_pipeline | continue | pause_for_human | retry.
+  max_retries: 2             # When on_error: retry.
+  resume: true               # Resume prior session on same provider. Default: false.
+
+  system_prompt: "full override"  # String/file. Replaces provider default.
+  append_system_prompt:      # Array, layered on top in order.
+    - "inline text"
+    - file: ./prompts/ctx.md
+    - text: "{{ step.info.result }}"
+
+  tools:
+    disabled: true           # No tool defs at all.
+    allow: [Read, "Edit(./src/*)"]
+    deny: [WebFetch]
+
+  output_schema:             # JSON Schema. Validated at runtime. Enables {{ step.<id>.items }} for arrays.
+    type: object
+    properties:
+      category: { type: string, enum: [bugfix, feature, refactor] }
+    required: [category]
+  input_schema:              # JSON Schema. Validated before step runs. Enables field: + equals: in on_result.
+    type: object
+    properties:
+      category: { type: string }
+    required: [category]
+
+  sampling:                  # Per-step override. Field-level merge with defaults.
+    temperature: 0.9
+    thinking: true           # true -> 1.0, false -> 0.0.
+
+  async: true                # Non-blocking launch. MUST appear in at least one depends_on.
+  depends_on: [lint, test]   # Wait for listed steps. No forward refs, no cycles.
+  action: join               # Sync barrier. Requires depends_on. No LLM call.
+                             # String join: concatenates [id]: responses.
+                             # Structured join (all deps have output_schema): { dep_id: output }.
+
+  on_result:                 # Declarative branching after step completes.
+    contains: "CLEAN"        # Operators: contains, matches, starts_with, is_empty, exit_code, always, field+equals.
+    if_true: { action: continue }
+    if_false: { action: pause_for_human, message: "Issues found." }
+  # Multi-branch array form (first match wins):
+  # on_result:
+  #   - exit_code: 0          # exit_code: only on shell context steps. Use 'any' for non-zero.
+  #     action: continue
+  #   - matches: /error/i     # Regex: /PATTERN/FLAGS. Flags: i m s.
+  #     action: abort_pipeline
+  #   - field: category       # Requires input_schema.
+  #     equals: "bugfix"
+  #     action: continue
+  #   - always:
+  #     action: continue
+  # Actions: continue | abort_pipeline | break | pause_for_human | pipeline: <path>
+
+  before:                    # Private pre-processing. Not hookable.
+    - ail/janitor            # Short-form: skill or file.
+    - prompt: "Optimize."    # Full-form. use_original (revert transform) only valid here.
+  then:                      # Private post-processing. Not hookable.
+    - prompt: "Summarize."
+
+# ── CONDITION OPERATORS (condition: and exit_when:) ──
+# Named:  always | never
+# {{ var }} == value            String equality (trimmed).
+# {{ var }} != value            String inequality.
+# {{ var }} contains 'text'     Case-insensitive substring.
+# {{ var }} starts_with 'x'     Case-insensitive prefix.
+# {{ var }} ends_with 'x'       Case-insensitive suffix.
+# {{ var }} matches /PAT/i      Regex. Flags: i m s.
+
+# ── TEMPLATE VARIABLES — {{ variable }} ──
+# Resolved at execution time. Unresolved = fatal error (never silently empty).
+#
+# {{ step.invocation.prompt }}         User prompt that triggered this run.
+# {{ step.invocation.response }}       Runner response before pipeline steps.
+# {{ last_response }}                  Most recent step response.
+# {{ step.<id>.response }}             Named prompt/skill step response.
+# {{ step.<id>.result }}               Context step output (shell: stdout+stderr).
+# {{ step.<id>.stdout }}               Shell stdout only.
+# {{ step.<id>.stderr }}               Shell stderr only.
+# {{ step.<id>.exit_code }}            Shell exit code (string).
+# {{ step.<id>.items }}                Array from output_schema type: array.
+# {{ step.<id>.tool_calls }}           Tool events as JSON array.
+# {{ pipeline.run_id }}                Run UUID.
+# {{ session.tool }}                   Runner name (e.g. "claude").
+# {{ session.cwd }}                    Working directory.
+# {{ env.VAR }}                        Env var (fatal if unset).
+# {{ env.VAR | default("fb") }}       Env var with fallback.
+#
+# do_while body only:
+# {{ do_while.iteration }}             0-based index.
+# {{ do_while.max_iterations }}        Declared max.
+#
+# for_each body only:
+# {{ for_each.item }}                  Current item (or {{ for_each.<as> }}).
+# {{ for_each.index }}                 1-based index.
+# {{ for_each.total }}                 Total items (after max_items).
+#
+# After loops (from later steps):
+# {{ step.<loop_id>.index }}           do_while iterations completed.
+# {{ step.<loop_id>::<step_id>.* }}    Inner step result (final iteration).
+#
+# Join steps:
+# {{ step.<join>.response }}           String join output.
+# {{ step.<join>.<dep>.<field> }}      Structured join field access.

--- a/spec/core/s31-spec-access.md
+++ b/spec/core/s31-spec-access.md
@@ -1,0 +1,89 @@
+## 31. Specification Access & Injection
+
+> **Implementation status:** Fully implemented. `ail spec` CLI command, `context: spec:` context source, and `append_system_prompt: - spec:` system prompt entry all functional.
+
+### 31.1 Purpose
+
+The AIL specification is compiled into the binary as a set of embedded resources. This enables pipelines to inject spec content into LLM context windows at runtime — supporting the use case of **pipelines that design their own pipelines**.
+
+Since no LLM has been trained on AIL, spec injection provides the LLM with the knowledge it needs to generate correct `.ail.yaml` files.
+
+### 31.2 Tiers
+
+Three compression tiers trade detail for token budget:
+
+| Tier | Name | Tokens | Contents | Use case |
+|---|---|---|---|---|
+| T1 | `schema` | ~2-3K | Annotated YAML schema with inline constraints | Syntax reminder for someone who roughly knows AIL |
+| T2 | `compact` | ~10-12K | Compressed NL — all rules, no examples | Teach an LLM enough to write correct pipelines |
+| T3 | `prose` | ~80K | Full specification verbatim | Deep reference for edge cases and rationale |
+
+T1 and T2 are hand-authored checked-in files under `spec/compressed/`. T3 is the raw concatenation of all `spec/core/s*.md` and `spec/runner/r*.md` files.
+
+### 31.3 CLI Command — `ail spec`
+
+```
+ail spec                          # full spec (T3 prose, default)
+ail spec --format schema          # T1 annotated YAML schema
+ail spec --format compact         # T2 compressed NL reference
+ail spec --format prose           # T3 full prose (explicit)
+ail spec --section s05            # one section (prose)
+ail spec --section s05,s11,r02    # multiple sections (comma-separated)
+ail spec --list                   # section IDs, titles, word counts
+ail spec --core                   # core sections only
+ail spec --runner                 # runner sections only
+```
+
+Output goes to stdout and is pipeable.
+
+### 31.4 Pipeline Integration — `context: spec:`
+
+A new context source type injects embedded spec content as a step result:
+
+```yaml
+pipeline:
+  - id: learn_ail
+    context:
+      spec: compact              # injects T2 as {{ step.learn_ail.result }}
+```
+
+Accepted query values: `compact`, `schema`, `prose`, `core`, `runner`, or any section ID (`s05`, `r02`, etc.).
+
+The step produces a `TurnEntry` with the spec content in `stdout` and `exit_code: 0`. All standard context step template variables apply (`{{ step.<id>.result }}`, `{{ step.<id>.stdout }}`).
+
+### 31.5 Pipeline Integration — `append_system_prompt: - spec:`
+
+A new system prompt entry type injects spec content into the LLM's system prompt:
+
+```yaml
+pipeline:
+  - id: design_pipeline
+    prompt: "Design an AIL pipeline for: {{ step.invocation.prompt }}"
+    append_system_prompt:
+      - spec: compact             # inject T2 into system prompt
+      - spec: s05                 # inject specific section
+```
+
+Accepts the same query values as `context: spec:`.
+
+### 31.6 Zero-Code Fallback
+
+The CLI command can be used with existing `context: shell:` steps without any executor changes:
+
+```yaml
+pipeline:
+  - id: learn_ail
+    context:
+      shell: "ail spec --format compact"
+```
+
+### 31.7 Architecture
+
+Spec content is compiled into the `ail-spec` crate via `build.rs` at build time. The crate:
+
+- Scans `spec/core/s*.md` and `spec/runner/r*.md` using `include_str!`
+- Embeds T1 from `spec/compressed/schema.yaml` and T2 from `spec/compressed/compact.md`
+- Exposes a public API: `section(id)`, `list_sections()`, `full_prose()`, `compact()`, `schema()`
+- Automatically picks up new spec files on rebuild (no Rust code changes needed)
+
+Dependency chain: `ail-spec` → `ail-core` (for `context: spec:` and `append_system_prompt: - spec:`) → `ail` (for the CLI command).


### PR DESCRIPTION
Embed the full AIL specification into the binary at build time via a new
`ail-spec` crate. Enables pipelines that teach LLMs about AIL — supporting
self-designing pipelines without prior LLM training on the format.

Three access tiers: T1 schema (~2K tokens), T2 compact (~10K tokens),
T3 full prose (~80K tokens). CLI command `ail spec` with --format,
--section, --list, --core, --runner flags. Native `context: spec:` and
`append_system_prompt: - spec:` pipeline sources for zero-subprocess
spec injection.

https://claude.ai/code/session_01MiJeSwUcLY27vnc5ZJcM6c