### PR TITLE
ci: add release-binary.yml workflow_dispatch pipeline (PR 2 for #185)

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,217 @@
+name: Release Binary
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Version bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  # ── Preflight: detect in-scope changes, bump version, commit, tag ─────────
+  preflight:
+    name: Preflight (bump + tag)
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      new_version: ${{ steps.bump.outputs.new_version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for in-scope changes since last release
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          LAST_TAG=$(git tag --list 'ail-v*' --sort=-v:refname | head -1 || true)
+          if [ -z "${LAST_TAG}" ]; then
+            echo "No prior ail-v* tag — first binary release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Last tag: ${LAST_TAG}"
+          CHANGED=$(git diff --name-only "${LAST_TAG}..HEAD" -- ail ail-core ail-init ail-spec stub-llm Cargo.toml Cargo.lock || true)
+          if [ -z "${CHANGED}" ]; then
+            echo "::notice::No in-scope changes since ${LAST_TAG}; nothing to release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "In-scope changes since ${LAST_TAG}:"
+            echo "${CHANGED}"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version in workspace Cargo.toml
+        id: bump
+        if: steps.check.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          CURRENT=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "Current: ${CURRENT}"
+          IFS='.' read -r MAJ MIN PAT <<< "${CURRENT}"
+          case "${{ inputs.bump_type }}" in
+            patch) NEW="${MAJ}.${MIN}.$((PAT+1))" ;;
+            minor) NEW="${MAJ}.$((MIN+1)).0" ;;
+            major) NEW="$((MAJ+1)).0.0" ;;
+            *) echo "::error::Unknown bump_type: ${{ inputs.bump_type }}"; exit 1 ;;
+          esac
+          echo "New: ${NEW}"
+          # In-place rewrite via temp file (atomic, portable).
+          TMP=$(mktemp)
+          sed "s/^version = \"${CURRENT}\"/version = \"${NEW}\"/" Cargo.toml > "${TMP}"
+          mv "${TMP}" Cargo.toml
+          # Sanity check: exactly one workspace version line should now read ${NEW}.
+          MATCHES=$(grep -c "^version = \"${NEW}\"" Cargo.toml)
+          if [ "${MATCHES}" -ne 1 ]; then
+            echo "::error::Expected 1 workspace version line; found ${MATCHES}"
+            exit 1
+          fi
+          echo "new_version=${NEW}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust toolchain
+        if: steps.check.outputs.should_release == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Refresh Cargo.lock
+        if: steps.check.outputs.should_release == 'true'
+        run: cargo update --workspace
+
+      - name: Commit, tag, push
+        if: steps.check.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore: bump ail version to ${{ steps.bump.outputs.new_version }}"
+          git tag "ail-v${{ steps.bump.outputs.new_version }}"
+          git push origin HEAD:main
+          git push origin "ail-v${{ steps.bump.outputs.new_version }}"
+
+  # ── Build binaries for each target off the new tag ────────────────────────
+  build:
+    name: Build ${{ matrix.target }}
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+            binary: ail
+            artifact: ail-x86_64-apple-darwin
+          - target: aarch64-apple-darwin
+            runner: macos-15
+            binary: ail
+            artifact: ail-aarch64-apple-darwin
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            binary: ail
+            artifact: ail-x86_64-unknown-linux-musl
+            use-cross: true
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-latest
+            binary: ail
+            artifact: ail-aarch64-unknown-linux-musl
+            use-cross: true
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            binary: ail.exe
+            artifact: ail-x86_64-pc-windows-msvc.exe
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ail-v${{ needs.preflight.outputs.new_version }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (Linux musl)
+        if: matrix.use-cross == true
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (cross)
+        if: matrix.use-cross == true
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Build (native)
+        if: matrix.use-cross != true
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Strip binary (Unix)
+        if: runner.os != 'Windows'
+        run: strip target/${{ matrix.target }}/release/${{ matrix.binary }}
+
+      - name: Rename binary (Unix)
+        if: runner.os != 'Windows'
+        run: cp target/${{ matrix.target }}/release/${{ matrix.binary }} ${{ matrix.artifact }}
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Copy-Item target/${{ matrix.target }}/release/${{ matrix.binary }} -Destination ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          retention-days: 1
+
+  # ── Publish GitHub Release with all binaries attached ─────────────────────
+  release:
+    name: Create GitHub Release
+    needs: [preflight, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ail-v${{ needs.preflight.outputs.new_version }}
+
+      - name: Download all binaries
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List dist contents
+        run: ls -la dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ail-v${{ needs.preflight.outputs.new_version }}
+          name: ail v${{ needs.preflight.outputs.new_version }}
+          files: dist/*
+          body: |
+            ## ail v${{ needs.preflight.outputs.new_version }}
+
+            Standalone Rust binaries for the `ail` CLI.
+
+            | Platform | Artifact |
+            |----------|----------|
+            | macOS (Intel) | `ail-x86_64-apple-darwin` |
+            | macOS (Apple Silicon) | `ail-aarch64-apple-darwin` |
+            | Linux (x86_64, musl) | `ail-x86_64-unknown-linux-musl` |
+            | Linux (ARM64, musl) | `ail-aarch64-unknown-linux-musl` |
+            | Windows (x86_64) | `ail-x86_64-pc-windows-msvc.exe` |
+
+            ### Installation
+
+            Download the binary for your platform, mark it executable (`chmod +x`), and place it on your `PATH`. Or use the VS Code extension's built-in installer (`ail Chat: Install CLI Binary to PATH`).


### PR DESCRIPTION
## Summary

PR 2 of the versioning work in #185. Establishes the binary release pipeline: one button click in GitHub Actions produces a new `ail-v*` release with cross-platform binaries attached.

**Trigger:** `workflow_dispatch` with a `bump_type` input (`patch` / `minor` / `major`, default `patch`).

**Pipeline:**

1. **Preflight** — checks for in-scope changes since the last `ail-v*` tag (scope: `ail*`, `stub-llm`, `Cargo.toml`, `Cargo.lock`). Exits cleanly if nothing changed (docs-only commits won't accidentally bump). Reads `[workspace.package].version`, applies the requested bump, rewrites `Cargo.toml`, refreshes `Cargo.lock` via `cargo update --workspace`, commits `chore: bump ail version to X.Y.Z` to `main`, tags `ail-vX.Y.Z`, pushes both.
2. **Build** — matrix of 5 targets (macOS Intel, macOS Apple Silicon, Linux x86_64 musl, Linux ARM64 musl, Windows x86_64). Linux uses cross-rs. Checks out the new tag so binaries report the bumped version. Stripped, renamed, uploaded as artifacts.
3. **Release** — downloads all artifacts; creates a GitHub Release on the new tag with binaries attached and a per-platform install table.

`Cargo.toml` stays the source of truth — no env-var override, no build-script-derived version. The workflow types the new number; humans never type version numbers in `Cargo.toml`.

**Does not touch `release-extension.yml`** — that workflow keeps building binaries from source on `vscode-v*` tag push. PR 3 will rework it to download from `ail-v*` releases instead.

## Verified

- [x] YAML parses cleanly.
- [x] No changes to existing workflows; new file only.

## Test plan

- [ ] First dispatch (`bump_type=patch`): produces `ail-v0.4.1` tag + GitHub Release with 5 binaries attached. The bump commit lands on `main` as `chore: bump ail version to 0.4.1`. `Cargo.toml` workspace version becomes `0.4.1`.
- [ ] Second dispatch with no in-scope changes since `ail-v0.4.1`: workflow exits via the skip-if-unchanged preflight; no commit, no tag, no release.
- [ ] After committing a docs-only change and dispatching: still skips (docs aren't in scope).
- [ ] After committing an `ail-core/` change and dispatching: bumps to `0.4.2`.
- [ ] Dispatch with `bump_type=minor` from `0.4.2`: produces `0.5.0`.

## Permissions / setup notes

- Workflow uses `permissions: contents: write` for both the version-bump push and the GitHub Release creation. Same model as the existing `release-extension.yml`.
- Pushes directly to `main`. If branch protection blocks direct pushes from `github-actions[bot]`, the workflow will fail loudly on the push step — adjust the rule (allow this bot for `chore: bump ail version to *` commits) or grant a PAT.
- Tag prefix `ail-v*` chosen to namespace from the existing `vscode-v*` (extension) and the future `vscode-ail-v*` (post-PR 3 extension).

Refs #185

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLjD5o646qQ87YaPPiNjQK)_