### PR TITLE
feat(vscode-ail-chat): bundled-fallback resolution + update detection (PR 5 for #185)

### DIFF
--- a/vscode-ail-chat/package.json
+++ b/vscode-ail-chat/package.json
@@ -76,6 +76,13 @@
           "type": "boolean",
           "default": false,
           "description": "Run ail with --headless (--dangerously-skip-permissions). Use only in trusted workspaces."
+        },
+        "ail-chat.updateCheckIntervalDays": {
+          "type": "number",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 30,
+          "description": "How often (in days) to check for new ail releases at activation. 0 = check every activation. Set to a larger value to reduce GitHub API traffic."
         }
       }
     },
@@ -114,6 +121,11 @@
       {
         "command": "ail-chat.installBinary",
         "title": "ail Chat: Install CLI Binary to PATH",
+        "category": "ail Chat"
+      },
+      {
+        "command": "ail-chat.checkForUpdates",
+        "title": "ail Chat: Check for ail Updates",
         "category": "ail Chat"
       }
     ]

--- a/vscode-ail-chat/src/binary.ts
+++ b/vscode-ail-chat/src/binary.ts
@@ -2,9 +2,15 @@
  * Binary resolution — finds the ail executable to use.
  *
  * Resolution order:
- *   1. ail.binaryPath setting (if set and file exists)
- *   2. Bundled binary in dist/ail-{platform-triple}
- *   3. ail on PATH
+ *   1. ail-chat.binaryPath setting (if set and file exists)         → source: 'config'
+ *   2. ail on PATH (via `which`/`where`)                            → source: 'path'
+ *   3. Bundled binary in dist/ail-{platform-triple} (never-stuck)   → source: 'bundled'
+ *
+ * Bundled is the safety net so the extension always launches with a working
+ * binary — even on a fresh install with no network. PATH wins over bundled
+ * because users who installed `ail` deliberately should keep using their
+ * chosen version; the activation-time update check tells them when the
+ * bundled / latest release is newer.
  *
  * Reports a warning (not an error) if the resolved binary's version is below
  * the minimum declared in package.json#config.ailMinVersion.
@@ -15,10 +21,14 @@ import * as path from "path";
 import { execFile } from "child_process";
 import * as vscode from "vscode";
 import { createPlatform } from "./platforms";
+import { isAilOnPath } from "./path-detection";
+
+export type BinarySource = "config" | "path" | "bundled";
 
 export interface ResolvedBinary {
   path: string;
   version: string;
+  source: BinarySource;
 }
 
 let cached: ResolvedBinary | undefined;
@@ -47,8 +57,12 @@ async function getVersion(binaryPath: string): Promise<string> {
       if (err) {
         reject(err);
       } else {
-        // Output format: "ail 0.1.0" — extract last token
-        const version = stdout.trim().split(/\s+/).pop() ?? "unknown";
+        // Output formats:
+        //   "ail 0.4.0"
+        //   "ail 0.4.0 (rev abc123, built 2026-04-25)"
+        // Take the second whitespace-separated token (the SemVer).
+        const tokens = stdout.trim().split(/\s+/);
+        const version = tokens[1] ?? "unknown";
         resolve(version);
       }
     });
@@ -56,7 +70,7 @@ async function getVersion(binaryPath: string): Promise<string> {
 }
 
 /** Compare two semver strings. Returns true if actual >= minimum. */
