### PR TITLE
ci: rework release-extension.yml to dispatch + ail-v* download (PR 3 for #185)

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,93 +1,116 @@
 name: Release Extension
 
 on:
-  push:
-    tags:
-      - "vscode-v*"
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Extension version bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
 
 jobs:
-  # ── Build ail binaries for all platforms ─────────────────────────────────
-  build-binaries:
-    name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-apple-darwin
-            runner: macos-15-intel  # Intel x86_64 (macos-13 removed Sep 2025)
-            binary: ail
-            artifact: ail-x86_64-apple-darwin
-
-          - target: aarch64-apple-darwin
-            runner: macos-15        # Apple Silicon
-            binary: ail
-            artifact: ail-aarch64-apple-darwin
-
-          - target: x86_64-unknown-linux-musl
-            runner: ubuntu-latest
-            binary: ail
-            artifact: ail-x86_64-unknown-linux-musl
-            use-cross: true
-
-          - target: x86_64-pc-windows-msvc
-            runner: windows-latest
-            binary: ail.exe
-            artifact: ail-x86_64-pc-windows-msvc.exe
-
+  # ── Preflight: detect in-scope changes, look up bundled binary, bump, tag ─
+  preflight:
+    name: Preflight (bump + tag)
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      new_version: ${{ steps.bump.outputs.new_version }}
+      ail_binary_version: ${{ steps.ail_release.outputs.version }}
+      ail_binary_tag: ${{ steps.ail_release.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          fetch-depth: 0
 
-      - name: Install cross (Linux musl)
-        if: matrix.use-cross == true
-        run: cargo install cross --git https://github.com/cross-rs/cross
+      - name: Check for in-scope changes since last release
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          LAST_TAG=$(git tag --list 'vscode-ail-v*' --sort=-v:refname | head -1 || true)
+          if [ -z "${LAST_TAG}" ]; then
+            echo "No prior vscode-ail-v* tag — first extension release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Last tag: ${LAST_TAG}"
+          CHANGED=$(git diff --name-only "${LAST_TAG}..HEAD" -- vscode-ail-chat || true)
+          if [ -z "${CHANGED}" ]; then
+            echo "::notice::No in-scope changes since ${LAST_TAG}; nothing to release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "In-scope changes since ${LAST_TAG}:"
+            echo "${CHANGED}"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Build (cross)
-        if: matrix.use-cross == true
-        run: cross build --release --target ${{ matrix.target }}
+      - name: Look up latest ail-v* release
+        id: ail_release
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          LATEST=$(gh release list --repo "${{ github.repository }}" --limit 50 --json tagName --jq '.[].tagName' | grep '^ail-v' | head -1 || true)
+          if [ -z "${LATEST}" ]; then
+            echo "::error::No ail-v* release found. Run release-binary.yml first."
+            exit 1
+          fi
+          VERSION="${LATEST#ail-v}"
+          echo "Bundled binary tag: ${LATEST} (version ${VERSION})"
+          echo "tag=${LATEST}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Build (native)
-        if: matrix.use-cross != true
-        run: cargo build --release --target ${{ matrix.target }}
+      - name: Bump version + stamp ailBundledVersion in package.json
+        id: bump
+        if: steps.check.outputs.should_release == 'true'
+        working-directory: vscode-ail-chat
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm version ${{ inputs.bump_type }} --no-git-tag-version
+          NEW=$(node -p "require('./package.json').version")
+          echo "New extension version: ${NEW}"
+          npm pkg set "config.ailBundledVersion=${{ steps.ail_release.outputs.version }}"
+          echo "Stamped config.ailBundledVersion=${{ steps.ail_release.outputs.version }}"
+          echo "new_version=${NEW}" >> "$GITHUB_OUTPUT"
 
-      - name: Strip binary (Unix)
-        if: runner.os != 'Windows'
-        run: strip target/${{ matrix.target }}/release/${{ matrix.binary }}
+      - name: Commit, tag, push
+        if: steps.check.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add vscode-ail-chat/package.json vscode-ail-chat/package-lock.json
+          git commit -m "chore: bump vscode-ail-chat to ${{ steps.bump.outputs.new_version }} (bundles ail v${{ steps.ail_release.outputs.version }})"
+          git tag "vscode-ail-v${{ steps.bump.outputs.new_version }}"
+          git push origin HEAD:main
+          git push origin "vscode-ail-v${{ steps.bump.outputs.new_version }}"
 
-      - name: Rename binary to platform artifact name (Unix)
-        if: runner.os != 'Windows'
-        run: cp target/${{ matrix.target }}/release/${{ matrix.binary }} ${{ matrix.artifact }}
-
-      - name: Rename binary to platform artifact name (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: Copy-Item target/${{ matrix.target }}/release/${{ matrix.binary }} -Destination ${{ matrix.artifact }}
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}
-          retention-days: 1
-
-  # ── Package and publish VSIX ──────────────────────────────────────────────
+  # ── Package VSIX with binaries downloaded from the ail-v* release ─────────
   package-vsix:
     name: Package VSIX
-    needs: build-binaries
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: vscode-ail-chat
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: vscode-ail-v${{ needs.preflight.outputs.new_version }}
 
       - name: Use Node.js 22
         uses: actions/setup-node@v6
@@ -102,11 +125,16 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Download all binaries
-        uses: actions/download-artifact@v8
-        with:
-          path: vscode-ail-chat/dist
-          merge-multiple: true
+      - name: Download bundled binaries from ail-v* release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: .
+        run: |
+          set -euo pipefail
+          mkdir -p vscode-ail-chat/dist
+          gh release download "${{ needs.preflight.outputs.ail_binary_tag }}" \
+            --repo "${{ github.repository }}" \
+            --dir vscode-ail-chat/dist
 
       - name: Make binaries executable (Unix)
         run: chmod +x dist/ail-* || true
@@ -117,28 +145,20 @@ jobs:
       - name: Install vsce
         run: npm install -g @vscode/vsce
 
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#vscode-v}" >> "$GITHUB_OUTPUT"
-        shell: bash
-        working-directory: .
-
-      - name: Update version in package.json
-        run: |
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
-
-      # Package once per target platform (VS Code platform-specific VSIX)
       - name: Package VSIX — linux x64
-        run: vsce package --target linux-x64 --out ail-linux-x64-${{ steps.version.outputs.version }}.vsix
+        run: vsce package --target linux-x64 --out ail-linux-x64-${{ needs.preflight.outputs.new_version }}.vsix
+
+      - name: Package VSIX — linux arm64
+        run: vsce package --target linux-arm64 --out ail-linux-arm64-${{ needs.preflight.outputs.new_version }}.vsix
 
       - name: Package VSIX — darwin x64
-        run: vsce package --target darwin-x64 --out ail-darwin-x64-${{ steps.version.outputs.version }}.vsix
+        run: vsce package --target darwin-x64 --out ail-darwin-x64-${{ needs.preflight.outputs.new_version }}.vsix
 
       - name: Package VSIX — darwin arm64
-        run: vsce package --target darwin-arm64 --out ail-darwin-arm64-${{ steps.version.outputs.version }}.vsix
+        run: vsce package --target darwin-arm64 --out ail-darwin-arm64-${{ needs.preflight.outputs.new_version }}.vsix
 
       - name: Package VSIX — win32 x64
-        run: vsce package --target win32-x64 --out ail-win32-x64-${{ steps.version.outputs.version }}.vsix
+        run: vsce package --target win32-x64 --out ail-win32-x64-${{ needs.preflight.outputs.new_version }}.vsix
 
       - name: Upload VSIX artifacts
         uses: actions/upload-artifact@v7
@@ -149,38 +169,44 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: vscode-ail-v${{ needs.preflight.outputs.new_version }}
+          name: "VS Code Extension v${{ needs.preflight.outputs.new_version }}"
           files: vscode-ail-chat/*.vsix
-          name: "VSCode Extension ${{ steps.version.outputs.version }}"
           body: |
-            ## ail VSCode Extension v${{ steps.version.outputs.version }}
+            ## ail VS Code Extension v${{ needs.preflight.outputs.new_version }}
+
+            Bundled `ail` binary: **v${{ needs.preflight.outputs.ail_binary_version }}**.
 
             ### Installation
 
             Download the `.vsix` for your platform and install with:
             ```
-            code --install-extension ail-<platform>-${{ steps.version.outputs.version }}.vsix
+            code --install-extension ail-<platform>-${{ needs.preflight.outputs.new_version }}.vsix
             ```
 
             | Platform | File |
             |----------|------|
-            | macOS (Intel) | `ail-darwin-x64-*.vsix` |
-            | macOS (Apple Silicon) | `ail-darwin-arm64-*.vsix` |
-            | Linux x64 | `ail-linux-x64-*.vsix` |
-            | Windows x64 | `ail-win32-x64-*.vsix` |
+            | macOS (Intel) | `ail-darwin-x64-${{ needs.preflight.outputs.new_version }}.vsix` |
+            | macOS (Apple Silicon) | `ail-darwin-arm64-${{ needs.preflight.outputs.new_version }}.vsix` |
+            | Linux (x64) | `ail-linux-x64-${{ needs.preflight.outputs.new_version }}.vsix` |
+            | Linux (ARM64) | `ail-linux-arm64-${{ needs.preflight.outputs.new_version }}.vsix` |
+            | Windows (x64) | `ail-win32-x64-${{ needs.preflight.outputs.new_version }}.vsix` |
 
-            The `ail` binary is bundled — no Rust toolchain required.
+            The `ail` binary is bundled — no Rust toolchain required for installation.
 
-  # ── Publish to VS Code Marketplace (optional, requires secret) ───────────
+  # ── Publish to VS Code Marketplace (optional, requires PUBLISH_TO_MARKETPLACE=true) ─
   publish:
     name: Publish to Marketplace
-    needs: package-vsix
-    runs-on: ubuntu-latest
+    needs: [preflight, package-vsix]
     if: vars.PUBLISH_TO_MARKETPLACE == 'true'
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: vscode-ail-chat
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: vscode-ail-v${{ needs.preflight.outputs.new_version }}
 
       - name: Use Node.js 22
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

PR 3 of the versioning work in #185. Reworks the extension release pipeline so it triggers via `workflow_dispatch` (not on tag push), versions independently from the binary, and bundles the binary by **downloading from the latest `ail-v*` GitHub Release** instead of building it from source.

**Trigger:** `workflow_dispatch` with a `bump_type` input (`patch` / `minor` / `major`, default `patch`).

**Pipeline:**

1. **Preflight** — checks for in-scope changes since the last `vscode-ail-v*` tag (scope: `vscode-ail-chat/`). Exits cleanly if nothing under `vscode-ail-chat/` has changed (binary-only and docs-only commits don't bump the extension). Looks up the latest `ail-v*` GitHub Release; fails loudly if none exists yet (run `release-binary.yml` first). Bumps `vscode-ail-chat/package.json` via `npm version <bump> --no-git-tag-version`. Stamps `config.ailBundledVersion` to the bundled binary's version. Commits, tags `vscode-ail-v<new>`, pushes both.
2. **package-vsix** — checks out the new tag. Downloads bundled binaries from the `ail-v*` release via `gh release download` (no Rust toolchain needed in this job anymore). Produces five per-target VSIXs: `linux-x64`, `linux-arm64` (new), `darwin-x64`, `darwin-arm64`, `win32-x64`. Creates a GitHub Release on the new tag with all VSIXs attached and a per-platform install table that includes the bundled binary version.
3. **publish** — marketplace publish (existing behaviour, gated on `vars.PUBLISH_TO_MARKETPLACE`).

## What changed vs. the old workflow

| | Old | New |
|---|---|---|
| Trigger | `push: tags: [vscode-v*]` | `workflow_dispatch` with `bump_type` |
| Tag prefix | `vscode-v*` | `vscode-ail-v*` |
| Binary source | built from source in this workflow | downloaded from latest `ail-v*` release |
| Version bump | implicit (from pushed tag name) | explicit (`npm version` in workflow) |
| `ailBundledVersion` | unwritten | stamped to the downloaded binary's version |
| Skip-if-unchanged | none | preflight gate against last `vscode-ail-v*` tag |
| VSIX targets | 4 (linux-x64, darwin-x64/arm64, win32-x64) | 5 (adds linux-arm64) |

## Verified

- [x] YAML parses cleanly.
- [x] No code changes outside the workflow file.

## Test plan

- [ ] **First dispatch (after #190 has produced an `ail-v*` release):** bumps `vscode-ail-chat/package.json` → `0.1.1`, stamps `config.ailBundledVersion` to the latest `ail-v*` version, commits + tags `vscode-ail-v0.1.1`, downloads binaries from the `ail-v*` release, packages 5 VSIXs, attaches to a `vscode-ail-v0.1.1` GitHub Release.
- [ ] **Dispatch with no in-scope changes:** workflow exits via the skip-if-unchanged preflight; no commit, no tag, no release.
- [ ] **Dispatch when no `ail-v*` release exists:** fails loudly at the preflight `Look up latest ail-v*` step. (Bootstrap order: binary release first, then extension.)
- [ ] **Dispatch with `bump_type=minor`:** moves extension from `0.1.1` → `0.2.0`, bundling the same `ail-v*` version that's currently latest.
- [ ] **Marketplace publish (with `PUBLISH_TO_MARKETPLACE=true`):** all 5 VSIXs publish under the same extension version.

## Why a different branch

PR 2 (#190) lives on `claude/review-ail-versioning-12KMy`. Pushing this commit there would have grown #190 to cover both workflows, which isn't what we agreed on (multiple safe PRs). This PR lives on `claude/release-extension-rework` instead so #190 and this PR can be reviewed and merged independently.

This PR has **no code dependency** on #190 — both workflow files are independent. The runtime dependency (this workflow needs a real `ail-v*` release to download binaries) is handled by the explicit fail-loud at the preflight step.

Refs #185

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLjD5o646qQ87YaPPiNjQK)_