### PR TITLE
feat: workspace-inherited version (PR 1 for #185, supersedes #188)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ail"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "ail-core",
  "ail-init",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "ail-core"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "ail-spec",
  "dirs",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "ail-init"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "ail-core",
  "dialoguer",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "ail-spec"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "glob",
 ]
@@ -1823,7 +1823,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stub-llm"
-version = "0.0.1"
+version = "0.4.0"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["ail-core", "ail", "ail-init", "ail-spec", "stub-llm"]
 resolver = "2"
+
+[workspace.package]
+version = "0.4.0"
+edition = "2021"

--- a/ail-core/Cargo.toml
+++ b/ail-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ail-core"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license = "MPL-2.0"
 
 [dependencies]

--- a/ail-core/src/lib.rs
+++ b/ail-core/src/lib.rs
@@ -17,5 +17,5 @@ pub mod template;
 pub mod test_helpers;
 
 pub fn version() -> &'static str {
-    "0.0.1"
+    env!("CARGO_PKG_VERSION")
 }

--- a/ail-init/Cargo.toml
+++ b/ail-init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ail-init"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license = "MPL-2.0"
 
 [dependencies]

--- a/ail-spec/Cargo.toml
+++ b/ail-spec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ail-spec"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 build = "build.rs"
 
 [build-dependencies]

--- a/ail/Cargo.toml
+++ b/ail/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ail"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license = "AGPL-3.0-only"
 
 [[bin]]

--- a/stub-llm/Cargo.toml
+++ b/stub-llm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stub-llm"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Lightweight stub HTTP server for LLM integration testing"
 license = "MPL-2.0"
 


### PR DESCRIPTION
## Summary

PR 1 of the versioning work in #185. Establishes the Rust half: workspace-package inheritance and an accurate `version()` that reads straight from `Cargo.toml`. Replaces the closed #188 with the simpler Cargo-toml-as-truth design after the [crates.io pivot](https://github.com/AlexChesser/ail/issues/185#issuecomment-4319831638).

- `[workspace.package]` baseline `0.4.0` (higher than any previously-shipped placeholder, per discussion in #185).
- All five crates use `version.workspace = true` / `edition.workspace = true`.
- `ail_core::version()` returns `env!("CARGO_PKG_VERSION")` — no custom build script, no env-var override.

`Cargo.toml` is the single source of truth for the version. The release workflow (separate PR) will handle bumps: read `Cargo.toml`, increment PATCH/MINOR/MAJOR per dispatch input, commit the bump back to `main`, tag, release. Same one-button release UX, no Cargo-tooling lies, and **crates.io publication stays a clean future option** without redesign.

Build info (commit SHA + build date) will land separately via `vergen` in a follow-up PR.

## Verified

- [x] `cargo build` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo test` — 1207 passing, 0 failed.
- [x] `ail --version` reports `ail 0.4.0`.

## Test plan

- [ ] After merge, bumping `[workspace.package].version` to `0.4.1` in a follow-up commit causes a fresh build to report `ail 0.4.1`. (Trivial — `env!("CARGO_PKG_VERSION")` reads it directly.)
- [ ] No regressions in dependent crates (clap version reporting, landing page, tracing span — all consume `ail_core::version()`).

Refs #185, supersedes #188

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLjD5o646qQ87YaPPiNjQK)_