### PR TITLE
feat(vscode-ail-chat): ailMinVersion enforcement with Use Anyway override (PR 6 for #185)

### DIFF
--- a/vscode-ail-chat/package.json
+++ b/vscode-ail-chat/package.json
@@ -127,6 +127,11 @@
         "command": "ail-chat.checkForUpdates",
         "title": "ail Chat: Check for ail Updates",
         "category": "ail Chat"
+      },
+      {
+        "command": "ail-chat.useAnyway",
+        "title": "ail Chat: Toggle \"Use Anyway\" Override (Bypass Minimum Version)",
+        "category": "ail Chat"
       }
     ]
   },

--- a/vscode-ail-chat/src/binary.ts
+++ b/vscode-ail-chat/src/binary.ts
@@ -12,8 +12,8 @@
  * chosen version; the activation-time update check tells them when the
  * bundled / latest release is newer.
  *
- * Reports a warning (not an error) if the resolved binary's version is below
- * the minimum declared in package.json#config.ailMinVersion.
+ * The minimum-version gate (refusal + "Use Anyway" override + status bar)
+ * lives in `min-version-gate.ts`; this module is purely about resolution.
  */
 
 import * as fs from "fs";
@@ -144,19 +144,6 @@ export async function resolveBinary(
     const msg = `ail binary not executable at '${binaryPath}'. Set ail-chat.binaryPath to override.`;
     void vscode.window.showErrorMessage(msg);
     throw new Error(msg);
-  }
-
-  // Check minimum version
-  const pkgJson = JSON.parse(
-    fs.readFileSync(path.join(context.extensionPath, "package.json"), "utf-8")
-  ) as { config?: { ailMinVersion?: string } };
-  const minVersion = pkgJson.config?.ailMinVersion ?? "0.0.0";
-
-  if (!meetsMinVersion(version, minVersion)) {
-    void vscode.window.showWarningMessage(
-      `ail ${version} is below the minimum required version ${minVersion}. ` +
-        `Some features may not work correctly. Update ail or set ail.binaryPath.`
-    );
   }
 
   cached = { path: binaryPath, version, source };

--- a/vscode-ail-chat/src/extension.ts
+++ b/vscode-ail-chat/src/extension.ts
@@ -10,6 +10,13 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { clearBinaryCache, resolveBinary, ResolvedBinary } from './binary';
 import { checkForLatestRelease, compareVersions } from './update-checker';
+import {
+  getMinVersionState,
+  isAcceptable,
+  MinVersionStatusItem,
+  setUseAnyway,
+  MinVersionState,
+} from './min-version-gate';
 import { SessionManager } from './session-manager';
 import { ChatViewProvider } from './chat-view-provider';
 import { PipelineGraphPanel } from './pipeline-graph/PipelineGraphPanel';
@@ -21,6 +28,8 @@ import { PipelineStepsProvider } from './steps-tree-provider';
 import { createBinaryInstaller } from './platforms';
 
 let chatProvider: ChatViewProvider | undefined;
+let minVersionState: MinVersionState | undefined;
+let minVersionStatusItem: MinVersionStatusItem | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
@@ -40,6 +49,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
   const historyProvider = new RunHistoryProvider('', cwd);
   const stepsProvider = new PipelineStepsProvider();