-function meetsMinVersion(actual: string, minimum: string): boolean {
+export function meetsMinVersion(actual: string, minimum: string): boolean {
   const parse = (v: string) => v.split(".").map((n) => parseInt(n, 10) || 0);
   const [maj1, min1, pat1] = parse(actual);
   const [maj2, min2, pat2] = parse(minimum);
@@ -80,13 +94,23 @@ export async function resolveBinary(
   const configuredPath = config.get<string>("binaryPath", "");
 
   let binaryPath: string | undefined;
+  let source: BinarySource | undefined;
 
   // 1. User-configured path
   if (configuredPath && fs.existsSync(configuredPath)) {
     binaryPath = configuredPath;
+    source = "config";
   }
 
-  // 2. Bundled binary
+  // 2. PATH
+  if (!binaryPath) {
+    if (await isAilOnPath()) {
+      binaryPath = createPlatform().binary.pathBinaryName();
+      source = "path";
+    }
+  }
+
+  // 3. Bundled (never-stuck fallback)
   if (!binaryPath) {
     const bundled = path.join(
       context.extensionPath,
@@ -95,6 +119,7 @@ export async function resolveBinary(
     );
     if (fs.existsSync(bundled)) {
       binaryPath = bundled;
+      source = "bundled";
       // Ensure executable
       try {
         fs.chmodSync(bundled, 0o755);
@@ -104,9 +129,11 @@ export async function resolveBinary(
     }
   }
 
-  // 3. PATH fallback
-  if (!binaryPath) {
-    binaryPath = createPlatform().binary.pathBinaryName();
+  if (!binaryPath || !source) {
+    const msg =
+      "ail binary not found: no configured path, not on PATH, no bundled fallback. Set ail-chat.binaryPath to override.";
+    void vscode.window.showErrorMessage(msg);
+    throw new Error(msg);
   }
 
   // Verify binary works and get version
@@ -114,7 +141,7 @@ export async function resolveBinary(
   try {
     version = await getVersion(binaryPath);
   } catch (err) {
-    const msg = `ail binary not found or not executable at '${binaryPath}'. Set ail-chat.binaryPath to override.`;
+    const msg = `ail binary not executable at '${binaryPath}'. Set ail-chat.binaryPath to override.`;
     void vscode.window.showErrorMessage(msg);
     throw new Error(msg);
   }
@@ -132,7 +159,7 @@ export async function resolveBinary(
     );
   }
 
-  cached = { path: binaryPath, version };
+  cached = { path: binaryPath, version, source };
   return cached;
 }
 

--- a/vscode-ail-chat/src/extension.ts
+++ b/vscode-ail-chat/src/extension.ts
@@ -8,7 +8,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { clearBinaryCache, resolveBinary } from './binary';
+import { clearBinaryCache, resolveBinary, ResolvedBinary } from './binary';
+import { checkForLatestRelease, compareVersions } from './update-checker';
 import { SessionManager } from './session-manager';
 import { ChatViewProvider } from './chat-view-provider';
 import { PipelineGraphPanel } from './pipeline-graph/PipelineGraphPanel';
@@ -44,6 +45,7 @@ export function activate(context: vscode.ExtensionContext): void {
   void resolveBinary(context).then((b) => {
     historyProvider.setBinaryPath(b.path);
     historyProvider.refresh();
+    void onBinaryResolved(context, b);
   }).catch(() => { /* binary not found — history tree stays empty */ });
 
   context.subscriptions.push(
@@ -56,6 +58,26 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('ail-chat.openStep', (item) => {
       stepsProvider.openStep(item);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ail-chat.checkForUpdates', async () => {
+      const binary = await resolveBinary(context).catch(() => undefined);
+      const release = await checkForLatestRelease(context, { force: true });
+      if (!release) {
+        void vscode.window.showInformationMessage(
+          'No ail release information available right now. Check your network connection or try again later.'
+        );
+        return;
+      }
+      if (binary && compareVersions(release.version, binary.version) > 0) {
+        void promptUpdateAvailable(release.version, binary.version);
+      } else {
+        void vscode.window.showInformationMessage(
+          `ail is up to date (running ${binary?.version ?? 'unknown'}; latest release ${release.version}).`
+        );
+      }
     })
   );
 
@@ -151,6 +173,52 @@ export function activate(context: vscode.ExtensionContext): void {
       if (chatProvider) void chatProvider.sendSetupStatus();
     })
   );
+}
+
+/**
+ * Run after a successful resolveBinary() during activation.
+ * - If using bundled fallback, surface an informational toast inviting installation to PATH.
+ * - Run a throttled update check; if a newer ail-v* release is available, prompt to update.
+ */
+async function onBinaryResolved(
+  context: vscode.ExtensionContext,
+  binary: ResolvedBinary
+): Promise<void> {
+  if (binary.source === 'bundled') {
+    void promptInstallBundledFallback();
+  }
+
+  const release = await checkForLatestRelease(context);
+  if (release && compareVersions(release.version, binary.version) > 0) {
+    void promptUpdateAvailable(release.version, binary.version);
+  }
+}
+
+async function promptInstallBundledFallback(): Promise<void> {
+  const choice = await vscode.window.showInformationMessage(
+    'ail is not on your PATH — using the bundled fallback. Install to PATH for command-line use?',
+    'Install',
+    'Not Now'
+  );
+  if (choice === 'Install') {
+    void vscode.commands.executeCommand('ail-chat.installBinary');
+  }
+}
+
+async function promptUpdateAvailable(latest: string, current: string): Promise<void> {
+  const choice = await vscode.window.showInformationMessage(
+    `ail v${latest} is available (you have ${current}). Install update?`,
+    'Install Update',
+    'Release Notes',
+    'Not Now'
+  );
+  if (choice === 'Install Update') {
+    void vscode.commands.executeCommand('ail-chat.installBinary');
+  } else if (choice === 'Release Notes') {
+    void vscode.env.openExternal(
+      vscode.Uri.parse(`https://github.com/AlexChesser/ail/releases/tag/ail-v${latest}`)
+    );
+  }
 }
 
 // Process manager cleanup is handled by the view's onDidDispose.

--- a/vscode-ail-chat/src/update-checker.ts
+++ b/vscode-ail-chat/src/update-checker.ts
@@ -1,0 +1,104 @@
+/**
+ * Update checker — polls GitHub for the latest `ail-v*` release.
+ *
+ * Throttled via globalState. Default interval: 1 day, configurable up to 30.
+ * Manual checks (force: true) bypass the throttle and overwrite the cache.
+ *
+ * Failures are silent — a flaky network shouldn't alarm the user.
+ */
+
+import * as vscode from "vscode";
+
+const REPO = "AlexChesser/ail";
+const LAST_CHECK_KEY = "ail-chat.lastUpdateCheckMs";
+const LAST_RESULT_KEY = "ail-chat.lastUpdateResult";
+
+export interface ReleaseInfo {
+  /** SemVer without the `ail-v` prefix (e.g. "0.4.1"). */
+  version: string;
+  /** Full tag name (e.g. "ail-v0.4.1"). */
+  tag: string;
+  /** GitHub release page URL. */
+  url: string;
+}
+
+/** Compare two semver strings. Returns negative if a<b, 0 if equal, positive if a>b. */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => v.split(".").map((n) => parseInt(n, 10) || 0);
+  const [aMaj = 0, aMin = 0, aPat = 0] = parse(a);
+  const [bMaj = 0, bMin = 0, bPat = 0] = parse(b);
+  if (aMaj !== bMaj) return aMaj - bMaj;
+  if (aMin !== bMin) return aMin - bMin;
+  return aPat - bPat;
+}
+
+/**
+ * Check for the latest `ail-v*` release on GitHub.
+ *
+ * Returns the latest release info, or null if the check is throttled or
+ * the network call fails. Updates `globalState` with the new last-check
+ * timestamp and result on success.
+ */
+export async function checkForLatestRelease(
+  context: vscode.ExtensionContext,
+  options: { force?: boolean } = {}
+): Promise<ReleaseInfo | null> {
+  const cfg = vscode.workspace.getConfiguration("ail-chat");
+  const intervalDays = Math.max(0, cfg.get<number>("updateCheckIntervalDays", 1));
+
+  if (!options.force) {
+    const lastCheck = context.globalState.get<number>(LAST_CHECK_KEY, 0);
+    const elapsedMs = Date.now() - lastCheck;
+    const intervalMs = intervalDays * 24 * 60 * 60 * 1000;
+    if (elapsedMs < intervalMs) {
+      // Throttled — return cached result if any.
+      return context.globalState.get<ReleaseInfo>(LAST_RESULT_KEY) ?? null;
+    }
+  }
+
+  try {
+    const url = `https://api.github.com/repos/${REPO}/releases?per_page=20`;
+    const response = await fetch(url, {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub API returned HTTP ${response.status}`);
+    }
+    const releases = (await response.json()) as Array<{
+      tag_name?: string;
+      html_url?: string;
+      draft?: boolean;
+      prerelease?: boolean;
+    }>;
+
+    const ailRelease = releases.find(
+      (r) =>
+        typeof r.tag_name === "string" &&
+        r.tag_name.startsWith("ail-v") &&
+        !r.draft &&
+        !r.prerelease
+    );
+
+    if (!ailRelease || !ailRelease.tag_name) {
+      // No matching release — record the check timestamp anyway so we don't
+      // hammer the API; null out the stored result.
+      await context.globalState.update(LAST_CHECK_KEY, Date.now());
+      await context.globalState.update(LAST_RESULT_KEY, undefined);
+      return null;
+    }
+
+    const info: ReleaseInfo = {
+      version: ailRelease.tag_name.replace(/^ail-v/, ""),
+      tag: ailRelease.tag_name,
+      url: ailRelease.html_url ?? `https://github.com/${REPO}/releases/tag/${ailRelease.tag_name}`,
+    };
+
+    await context.globalState.update(LAST_CHECK_KEY, Date.now());
+    await context.globalState.update(LAST_RESULT_KEY, info);
+    return info;
+  } catch (err) {
+    // Silent failure — log to console but don't bother the user.
+    console.warn("ail update check failed:", err);
+    return null;
+  }
+}

--- a/vscode-ail-chat/test/update-checker.test.ts
+++ b/vscode-ail-chat/test/update-checker.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { compareVersions } from "../src/update-checker";
+
+describe("compareVersions", () => {
+  it("returns 0 for equal versions", () => {
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+    expect(compareVersions("0.0.0", "0.0.0")).toBe(0);
+  });
+
+  it("orders by major first", () => {
+    expect(compareVersions("2.0.0", "1.99.99")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+  });
+
+  it("orders by minor when majors are equal", () => {
+    expect(compareVersions("1.2.0", "1.1.99")).toBeGreaterThan(0);
+    expect(compareVersions("1.1.0", "1.2.0")).toBeLessThan(0);
+  });
+
+  it("orders by patch when major+minor are equal", () => {
+    expect(compareVersions("0.4.10", "0.4.9")).toBeGreaterThan(0);
+    expect(compareVersions("0.4.0", "0.4.1")).toBeLessThan(0);
+  });
+
+  it("treats missing components as 0", () => {
+    expect(compareVersions("1", "1.0.0")).toBe(0);
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+  });
+
+  it("handles non-numeric components as 0", () => {
+    expect(compareVersions("1.x.0", "1.0.0")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

PR 5 of the versioning work in #185. Wires the extension activation flow to:

- **Track which source the resolved binary came from** (`config` / `path` / `bundled`) and reorder resolution to `config → PATH → bundled`. Bundled is the never-stuck safety net, **not** the default — users who installed `ail` on PATH deliberately keep that binary, and the activation-time update check tells them when a newer release is available.
- **Surface an informational toast on activation when running on the bundled fallback**, with a one-click "Install" action that runs the existing `ail-chat.installBinary` command.
- **Poll GitHub for the latest `ail-v*` release on activation**, throttled via `globalState` (default once per day; configurable 0–30 via the new `ail-chat.updateCheckIntervalDays` setting). When a newer release is available, prompt with **Install / Release Notes / Not Now**.
- **New `ail-chat.checkForUpdates` command** bypasses the throttle for manual checks and reports up-to-date / newer-available state inline.

## What changed

**`binary.ts`:**
- Adds `BinarySource` (`'config' | 'path' | 'bundled'`) and `ResolvedBinary.source`.
- Resolution order: config → PATH (via existing `isAilOnPath`) → bundled.
- Tightens the "ail not found" error path now that all three lookups can fail without a binary handy.
- Updates `getVersion()` to handle the new `"ail 0.4.0 (rev ..., built ...)"` output format from #192 — picks the second whitespace-separated token rather than the last.
- Exports `meetsMinVersion()` for reuse.

**`update-checker.ts` (new):**
- `checkForLatestRelease()` with throttle + `globalState` caching. Silent failure on flaky networks (warn to console, return null).
- `compareVersions()` — pure SemVer triple compare.

**`extension.ts`:**
- `onBinaryResolved()` runs after `resolveBinary()` during activation: bundled-fallback toast + throttled update check + prompt.
- Registers `ail-chat.checkForUpdates` command.
- Uses `vscode.env.openExternal` for the Release Notes action.

**`package.json`:**
- New `ail-chat.updateCheckIntervalDays` config (number, 0–30, default 1).
- New `ail-chat.checkForUpdates` command.

## Out of scope (deferred to a follow-up PR)

- **Full `ailMinVersion` enforcement** — degraded mode, command-disable, `ail-chat.useAnyway` override. The existing minVersion warning stays as-is. Upgrading to refusal-with-override is a separate concern with its own UX surface and override semantics; happy to do it in a focused PR 6 once you've kicked the tires on this one.

## Verified

- [x] `npm run compile` clean (tsc).
- [x] `npm run lint` clean (eslint).
- [x] `npm test` — 230 vitest tests passing (was 224; +6 new for `compareVersions`).

## Test plan

- [ ] **First activation after install (no PATH `ail`):** runs on bundled binary, fires the "ail is not on your PATH — using the bundled fallback" toast.
- [ ] **First activation with PATH `ail` newer than bundled:** uses the PATH binary, no fallback toast, no update prompt (assuming current binary >= latest release).
- [ ] **Activation when latest `ail-v*` release > resolved binary:** fires the "ail v0.4.X is available" prompt with three actions; **Install** kicks off `installBinary`, **Release Notes** opens the GitHub release page externally, **Not Now** dismisses.
- [ ] **Throttling:** within `updateCheckIntervalDays` of last check, no GitHub API call on activation; cached result reused. Run "ail Chat: Check for ail Updates" command — the API call fires regardless and updates the cache.
- [ ] **Set `ail-chat.updateCheckIntervalDays` to 0:** check fires every activation. Set to 30: check fires at most monthly.
- [ ] **Network down / GitHub API unreachable:** silent failure (console warn only); no toast, no error popup. Activation still completes.
- [ ] **Install `ail` to PATH via the action:** post-install, `clearPathCache()` is invoked by the existing `installBinary` command; next reload picks up `source === 'path'`.

Refs #185

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLjD5o646qQ87YaPPiNjQK)_