### PR TITLE
feat: vergen build-info in --version output (PR 4 for #185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "tracing",
  "ureq",
  "uuid",
+ "vergen",
 ]
 
 [[package]]
@@ -384,6 +385,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1226,6 +1236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1344,6 +1369,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1914,6 +1945,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2259,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/ail-core/Cargo.toml
+++ b/ail-core/Cargo.toml
@@ -3,6 +3,10 @@ name = "ail-core"
 version.workspace = true
 edition.workspace = true
 license = "MPL-2.0"
+build = "build.rs"
+
+[build-dependencies]
+vergen = { version = "8", features = ["build", "git", "gitcl"] }
 
 [dependencies]
 thiserror = "1"

--- a/ail-core/build.rs
+++ b/ail-core/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    vergen::EmitBuilder::builder()
+        .build_date()
+        .git_sha(true)
+        .emit()?;
+    Ok(())
+}

--- a/ail-core/src/lib.rs
+++ b/ail-core/src/lib.rs
@@ -19,3 +19,14 @@ pub mod test_helpers;
 pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
+
+pub fn version_full() -> &'static str {
+    concat!(
+        env!("CARGO_PKG_VERSION"),
+        " (rev ",
+        env!("VERGEN_GIT_SHA"),
+        ", built ",
+        env!("VERGEN_BUILD_DATE"),
+        ")"
+    )
+}

--- a/ail/src/cli.rs
+++ b/ail/src/cli.rs
@@ -14,7 +14,7 @@ pub enum OutputFormat {
 #[derive(Parser)]
 #[command(
     name = "ail",
-    version = ail_core::version(),
+    version = ail_core::version_full(),
     about = "Artificial Intelligence Loops — the control plane for how agents behave after the human stops typing."
 )]
 pub struct Cli {

--- a/ail/src/help.rs
+++ b/ail/src/help.rs
@@ -1,7 +1,7 @@
 pub fn print_landing_page() {
     println!(
         "ail — Artificial Intelligence Loops {}",
-        ail_core::version()
+        ail_core::version_full()
     );
     println!();
     println!("The control plane for how agents behave after the human stops typing.");


### PR DESCRIPTION
## Summary

Optional follow-up PR (technically PR 4) for the versioning work in #185. Adds short git SHA and build date to the user-facing `ail --version` output and the landing page header, while keeping the bare SemVer for the tracing startup span (so logs stay clean).

**Sample output:**

```
$ ail --version
ail 0.4.0 (rev 16227e4, built 2026-04-25)

$ ail
ail — Artificial Intelligence Loops 0.4.0 (rev 16227e4, built 2026-04-25)

The control plane for how agents behave after the human stops typing.
[...]
```

Tracing startup span still emits `version=0.4.0` (unchanged).

## Implementation

- New `ail-core/build.rs` uses **vergen 8.x** (`build + git + gitcl` features) to emit `VERGEN_BUILD_DATE` and `VERGEN_GIT_SHA` (short form) as `cargo:rustc-env` at compile time.
- `ail_core::version()` stays as `env!("CARGO_PKG_VERSION")` — used by the tracing startup span.
- New `ail_core::version_full()` composes `"<version> (rev <sha>, built <date>)"` via `concat!`.
- `cli.rs` (clap `version` attribute) and `help.rs` (landing page) switch to `version_full()`.

The two-function API keeps the tracing call clean (bare SemVer for filtering and dashboards) while surfacing build info where it's useful (bug reports, support).

## Why vergen and not hand-rolled

Discussed in the issue thread. Hand-rolling the SHA part is trivial (~5 lines), but the cross-platform build-date piece pulls in `chrono` or hand-written YMD math. Vergen handles both correctly in ~7 lines of build script with one well-targeted build-dep. The original "we don't add deps for ~20 lines" stance was a misread — once you handle dates correctly, the hand-roll is bigger than vergen.

Notable: the **first** vergen variant tried (`vergen-gitcl 1.0.8`) had an internal `vergen-lib` version conflict that broke compilation. Switched to `vergen 8.x` with the unified `gitcl` feature, which has no such issue.

## Verified

- [x] `cargo build` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo test` — 1208 passing, 0 failed.
- [x] `ail --version` includes git SHA + build date.
- [x] `ail` (no args) landing page includes the same.

## Test plan

- [ ] After merge, the new commit's SHA is reflected in `ail --version` output for any binary built off main.
- [ ] First `release-binary.yml` dispatch produces a `ail-v*` release whose binaries embed the bump-commit's short SHA and build date in their `--version` output.
- [ ] In a non-git build context (e.g. `cargo install` from a tarball — not supported today, but a future scenario), vergen's fallback prevents the build from failing. Vergen 8.x emits `VERGEN_GIT_SHA=VERGEN_IDEMPOTENT_OUTPUT` or similar when git isn't available; the build still succeeds.

Refs #185

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLjD5o646qQ87YaPPiNjQK)_