+
+  minVersionStatusItem = new MinVersionStatusItem();
+  context.subscriptions.push(minVersionStatusItem);
 
   // Resolve binary path lazily for tree providers (falls back gracefully if binary not found)
   void resolveBinary(context).then((b) => {
@@ -88,6 +100,9 @@ export function activate(context: vscode.ExtensionContext): void {
         const installer = createBinaryInstaller();
         const result = await installer.install(binary.path);
         clearPathCache();
+        // Re-resolve so subsequent gate checks see the freshly-installed binary.
+        clearBinaryCache();
+        await refreshMinVersionGate(context);
         void vscode.window.showInformationMessage(result.message);
         if (chatProvider) void chatProvider.sendSetupStatus();
       } catch (err) {
@@ -98,7 +113,39 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   context.subscriptions.push(
+    vscode.commands.registerCommand('ail-chat.useAnyway', async () => {
+      const currentlyActive = minVersionState?.useAnywayActive ?? false;
+      if (currentlyActive) {
+        const choice = await vscode.window.showWarningMessage(
+          'Disable the "Use Anyway" override? The extension will refuse to start sessions with an outdated ail binary until you install an update.',
+          { modal: true },
+          'Disable'
+        );
+        if (choice === 'Disable') {
+          await setUseAnyway(context, false);
+          await refreshMinVersionGate(context);
+          void vscode.window.showInformationMessage('"Use Anyway" override disabled.');
+        }
+      } else {
+        const choice = await vscode.window.showWarningMessage(
+          'Bypass the minimum-version check? The extension may not work correctly with an outdated ail binary, and features may fail unpredictably.',
+          { modal: true, detail: `Required minimum: ${minVersionState?.minVersion ?? 'unknown'}\nResolved binary: ${minVersionState?.resolvedVersion ?? 'unknown'}` },
+          'Use Anyway'
+        );
+        if (choice === 'Use Anyway') {
+          await setUseAnyway(context, true);
+          await refreshMinVersionGate(context);
+          void vscode.window.showInformationMessage(
+            '"Use Anyway" override enabled. Run the same command to disable it later.'
+          );
+        }
+      }
+    })
+  );
+
+  context.subscriptions.push(
     vscode.commands.registerCommand('ail-chat.runInstallWizard', async () => {
+      if (!(await ensureMinVersionGate(context))) return;
       if (chatProvider) {
         await runInstallWizard(context, chatProvider, { bypassDismiss: true });
         void chatProvider.sendSetupStatus();
@@ -125,11 +172,13 @@ export function activate(context: vscode.ExtensionContext): void {
       void vscode.commands.executeCommand('workbench.view.extension.ail-chat-sidebar');
     }),
 
-    vscode.commands.registerCommand('ail-chat.newSession', () => {
+    vscode.commands.registerCommand('ail-chat.newSession', async () => {
+      if (!(await ensureMinVersionGate(context))) return;
       chatProvider?.reveal();
     }),
 
     vscode.commands.registerCommand('ail-chat.openPipelineGraph', async () => {
+      if (!(await ensureMinVersionGate(context))) return;
       // Pipeline resolution order:
       // 1. Active editor (if it's a .ail.yaml file)
       // 2. File picker dialog
@@ -177,6 +226,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
 /**
  * Run after a successful resolveBinary() during activation.
+ * - Compute and surface the minimum-version gate state (status bar + toast if below min).
  * - If using bundled fallback, surface an informational toast inviting installation to PATH.
  * - Run a throttled update check; if a newer ail-v* release is available, prompt to update.
  */
@@ -184,6 +234,13 @@ async function onBinaryResolved(
   context: vscode.ExtensionContext,
   binary: ResolvedBinary
 ): Promise<void> {
+  minVersionState = getMinVersionState(context, binary.version);
+  minVersionStatusItem?.update(minVersionState);
+
+  if (!isAcceptable(minVersionState)) {
+    void promptBelowMinVersion(minVersionState);
+  }
+
   if (binary.source === 'bundled') {
     void promptInstallBundledFallback();
   }
@@ -191,6 +248,56 @@ async function onBinaryResolved(
   const release = await checkForLatestRelease(context);
   if (release && compareVersions(release.version, binary.version) > 0) {
     void promptUpdateAvailable(release.version, binary.version);
+  }
+}
+
+/**
+ * Recompute the gate state (call after binary install or override toggle).
+ * Idempotent — safe to call as often as needed.
+ */
+async function refreshMinVersionGate(context: vscode.ExtensionContext): Promise<void> {
+  const binary = await resolveBinary(context).catch(() => undefined);
+  if (!binary) return;
+  minVersionState = getMinVersionState(context, binary.version);
+  minVersionStatusItem?.update(minVersionState);
+}
+
+/**
+ * Gate for session-starting commands. Returns true if execution should
+ * proceed; surfaces an actionable error toast and returns false otherwise.
+ */
+async function ensureMinVersionGate(context: vscode.ExtensionContext): Promise<boolean> {
+  // If we haven't resolved a binary yet, refresh once.
+  if (!minVersionState) {
+    await refreshMinVersionGate(context);
+  }
+  if (!minVersionState || isAcceptable(minVersionState)) return true;
+
+  const choice = await vscode.window.showErrorMessage(
+    `ail v${minVersionState.resolvedVersion} is below the minimum supported version (${minVersionState.minVersion}). Install an update to continue.`,
+    'Install Update',
+    'Use Anyway',
+    'Cancel'
+  );
+  if (choice === 'Install Update') {
+    void vscode.commands.executeCommand('ail-chat.installBinary');
+  } else if (choice === 'Use Anyway') {
+    void vscode.commands.executeCommand('ail-chat.useAnyway');
+  }
+  return false;
+}
+
+async function promptBelowMinVersion(state: MinVersionState): Promise<void> {
+  const choice = await vscode.window.showErrorMessage(
+    `ail v${state.resolvedVersion} is below the minimum supported version (${state.minVersion}). Sessions are blocked until you install an update.`,
+    'Install Update',
+    'Use Anyway',
+    'Dismiss'
+  );
+  if (choice === 'Install Update') {
+    void vscode.commands.executeCommand('ail-chat.installBinary');
+  } else if (choice === 'Use Anyway') {
+    void vscode.commands.executeCommand('ail-chat.useAnyway');
   }
 }
 

--- a/vscode-ail-chat/src/min-version-gate.ts
+++ b/vscode-ail-chat/src/min-version-gate.ts
@@ -1,0 +1,114 @@
+/**
+ * Minimum-version gate — refuses to start ail sessions when the resolved
+ * binary's version is below the minimum declared in package.json#config.ailMinVersion,
+ * unless the user has opted into the "Use Anyway" override.
+ *
+ * The override is persisted in globalState; users toggle it via the
+ * `ail-chat.useAnyway` command (with a modal confirmation).
+ *
+ * A status bar item with theme-respecting error / warning colours surfaces
+ * the state at all times when the binary is below minimum.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { meetsMinVersion } from "./binary";
+
+const USE_ANYWAY_KEY = "ail-chat.useAnywayBelowMinVersion";
+
+export interface MinVersionState {
+  /** Minimum version declared in package.json#config.ailMinVersion (e.g. "0.4.0"). */
+  minVersion: string;
+  /** Version of the resolved ail binary (e.g. "0.4.1"). */
+  resolvedVersion: string;
+  /** True if resolvedVersion >= minVersion. */
+  meetsMin: boolean;
+  /** True if the user has opted into the override. */
+  useAnywayActive: boolean;
+}
+
+/** Read the declared minVersion from the extension's own package.json. */
+export function readDeclaredMinVersion(extensionPath: string): string {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(extensionPath, "package.json"), "utf-8")
+    ) as { config?: { ailMinVersion?: string } };
+    return pkg.config?.ailMinVersion ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/** Compute the current min-version state from a resolved binary version. */
+export function getMinVersionState(
+  context: vscode.ExtensionContext,
+  resolvedVersion: string
+): MinVersionState {
+  const minVersion = readDeclaredMinVersion(context.extensionPath);
+  return {
+    minVersion,
+    resolvedVersion,
+    meetsMin: meetsMinVersion(resolvedVersion, minVersion),
+    useAnywayActive: context.globalState.get<boolean>(USE_ANYWAY_KEY, false),
+  };
+}
+
+/** True when the binary satisfies the gate (either meets minimum or override is active). */
+export function isAcceptable(state: MinVersionState): boolean {
+  return state.meetsMin || state.useAnywayActive;
+}
+
+/** Persist the override flag. */
+export async function setUseAnyway(
+  context: vscode.ExtensionContext,
+  enabled: boolean
+): Promise<void> {
+  await context.globalState.update(USE_ANYWAY_KEY, enabled);
+}
+
+/**
+ * A status bar item that mirrors the gate state.
+ *
+ *   - Hidden when meetsMin is true.
+ *   - Error-themed when below min and override inactive.
+ *   - Warning-themed when below min and override active (so users don't forget).
+ *
+ * Click action runs `ail-chat.installBinary` to surface the recovery path.
+ */
+export class MinVersionStatusItem implements vscode.Disposable {
+  private item: vscode.StatusBarItem;
+
+  constructor() {
+    this.item = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
+      100
+    );
+    this.item.command = "ail-chat.installBinary";
+  }
+
+  update(state: MinVersionState): void {
+    if (state.meetsMin) {
+      this.item.hide();
+      return;
+    }
+    if (state.useAnywayActive) {
+      this.item.text = `$(warning) ail v${state.resolvedVersion} (override)`;
+      this.item.tooltip = `ail v${state.resolvedVersion} is below the minimum supported version (${state.minVersion}). "Use Anyway" override is active. Click to install update.`;
+      this.item.backgroundColor = new vscode.ThemeColor(
+        "statusBarItem.warningBackground"
+      );
+    } else {
+      this.item.text = `$(error) ail v${state.resolvedVersion} < required ${state.minVersion}`;
+      this.item.tooltip = `ail v${state.resolvedVersion} is below the minimum supported version (${state.minVersion}). Click to install update.`;
+      this.item.backgroundColor = new vscode.ThemeColor(
+        "statusBarItem.errorBackground"
+      );
+    }
+    this.item.show();
+  }
+
+  dispose(): void {
+    this.item.dispose();
+  }
+}

--- a/vscode-ail-chat/test/min-version-gate.test.ts
+++ b/vscode-ail-chat/test/min-version-gate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { isAcceptable, MinVersionState } from "../src/min-version-gate";
+
+const baseState: MinVersionState = {
+  minVersion: "0.4.0",
+  resolvedVersion: "0.4.0",
+  meetsMin: true,
+  useAnywayActive: false,
+};
+
+describe("isAcceptable", () => {
+  it("returns true when binary meets the minimum", () => {
+    expect(isAcceptable({ ...baseState, meetsMin: true, useAnywayActive: false })).toBe(true);
+  });
+
+  it("returns true when override is active even if binary is below minimum", () => {
+    expect(
+      isAcceptable({
+        ...baseState,
+        resolvedVersion: "0.3.0",
+        meetsMin: false,
+        useAnywayActive: true,
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when binary is below minimum and override is not active", () => {
+    expect(
+      isAcceptable({
+        ...baseState,
+        resolvedVersion: "0.3.0",
+        meetsMin: false,
+        useAnywayActive: false,
+      })
+    ).toBe(false);
+  });
+
+  it("returns true when both meetsMin and useAnywayActive are true", () => {
+    expect(isAcceptable({ ...baseState, meetsMin: true, useAnywayActive: true })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

PR 6 (final piece) of the versioning work in #185. Hardens the minimum-version check from a passive warning into an enforced gate with a deliberate user override.

## Behaviour

When the resolved binary's version is below `package.json#config.ailMinVersion`:

1. **Theme-respecting status bar item** (left, priority 100):
   - Error background (`statusBarItem.errorBackground`) when blocked.
   - Warning background when "Use Anyway" override is active (so users don't forget they're running in an unsupported state).
   - Click action runs `ail-chat.installBinary`.
2. **Activation-time error toast**: `Install Update` / `Use Anyway` / `Dismiss`.
3. **Session-starting commands refuse to proceed**:
   - `ail-chat.newSession`
   - `ail-chat.openPipelineGraph`
   - `ail-chat.runInstallWizard`
   
   Each surfaces the same toast and aborts.
4. **New `ail-chat.useAnyway` command** toggles the persistent override (stored in `globalState`). Modal confirmation in both directions:
   - Enabling: warns about breakage.
   - Disabling: restores enforcement.

## Architecture

- **New `min-version-gate.ts`** owns the policy:
  - `MinVersionState` — `minVersion`, `resolvedVersion`, `meetsMin`, `useAnywayActive`.
  - `readDeclaredMinVersion()` — reads `package.json#config.ailMinVersion`.
  - `getMinVersionState()` — builds state from `globalState` + version.
  - `isAcceptable()` — pure check (meets min OR override active).
  - `setUseAnyway()` — persists override flag.
  - `MinVersionStatusItem` — `vscode.StatusBarItem` wrapper with theme colours; idempotent `update()`.
- **`binary.ts`** is now purely about resolution (removed the inline `showWarningMessage`; the gate module handles policy).
- **`extension.ts`**:
  - Instantiates the status item once on activation.
  - `onBinaryResolved()` computes initial state and surfaces the toast if blocked, alongside the existing bundled-fallback / update-check flows.
  - `refreshMinVersionGate()` recomputes after binary install or override toggle.
  - `ensureMinVersionGate()` wraps session-starting command handlers.

## Notable scope decisions

- **Did NOT intrude into `ChatViewProvider`.** The webview-driven session flow remains as-is; the gate covers explicit session-starting commands only. If a user starts typing in a chat with a below-min binary, the existing spawn-error path applies — no worse than today, and the prominent status bar + activation toast make the situation obvious. Adding deeper enforcement to the webview flow can be a follow-up if the gate proves insufficient.
- **`ailMinVersion` is currently `"0.0.1"`** (well below any real `ail` version), so this gate does not trip in practice today. It's machinery for future use when the extension starts requiring newer binary features.

## Verified

- [x] `npm run compile` clean (tsc).
- [x] `npm run lint` clean (eslint).
- [x] `npm test` — 234 vitest tests passing (was 230; +4 new for `isAcceptable`).

## Test plan

- [ ] Set `package.json#config.ailMinVersion` to a value above your installed ail (e.g. `"99.0.0"`), reload window:
  - [ ] Status bar item appears with error background, says `ail v<x> < required 99.0.0`.
  - [ ] Activation toast appears with three buttons.
  - [ ] Run `ail Chat: New Session` → blocked with the same toast.
  - [ ] Run `ail Chat: Open Pipeline Graph` → blocked.
  - [ ] Run `ail Chat: Toggle "Use Anyway" Override...` → modal confirmation; on accept, status bar switches to warning background; commands now succeed.
  - [ ] Run the same toggle command again → modal asks to disable; on accept, gate re-enforces.
  - [ ] Run `ail Chat: Install CLI Binary to PATH` → not blocked (the gate's recovery path).
  - [ ] Run `ail Chat: Check for ail Updates` → not blocked (helpful even when below min).
- [ ] Restore `ailMinVersion` to `"0.0.1"`, reload → status bar hidden, no toast, commands work normally.

Refs #185

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLjD5o646qQ87YaPPiNjQK)_