### PR TITLE
ci: drop linux-arm64 + revert orphan 0.4.1 bump (mulligan to first real release)

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -124,11 +124,6 @@ jobs:
             binary: ail
             artifact: ail-x86_64-unknown-linux-musl
             use-cross: true
-          - target: aarch64-unknown-linux-musl
-            runner: ubuntu-latest
-            binary: ail
-            artifact: ail-aarch64-unknown-linux-musl
-            use-cross: true
           - target: x86_64-pc-windows-msvc
             runner: windows-latest
             binary: ail.exe
@@ -210,7 +205,6 @@ jobs:
             | macOS (Intel) | `ail-x86_64-apple-darwin` |
             | macOS (Apple Silicon) | `ail-aarch64-apple-darwin` |
             | Linux (x86_64, musl) | `ail-x86_64-unknown-linux-musl` |
-            | Linux (ARM64, musl) | `ail-aarch64-unknown-linux-musl` |
             | Windows (x86_64) | `ail-x86_64-pc-windows-msvc.exe` |
 
             ### Installation

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -149,9 +149,6 @@ jobs:
       - name: Package VSIX — linux x64
         run: vsce package --target linux-x64 --out ail-linux-x64-${{ needs.preflight.outputs.new_version }}.vsix
 
-      - name: Package VSIX — linux arm64
-        run: vsce package --target linux-arm64 --out ail-linux-arm64-${{ needs.preflight.outputs.new_version }}.vsix
-
       - name: Package VSIX — darwin x64
         run: vsce package --target darwin-x64 --out ail-darwin-x64-${{ needs.preflight.outputs.new_version }}.vsix
 
@@ -190,7 +187,6 @@ jobs:
             | macOS (Intel) | `ail-darwin-x64-${{ needs.preflight.outputs.new_version }}.vsix` |
             | macOS (Apple Silicon) | `ail-darwin-arm64-${{ needs.preflight.outputs.new_version }}.vsix` |
             | Linux (x64) | `ail-linux-x64-${{ needs.preflight.outputs.new_version }}.vsix` |
-            | Linux (ARM64) | `ail-linux-arm64-${{ needs.preflight.outputs.new_version }}.vsix` |
             | Windows (x64) | `ail-win32-x64-${{ needs.preflight.outputs.new_version }}.vsix` |
 
             The `ail` binary is bundled — no Rust toolchain required for installation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ail"
-version = "0.4.1"
+version = "0.4.0"
 dependencies = [
  "ail-core",
  "ail-init",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "ail-core"
-version = "0.4.1"
+version = "0.4.0"
 dependencies = [
  "ail-spec",
  "dirs",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "ail-init"
-version = "0.4.1"
+version = "0.4.0"
 dependencies = [
  "ail-core",
  "dialoguer",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "ail-spec"
-version = "0.4.1"
+version = "0.4.0"
 dependencies = [
  "glob",
 ]
@@ -1854,7 +1854,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stub-llm"
-version = "0.4.1"
+version = "0.4.0"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["ail-core", "ail", "ail-init", "ail-spec", "stub-llm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.0"
 edition = "2021"


### PR DESCRIPTION
## Summary

Two changes bundled per request:

1. **Drops `aarch64-unknown-linux-musl` from the release-binary matrix** and the matching `linux-arm64` VSIX from the extension release. The cross-compile (musl + bundled SQLite via cross-rs) was failing in [run 24935060937](https://github.com/AlexChesser/ail/actions/runs/24935060937), and Linux ARM64 was a net-new platform in the versioning work — it was never shipped before — so this restores the historical four-platform matrix.

2. **Reverts the auto-bump commit `2cf8549` (Cargo.toml 0.4.0 → 0.4.1)** that was created by the failed release run. No GitHub Release was produced for `ail-v0.4.1` because the build job failed before the release step ran. With this revert, `Cargo.toml` is back to `0.4.0`.

## What this leaves you with after merge

- Four-platform matrix:
  - macOS (Intel) — `x86_64-apple-darwin`
  - macOS (Apple Silicon) — `aarch64-apple-darwin`
  - Linux (x86_64, musl) — `x86_64-unknown-linux-musl`
  - Windows (x86_64) — `x86_64-pc-windows-msvc`
- `Cargo.toml` workspace version: `0.4.0`.

## Manual cleanup needed (out-of-band)

The orphan `ail-v0.4.1` tag still exists on origin. Tag deletion from a workflow context returned `HTTP 403` (likely a tag protection rule or scoped credentials). **Please delete the tag manually before dispatching the next release run** — otherwise the preflight will see the tag and skip the release as "no in-scope changes since `ail-v0.4.1`".

Either of these works:
- GitHub UI: https://github.com/AlexChesser/ail/tags → hover over `ail-v0.4.1` → trash icon.
- Local terminal (with your own auth): `git push --delete origin ail-v0.4.1`.

## Verified

- [x] `cargo build` clean.
- [x] `ail --version` reports `ail 0.4.0 (rev ffc81a2, built 2026-04-25)`.
- [x] Both YAML files parse cleanly.

## Next step

After this merges AND you delete the orphan tag, dispatch `release-binary.yml` with `bump_type=patch` to produce `ail-v0.4.1` as your first real binary release. Then dispatch `release-extension.yml` to produce `vscode-ail-v0.1.1` bundling that binary.

Refs #185