### PR TITLE
fix(vscode-ail-chat): bundle ail binary correctly in VSIX

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -62,11 +62,20 @@ jobs:
         if: runner.os != 'Windows'
         run: strip target/${{ matrix.target }}/release/${{ matrix.binary }}
 
+      - name: Rename binary to platform artifact name (Unix)
+        if: runner.os != 'Windows'
+        run: cp target/${{ matrix.target }}/release/${{ matrix.binary }} ${{ matrix.artifact }}
+
+      - name: Rename binary to platform artifact name (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Copy-Item target/${{ matrix.target }}/release/${{ matrix.binary }} -Destination ${{ matrix.artifact }}
+
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: target/${{ matrix.target }}/release/${{ matrix.binary }}
+          path: ${{ matrix.artifact }}
           retention-days: 1
 
   # ── Package and publish VSIX ──────────────────────────────────────────────

--- a/vscode-ail-chat/esbuild.js
+++ b/vscode-ail-chat/esbuild.js
@@ -85,11 +85,17 @@ function copyCodiconAssets() {
 
 async function build() {
   if (!watch) {
-    // Clean dist before every non-watch build (rmdirSync works on Node ≥12.10)
+    // Clean dist but preserve bundled ail binaries (ail-<triple> / ail-<triple>.exe).
+    // Full rmSync would wipe binaries downloaded by CI before vsce package runs.
     const dist = path.join(__dirname, 'dist');
-    try {
-      (fs.rmSync || fs.rmdirSync)(dist, { recursive: true, force: true });
-    } catch (_) {}
+    if (fs.existsSync(dist)) {
+      for (const entry of fs.readdirSync(dist)) {
+        if (/^ail[-.]/.test(entry)) continue; // keep bundled binaries
+        try {
+          (fs.rmSync || fs.rmdirSync)(path.join(dist, entry), { recursive: true, force: true });
+        } catch (_) {}
+      }
+    }
   }
 
   copyCodiconAssets();


### PR DESCRIPTION
## Summary

- **esbuild.js was nuking `dist/` on every production build.** `vsce package` runs `vscode:prepublish` (→ `esbuild.js --production`), which deleted the entire `dist/` directory — including any binaries CI had just downloaded. Fixed by iterating entries and skipping files matching `/^ail[-\.]/` instead of doing a full `rmSync`.

- **Artifact filenames didn't match what the extension expects.** Binaries were uploaded using their original name (`ail`), so with `merge-multiple: true` all four platforms overwrote each other and landed as `dist/ail`. But `binary.ts` constructs the path as `dist/ail-<platform-triple>` (e.g. `dist/ail-aarch64-apple-darwin`). Fixed by adding a rename step before upload so the artifact file is already named correctly.

## Test plan

- [ ] Push a `vscode-v*` tag and verify the `build-binaries` artifacts are named `ail-aarch64-apple-darwin`, `ail-x86_64-apple-darwin`, etc.
- [ ] Confirm the `package-vsix` job's `dist/` contains the platform binaries after download
- [ ] Install the produced `ail-darwin-arm64-*.vsix` and verify no "ail binary not found" error on activation