### PR TITLE
refactor(vscode-ail-chat): consolidate platform-specific code under src/platforms/

### DIFF
--- a/vscode-ail-chat/src/ail-process-manager.ts
+++ b/vscode-ail-chat/src/ail-process-manager.ts
@@ -11,8 +11,7 @@
 import { spawn, ChildProcess } from 'child_process';
 import { AilEvent, HostToWebviewMessage } from './types';
 import { parseNdjsonStream } from './ndjson';
-import { ProcessKiller } from './process/killer';
-import { createProcessKiller } from './process/factory';
+import { ProcessKiller, createProcessKiller } from './platforms';
 import { AilOutputChannel } from './output-channel';
 
 export interface StartOptions {

--- a/vscode-ail-chat/src/binary.ts
+++ b/vscode-ail-chat/src/binary.ts
@@ -14,6 +14,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { execFile } from "child_process";
 import * as vscode from "vscode";
+import { createPlatform } from "./platforms";
 
 export interface ResolvedBinary {
   path: string;
@@ -36,8 +37,7 @@ export function platformTriple(): string {
 
 /** Returns the bundled binary filename for this platform. */
 function bundledBinaryName(): string {
-  const triple = platformTriple();
-  return process.platform === "win32" ? `ail-${triple}.exe` : `ail-${triple}`;
+  return createPlatform().binary.bundledBinaryName(platformTriple());
 }
 
 /** Run `ail --version` and return the version string. */
@@ -106,7 +106,7 @@ export async function resolveBinary(
 
   // 3. PATH fallback
   if (!binaryPath) {
-    binaryPath = process.platform === "win32" ? "ail.exe" : "ail";
+    binaryPath = createPlatform().binary.pathBinaryName();
   }
 
   // Verify binary works and get version

--- a/vscode-ail-chat/src/chat-view-provider.ts
+++ b/vscode-ail-chat/src/chat-view-provider.ts
@@ -7,7 +7,7 @@ import { SessionManager } from './session-manager';
 import { WebviewToHostMessage } from './types';
 import { PipelineGraphPanel } from './pipeline-graph/PipelineGraphPanel';
 import { AilOutputChannel } from './output-channel';
-import { createProcessKiller } from './process/factory';
+import { createProcessKiller } from './platforms';
 import type { RunHistoryProvider } from './history-tree-provider';
 import type { PipelineStepsProvider } from './steps-tree-provider';
 

--- a/vscode-ail-chat/src/platforms/index.ts
+++ b/vscode-ail-chat/src/platforms/index.ts
@@ -1,0 +1,30 @@
+import { ProcessKiller, BinaryResolver } from './types';
+import { PosixProcessKiller } from './posix/killer';
+import { PosixBinaryResolver } from './posix/binary';
+import { WindowsProcessKiller } from './win/killer';
+import { WindowsBinaryResolver } from './win/binary';
+
+export type { ProcessKiller, BinaryResolver };
+export { PosixProcessKiller, WindowsProcessKiller };
+
+export interface Platform {
+  killer: ProcessKiller;
+  binary: BinaryResolver;
+}
+
+export function createPlatform(): Platform {
+  if (process.platform === 'win32') {
+    return {
+      killer: new WindowsProcessKiller(),
+      binary: new WindowsBinaryResolver(),
+    };
+  }
+  return {
+    killer: new PosixProcessKiller(),
+    binary: new PosixBinaryResolver(),
+  };
+}
+
+export function createProcessKiller(): ProcessKiller {
+  return createPlatform().killer;
+}

--- a/vscode-ail-chat/src/platforms/posix/binary.ts
+++ b/vscode-ail-chat/src/platforms/posix/binary.ts
@@ -1,0 +1,10 @@
+import { BinaryResolver } from '../types';
+
+export class PosixBinaryResolver implements BinaryResolver {
+  bundledBinaryName(triple: string): string {
+    return `ail-${triple}`;
+  }
+  pathBinaryName(): string {
+    return 'ail';
+  }
+}

--- a/vscode-ail-chat/src/platforms/posix/killer.ts
+++ b/vscode-ail-chat/src/platforms/posix/killer.ts
@@ -1,5 +1,5 @@
 import { ChildProcess } from 'child_process';
-import { ProcessKiller } from '../killer';
+import { ProcessKiller } from '../types';
 
 export class PosixProcessKiller implements ProcessKiller {
   kill(proc: ChildProcess): Promise<void> {

--- a/vscode-ail-chat/src/platforms/types.ts
+++ b/vscode-ail-chat/src/platforms/types.ts
@@ -1,6 +1,10 @@
 import { ChildProcess } from 'child_process';
 
 export interface ProcessKiller {
-  /** Terminate the process and its descendants. */
   kill(proc: ChildProcess): Promise<void>;
+}
+
+export interface BinaryResolver {
+  bundledBinaryName(triple: string): string;
+  pathBinaryName(): string;
 }

--- a/vscode-ail-chat/src/platforms/win/binary.ts
+++ b/vscode-ail-chat/src/platforms/win/binary.ts
@@ -1,0 +1,10 @@
+import { BinaryResolver } from '../types';
+
+export class WindowsBinaryResolver implements BinaryResolver {
+  bundledBinaryName(triple: string): string {
+    return `ail-${triple}.exe`;
+  }
+  pathBinaryName(): string {
+    return 'ail.exe';
+  }
+}

--- a/vscode-ail-chat/src/platforms/win/killer.ts
+++ b/vscode-ail-chat/src/platforms/win/killer.ts
@@ -1,5 +1,5 @@
 import { ChildProcess, spawn } from 'child_process';
-import { ProcessKiller } from '../killer';
+import { ProcessKiller } from '../types';
 
 export class WindowsProcessKiller implements ProcessKiller {
   kill(proc: ChildProcess): Promise<void> {

--- a/vscode-ail-chat/src/process/factory.ts
+++ b/vscode-ail-chat/src/process/factory.ts
@@ -1,9 +1,0 @@
-import { ProcessKiller } from './killer';
-import { PosixProcessKiller } from './posix/killer';
-import { WindowsProcessKiller } from './win/killer';
-
-export function createProcessKiller(): ProcessKiller {
-  return process.platform === 'win32'
-    ? new WindowsProcessKiller()
-    : new PosixProcessKiller();
-}

--- a/vscode-ail-chat/test/ail-process-manager.test.ts
+++ b/vscode-ail-chat/test/ail-process-manager.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mapAilEventToMessages, AilEventMapper, AilProcessManager } from '../src/ail-process-manager';
 import { AilEvent } from '../src/types';
-import type { ProcessKiller } from '../src/process/killer';
+import type { ProcessKiller } from '../src/platforms';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Readable, PassThrough } from 'stream';

--- a/vscode-ail-chat/test/platforms/index.test.ts
+++ b/vscode-ail-chat/test/platforms/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { createProcessKiller } from '../../src/process/factory';
-import { PosixProcessKiller } from '../../src/process/posix/killer';
-import { WindowsProcessKiller } from '../../src/process/win/killer';
+import { createProcessKiller } from '../../src/platforms/index';
+import { PosixProcessKiller } from '../../src/platforms/posix/killer';
+import { WindowsProcessKiller } from '../../src/platforms/win/killer';
 
 describe('createProcessKiller', () => {
   it('returns WindowsProcessKiller on win32', () => {

--- a/vscode-ail-chat/test/platforms/posix/binary.test.ts
+++ b/vscode-ail-chat/test/platforms/posix/binary.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { PosixBinaryResolver } from '../../../src/platforms/posix/binary';
+
+describe('PosixBinaryResolver', () => {
+  it('returns bundled binary name without .exe', () => {
+    const resolver = new PosixBinaryResolver();
+    expect(resolver.bundledBinaryName('aarch64-apple-darwin')).toBe('ail-aarch64-apple-darwin');
+    expect(resolver.bundledBinaryName('x86_64-unknown-linux-musl')).toBe('ail-x86_64-unknown-linux-musl');
+  });
+
+  it('returns ail as path binary name', () => {
+    const resolver = new PosixBinaryResolver();
+    expect(resolver.pathBinaryName()).toBe('ail');
+  });
+});

--- a/vscode-ail-chat/test/platforms/posix/killer.test.ts
+++ b/vscode-ail-chat/test/platforms/posix/killer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 describe('PosixProcessKiller', () => {
   it.skipIf(process.platform === 'win32')('sends SIGTERM then SIGKILL after timeout', async () => {
-    const { PosixProcessKiller } = await import('../../../src/process/posix/killer');
+    const { PosixProcessKiller } = await import('../../../src/platforms/posix/killer');
     const { spawn } = await import('child_process');
 
     const proc = spawn('sleep', ['30']);

--- a/vscode-ail-chat/test/platforms/win/binary.test.ts
+++ b/vscode-ail-chat/test/platforms/win/binary.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { WindowsBinaryResolver } from '../../../src/platforms/win/binary';
+
+describe('WindowsBinaryResolver', () => {
+  it('returns bundled binary name with .exe suffix', () => {
+    const resolver = new WindowsBinaryResolver();
+    expect(resolver.bundledBinaryName('x86_64-pc-windows-msvc')).toBe('ail-x86_64-pc-windows-msvc.exe');
+  });
+
+  it('returns ail.exe as path binary name', () => {
+    const resolver = new WindowsBinaryResolver();
+    expect(resolver.pathBinaryName()).toBe('ail.exe');
+  });
+});

--- a/vscode-ail-chat/test/platforms/win/killer.test.ts
+++ b/vscode-ail-chat/test/platforms/win/killer.test.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 describe('WindowsProcessKiller', () => {
   it('calls taskkill with /F /T /PID <pid>', () => {
     const source = fs.readFileSync(
-      path.join(__dirname, '../../../src/process/win/killer.ts'),
+      path.join(__dirname, '../../../src/platforms/win/killer.ts'),
       'utf-8'
     );
     expect(source).toContain("'taskkill'");


### PR DESCRIPTION
## Summary

- Renames `src/process/` → `src/platforms/` and expands scope to cover binary resolution
- Adds `BinaryResolver` interface (`posix/binary.ts`, `win/binary.ts`) so `binary.ts` no longer contains `process.platform` checks
- `platforms/index.ts` is the single factory — `createPlatform()` returns a `{ killer, binary }` object; `createProcessKiller()` kept as a convenience export
- Enforces a clear rule: **no `process.platform` references outside `src/platforms/`**
- Adds new tests for `PosixBinaryResolver` and `WindowsBinaryResolver`; migrates existing process tests to `test/platforms/`
- All 219 tests pass

## Test plan

- [ ] `npx vitest run` passes (22 files, 219 tests)
- [ ] Verify no `process.platform` references remain outside `src/platforms/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)