### PR TITLE
feat: workspace versioning + git-anchored AIL_VERSION (PR 1 of 2 for #185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ail"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "ail-core",
  "ail-init",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "ail-core"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "ail-spec",
  "dirs",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "ail-init"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "ail-core",
  "dialoguer",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "ail-spec"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "glob",
 ]
@@ -1823,7 +1823,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stub-llm"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["ail-core", "ail", "ail-init", "ail-spec", "stub-llm"]
 resolver = "2"
+
+[workspace.package]
+version = "0.4.0"
+edition = "2021"

--- a/ail-core/Cargo.toml
+++ b/ail-core/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "ail-core"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license = "MPL-2.0"
+build = "build.rs"
 
 [dependencies]
 thiserror = "1"

--- a/ail-core/build.rs
+++ b/ail-core/build.rs
@@ -1,0 +1,74 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
+    println!("cargo:rerun-if-changed=../Cargo.toml");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let base = env!("CARGO_PKG_VERSION");
+    let major_minor = base.rsplit_once('.').map(|x| x.0).unwrap_or(base);
+    let patch = compute_patch().unwrap_or_else(|| "0".to_string());
+
+    println!("cargo:rustc-env=AIL_VERSION={major_minor}.{patch}");
+}
+
+fn compute_patch() -> Option<String> {
+    let workspace_root = "..";
+
+    let cargo_toml = std::fs::read_to_string(format!("{workspace_root}/Cargo.toml")).ok()?;
+    let version_line = cargo_toml
+        .lines()
+        .find(|l| l.starts_with("version = \""))?
+        .to_string();
+
+    let anchor_out = Command::new("git")
+        .current_dir(workspace_root)
+        .args([
+            "log",
+            "--format=%H",
+            "-S",
+            &version_line,
+            "--",
+            "Cargo.toml",
+        ])
+        .output()
+        .ok()?;
+    let anchor = String::from_utf8(anchor_out.stdout)
+        .ok()?
+        .lines()
+        .last()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty());
+
+    let scope: &[&str] = &[
+        "ail",
+        "ail-core",
+        "ail-init",
+        "ail-spec",
+        "Cargo.toml",
+        "Cargo.lock",
+    ];
+
+    let mut args: Vec<String> = vec!["rev-list".into(), "--count".into()];
+    args.push(match &anchor {
+        Some(a) => format!("{a}..HEAD"),
+        None => "HEAD".into(),
+    });
+    args.push("--".into());
+    for s in scope {
+        args.push((*s).to_string());
+    }
+
+    let count_out = Command::new("git")
+        .current_dir(workspace_root)
+        .args(&args)
+        .output()
+        .ok()?;
+    let count = String::from_utf8(count_out.stdout)
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())?;
+
+    Some(count)
+}

--- a/ail-core/src/lib.rs
+++ b/ail-core/src/lib.rs
@@ -17,5 +17,5 @@ pub mod template;
 pub mod test_helpers;
 
 pub fn version() -> &'static str {
-    "0.0.1"
+    env!("AIL_VERSION")
 }

--- a/ail-init/Cargo.toml
+++ b/ail-init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ail-init"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license = "MPL-2.0"
 
 [dependencies]

--- a/ail-spec/Cargo.toml
+++ b/ail-spec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ail-spec"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 build = "build.rs"
 
 [build-dependencies]

--- a/ail/Cargo.toml
+++ b/ail/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ail"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license = "AGPL-3.0-only"
 
 [[bin]]

--- a/stub-llm/Cargo.toml
+++ b/stub-llm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stub-llm"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Lightweight stub HTTP server for LLM integration testing"
 license = "MPL-2.0"
 


### PR DESCRIPTION
**Closing in favour of a revised design.** See [#185 pivot comment](https://github.com/AlexChesser/ail/issues/185) for full reasoning.

Short version: the build.rs approach (Cargo.toml stays at `0.4.0` while `ail_core::version()` reports a git-derived `0.4.187`) makes Cargo.toml lie to crates.io. If we ever publish `ail-core` for downstream tooling, the design has to change. That's a one-way door I shouldn't have walked through casually.

Replacement design: Cargo.toml is the single source of truth; the release workflow does the bump (commits the new number back to `main` on dispatch); build info (sha, build date) goes into a separate string. Same one-button release UX, no Cargo-tooling lies, crates.io stays available.

A new (smaller) PR will follow with just the workspace inheritance + `env!("CARGO_PKG_VERSION")` change.