### PR TITLE
ci: authenticate release workflows with RELEASE_PAT for branch-protected main

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Check for in-scope changes since last release
         id: check

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Check for in-scope changes since last release
         id: check


### PR DESCRIPTION
## Summary

Tiny follow-up to the versioning work in #185 — wires the `RELEASE_PAT` secret into the preflight `checkout` step of both release workflows so the bump-commit + tag push to `main` can bypass branch protection.

## What this changes

Two-line addition to two workflow files. Only the preflight job's checkout needs the PAT (it's the one followed by `git push origin HEAD:main`); the downstream `build`, `package`, and `release` jobs are read-only and continue to use the default `GITHUB_TOKEN`.

```yaml
- uses: actions/checkout@v6
  with:
    fetch-depth: 0
    token: ${{ secrets.RELEASE_PAT }}     # new
```

## Setup required (already done by you)

- Fine-grained PAT scoped to `AlexChesser/ail` with **Contents: Read and write**.
- Stored as repo secret `RELEASE_PAT`.
- PAT-owner's role (e.g. **Repository admin** or **Maintain**) added to the bypass list of the ruleset on `main`.

## Verified

- [x] Both YAML files parse cleanly.
- [x] Diff is minimal (2 inserted lines, no other changes).

## Next step

Once this merges, **re-run the failed workflow** from the Actions tab (run ID `24934602186`). The bump-and-push step should now succeed, and the rest of the pipeline (build → release) should follow.

Refs #185

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLjD5o646qQ87YaPPiNjQK)_