### PR TITLE
Refactor help system and improve CLI documentation

### DIFF
--- a/ail/src/cli.rs
+++ b/ail/src/cli.rs
@@ -26,16 +26,15 @@ pub struct Cli {
     #[arg(long, value_name = "PROMPT")]
     pub once: Option<String>,
 
-    /// Path to the pipeline YAML file. Overrides automatic discovery.
+    /// Override pipeline file discovery (default: .ail.yaml → .ail/default.yaml → ~/.config/ail/default.yaml)
     #[arg(long, value_name = "PATH")]
     pub pipeline: Option<PathBuf>,
 
-    /// Pass `--dangerously-skip-permissions` to the underlying runner.
+    /// Skip all tool-use permission prompts (passes --dangerously-skip-permissions to the runner)
     #[arg(long)]
     pub headless: bool,
 
-    /// Override the model for all runner invocations (e.g. `gemma3:1b` for Ollama).
-    /// Takes precedence over any model declared in the pipeline YAML.
+    /// Override the model for all runner invocations
     #[arg(long, value_name = "MODEL")]
     pub model: Option<String>,
 
@@ -49,7 +48,7 @@ pub struct Cli {
     #[arg(long, value_name = "TOKEN")]
     pub provider_token: Option<String>,
 
-    /// Output format for pipeline execution. `json` emits an NDJSON event stream to stdout.
+    /// Output format: text (default) or json (NDJSON event stream)
     #[arg(long, value_name = "FORMAT", default_value = "text")]
     pub output_format: OutputFormat,
 
@@ -57,17 +56,15 @@ pub struct Cli {
     #[arg(long)]
     pub show_thinking: bool,
 
-    /// Print one summary line per completed step after execution (show-work mode).
+    /// Print one summary line per completed step
     #[arg(long)]
     pub show_work: bool,
 
-    /// Dry-run mode: resolve the full pipeline (templates, conditions, step ordering)
-    /// without making any LLM API calls. Shell context steps execute normally.
-    /// Output clearly indicates this is a dry run.
+    /// Resolve and print the pipeline without making any LLM calls
     #[arg(long)]
     pub dry_run: bool,
 
-    /// Stream per-step progress, thinking blocks, and responses as they arrive.
+    /// Stream per-step progress as it arrives
     #[arg(long, alias = "show-responses", hide_short_help = false)]
     pub watch: bool,
 
@@ -77,7 +74,7 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Resolve and output the full pipeline. Alias: mp
+    /// Print the fully-resolved pipeline YAML with all template variables resolved
     #[command(name = "materialize", visible_alias = "mp")]
     Materialize {
         /// Path to the pipeline YAML file. Overrides automatic discovery.
@@ -92,7 +89,7 @@ pub enum Commands {
         #[arg(long)]
         expand_pipelines: bool,
     },
-    /// Validate a pipeline file without running it.
+    /// Check a pipeline file for errors without running it
     Validate {
         /// Path to the pipeline YAML file to validate. Overrides automatic discovery.
         #[arg(long, value_name = "PATH")]
@@ -103,7 +100,7 @@ pub enum Commands {
         #[arg(long, value_name = "FORMAT", default_value = "text")]
         output_format: OutputFormat,
     },
-    /// Query execution logs stored by ail.
+    /// Query recorded pipeline runs
     Logs {
         /// Filter by session run_id (prefix match).
         #[arg(long)]
@@ -125,7 +122,7 @@ pub enum Commands {
         #[arg(long, default_value_t = 20)]
         limit: usize,
     },
-    /// Display a formatted pipeline run (ail-log format).
+    /// Show a single run in full detail
     Log {
         /// Run ID (UUID). If omitted, shows the most recent run for the current directory.
         #[arg(value_name = "RUN_ID")]
@@ -155,7 +152,7 @@ pub enum Commands {
         #[arg(long)]
         socket: String,
     },
-    /// Interactive chat mode: multi-turn conversation with pipeline execution after each message.
+    /// Machine-facing NDJSON chat protocol (IPC — used by IDE extensions)
     Chat {
         /// Send a single message and exit (non-interactive).
         #[arg(long, short)]
@@ -176,7 +173,18 @@ pub enum Commands {
         #[arg(long, value_name = "TOKEN")]
         provider_token: Option<String>,
     },
-    /// Print the AIL specification (embedded in the binary).
+    /// Browse the embedded AIL specification
+    #[command(long_about = "Browse the embedded AIL specification.\n\n\
+                            By default, prints the full specification in prose form.\n\n\
+                            Progressive disclosure options:\n\
+                            \n\
+                            --list                  Print a table of contents with section IDs and word counts\n\
+                            --section s05           Print a single section by ID\n\
+                            --section s05,r02       Print multiple sections (comma-separated)\n\
+                            --format compact        Print the compressed reference (~10k tokens)\n\
+                            --format schema         Print the annotated YAML schema (~2-3k tokens)\n\
+                            --core / --runner       Filter to core spec or runner spec only\n\n\
+                            Section IDs: s01–s33 (core), r01–r11 (runner). Run `ail spec --list` to browse.")]
     Spec {
         /// Output format: `prose` (default, full spec), `compact` (compressed reference),
         /// or `schema` (annotated YAML schema).
@@ -199,7 +207,7 @@ pub enum Commands {
         #[arg(long)]
         runner: bool,
     },
-    /// Scaffold an ail workspace from a starter template.
+    /// Scaffold an ail workspace from a template
     Init {
         /// Template name or alias. If omitted, shows an interactive picker.
         #[arg(value_name = "TEMPLATE")]
@@ -213,7 +221,7 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
-    /// Delete a pipeline run from the history.
+    /// Delete a recorded run from history
     Delete {
         /// Run ID to delete.
         #[arg(value_name = "RUN_ID")]

--- a/ail/src/help.rs
+++ b/ail/src/help.rs
@@ -1,0 +1,36 @@
+pub fn print_landing_page() {
+    println!(
+        "ail — Artificial Intelligence Loops {}",
+        ail_core::version()
+    );
+    println!();
+    println!("The control plane for how agents behave after the human stops typing.");
+    println!();
+    println!("Workflow:");
+    println!("  ail init                    Scaffold an ail workspace from a template");
+    println!("  ail \"<prompt>\"              Run a prompt through the discovered pipeline");
+    println!();
+    println!("Inspection:");
+    println!("  ail validate                Check a pipeline file for errors without running it");
+    println!("  ail materialize             Print the fully-resolved pipeline YAML");
+    println!("  ail logs                    Query recorded pipeline runs");
+    println!();
+    println!("Reference:");
+    println!("  ail spec                    Browse the embedded spec");
+    println!();
+    println!("Key flags:");
+    println!("  --pipeline <path>           Override pipeline file discovery");
+    println!(
+        "  --dry-run                   Resolve and print the pipeline without making LLM calls"
+    );
+    println!("  --headless                  Skip all tool-use permission prompts");
+    println!();
+    println!("Examples:");
+    println!("  ail \"refactor the auth module\"");
+    println!("  ail \"fix failing tests\" --pipeline .ail/strict.yaml");
+    println!("  ail init starter");
+    println!("  ail spec --list");
+    println!("  ail validate --pipeline .ail.yaml");
+    println!();
+    println!("Run `ail --help` for all flags  ·  `ail <command> --help` for command options.");
+}

--- a/ail/src/main.rs
+++ b/ail/src/main.rs
@@ -7,6 +7,7 @@ mod command;
 mod control_bridge;
 mod delete;
 mod dry_run;
+mod help;
 mod log;
 mod logs;
 mod materialize;
@@ -35,48 +36,34 @@ fn load_pipeline(explicit_path: Option<std::path::PathBuf>) -> ail_core::config:
     }
 }
 
-/// Initialise tracing. Always writes structured JSON logs to stderr.
-fn init_tracing() {
-    tracing_subscriber::fmt()
-        .json()
-        .with_writer(std::io::stderr)
-        .init();
+/// Initialise tracing conditionally based on output format.
+fn init_tracing(output_format: &OutputFormat) {
+    match output_format {
+        OutputFormat::Json => {
+            tracing_subscriber::fmt()
+                .json()
+                .with_writer(std::io::stderr)
+                .init();
+            tracing::info!(event = "startup", version = ail_core::version());
+        }
+        OutputFormat::Text => {
+            // Silent by default in text mode — developers can use RUST_LOG to enable tracing.
+            let _ = tracing_subscriber::fmt()
+                .with_writer(std::io::stderr)
+                .try_init();
+        }
+    }
 }
 
 fn exit_with(outcome: CommandOutcome) -> ! {
     std::process::exit(outcome.exit_code())
 }
 
-/// Landing page shown when `ail` is invoked with no prompt and no subcommand.
-/// Surfaces `ail init` as the first-step affordance for new users.
-fn print_landing_page() {
-    println!(
-        "ail — Artificial Intelligence Loops ({})",
-        ail_core::version()
-    );
-    println!();
-    println!("The control plane for how agents behave after the human stops typing.");
-    println!();
-    println!("Common commands:");
-    println!("  ail init                    {}", ail_init::help_summary());
-    println!("  ail \"your prompt\"           Run a prompt through the discovered pipeline");
-    println!("  ail spec                    Print the embedded AIL specification");
-    println!("  ail validate                Validate the current pipeline without running it");
-    println!("  ail materialize             Print the fully-resolved pipeline YAML");
-    println!("  ail logs                    Query recorded pipeline runs");
-    println!("  ail chat                    Interactive multi-turn conversation");
-    println!();
-    println!("Getting started: if this is your first time, run `ail init`.");
-    println!("For the full reference: `ail --help`.");
-}
-
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
 
-    init_tracing();
-
-    tracing::info!(event = "startup", version = ail_core::version());
+    init_tracing(&cli.output_format);
 
     // Effective prompt: positional wins, --once as long-form alias.
     let effective_prompt = cli.prompt.clone().or(cli.once.clone());
@@ -262,7 +249,7 @@ async fn main() {
             }
         },
         (None, None) => {
-            print_landing_page();
+            help::print_landing_page();
             std::process::exit(0);
         }
         (Some(_), Some(_)) => {


### PR DESCRIPTION
## Summary
This PR refactors the help and landing page system into a dedicated module and significantly improves CLI documentation with clearer, more concise help text throughout the codebase.

## Key Changes

- **New `help` module**: Extracted `print_landing_page()` from `main.rs` into a new `ail/src/help.rs` module for better code organization
- **Improved landing page**: Reorganized the landing page output with clearer sections (Workflow, Inspection, Reference, Key flags, Examples) and more actionable guidance
- **Conditional tracing initialization**: Modified `init_tracing()` to accept an `OutputFormat` parameter and conditionally initialize JSON or text-mode tracing based on the output format
- **Refined CLI help text**: Updated all command and flag descriptions in `cli.rs` to be more concise and user-friendly:
  - Shortened verbose descriptions while preserving essential information
  - Improved consistency in help text formatting
  - Added more detailed `long_about` for the `spec` command with progressive disclosure options
  - Clarified flag purposes (e.g., `--headless`, `--dry-run`, `--watch`)
- **Better spec command documentation**: Added comprehensive long-form help for the `spec` subcommand explaining all available options and section IDs

## Implementation Details

- The `init_tracing()` function now matches on `OutputFormat` to determine whether to use JSON formatting or silent text mode (respecting `RUST_LOG` environment variable)
- Landing page now groups related commands and flags logically, making it easier for new users to understand the workflow
- All help text improvements maintain backward compatibility while improving discoverability

https://claude.ai/code/session_019nRu2isW62f5xbt4qMbZ1U