### PR TITLE
Redesign pipeline discovery with per-project state and template namespacing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,11 +143,16 @@ See `ARCHITECTURE.md` for the full rationale including the 15-factor design tabl
 ## Pipeline File Discovery Order (SPEC §3.1)
 
 1. Explicit `--pipeline <path>` flag
-2. `.ail.yaml` in CWD
-3. `.ail/default.yaml` in CWD
-4. `~/.config/ail/default.yaml`
+2. Per-project last-used pointer: `~/.ail/projects/<sha1_of_cwd>/last_pipeline` (written by `config::load()` on every successful parse)
+3. Project default marker: `<cwd>/.ail/default` (single-line text file, contents = path relative to `.ail/`)
+4. Subdir enumeration: `<cwd>/.ail/<sub>/*.{yaml,yml}` at depth 2 — single candidate auto-resolves; multiple candidates trigger an interactive picker on TTY or a non-zero exit on non-TTY
+5. `~/.config/ail/default.yaml`
 
 If nothing found → passthrough mode (safe zero-config default).
+
+Sub-pipeline files at depth ≥ 3 (e.g. `.ail/oh-my-ail/agents/foo.ail.yaml`) are
+intentionally invisible to the picker — they remain addressable via `--pipeline`
+or by writing their relative path into `.ail/default`.
 
 ## --once Flow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "ail-spec",
  "assert_cmd",
  "clap",
+ "dialoguer",
  "dirs",
  "interprocess",
  "predicates",
@@ -404,7 +405,9 @@ checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
  "shell-words",
+ "tempfile",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]

--- a/ail-core/CLAUDE.md
+++ b/ail-core/CLAUDE.md
@@ -7,7 +7,8 @@ Consumed by `ail` (the binary) and future language-server / SDK targets.
 
 | Module | Responsibility |
 |---|---|
-| `config/discovery.rs` | Walk the four-step file resolution order (SPEC §3.1) |
+| `config/discovery.rs` | Project-aware pipeline file resolution (SPEC §3.1) — `discover() -> DiscoveryResult` (Resolved/Ambiguous/None) and `discover_all()` for picker UIs. Enumerates `.ail/<sub>/*.{yaml,yml}` at depth 2; deeper files are sub-pipelines and invisible to the picker. |
+| `config/project_state.rs` | Per-project pipeline-selection state — marker file (`<cwd>/.ail/default`) and last-used pointer (`~/.ail/projects/<sha1>/last_pipeline`). Reads are silent; writes are best-effort. |
 | `config/dto.rs` | Serde-deserialised raw structs — derives `Deserialize` |
 | `config/domain.rs` | Validated domain types — no `Deserialize` derives |
 | `config/validation/mod.rs` | `validate()` entry point, `cfg_err!` macro, `tools_to_policy` helper |

--- a/ail-core/src/config/discovery.rs
+++ b/ail-core/src/config/discovery.rs
@@ -1,103 +1,185 @@
-use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-/// Locate a pipeline file using the four-step discovery order from SPEC §3.1.
-/// Returns the first path that exists, or `None` if no file is found.
-/// Does not read or parse the file.
-pub fn discover(explicit: Option<PathBuf>) -> Option<PathBuf> {
-    // 1. Explicit path passed via --pipeline flag.
-    if let Some(path) = explicit {
-        return Some(path);
-    }
+use super::project_state;
 
-    // 2. `.ail.yaml` in the current working directory — return absolute path so
-    //    parent() in the executor always yields a usable directory (SPEC §9).
-    if let Ok(cwd) = std::env::current_dir() {
-        let candidate = cwd.join(".ail.yaml");
-        if candidate.exists() {
-            return Some(candidate);
-        }
+const AIL_DIRNAME: &str = ".ail";
 
-        // 3. `.ail/default.yaml` in the current working directory.
-        let candidate = cwd.join(".ail/default.yaml");
-        if candidate.exists() {
-            return Some(candidate);
-        }
-    }
-
-    // 4. `~/.config/ail/default.yaml`
-    if let Some(home) = dirs::home_dir() {
-        let user_default = home.join(".config/ail/default.yaml");
-        if user_default.exists() {
-            return Some(user_default);
-        }
-    }
-
-    None
-}
-
-/// A discovered pipeline file with a display name derived from its filename stem.
-#[derive(Debug, Clone)]
+/// A discovered pipeline file with a display name derived from its location
+/// under `.ail/`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PipelineEntry {
-    /// Display name shown in the picker (filename stem, e.g. `"code-review"`).
+    /// Display name shown in the picker. For `.ail/<sub>/default.yaml` this is
+    /// just the subdir name (`<sub>`); for `.ail/<sub>/<other>.yaml` it is
+    /// `<sub>/<other>` (the inner extension is stripped, including any double
+    /// extension like `.ail.yaml`).
     pub name: String,
-    /// Absolute or relative path used to load the pipeline.
+    /// Absolute path used to load the pipeline.
     pub path: PathBuf,
 }
 
-/// Discover all available pipeline files across the standard search locations.
-///
-/// Scan order (CWD entries take precedence over `~/.config/ail/` by name):
-/// 1. `.ail.yaml` in CWD — named `"default"`
-/// 2. `*.yaml` / `*.yml` in `.ail/` in CWD — named by file stem
-/// 3. `*.yaml` / `*.yml` in `~/.config/ail/` — named by file stem
-///
-/// Entries are deduplicated by name (first occurrence wins) and sorted alphabetically.
-/// Does not read or parse any files.
-pub fn discover_all() -> Vec<PipelineEntry> {
-    // Use a BTreeMap keyed by name for deduplication + sorted output.
-    let mut by_name: BTreeMap<String, PathBuf> = BTreeMap::new();
-
-    // 1. `.ail.yaml` in CWD.
-    let cwd_ail_yaml = PathBuf::from(".ail.yaml");
-    if cwd_ail_yaml.exists() {
-        by_name.entry("default".to_string()).or_insert(cwd_ail_yaml);
-    }
-
-    // 2. `.ail/*.yaml` and `.ail/*.yml` in CWD.
-    scan_dir(PathBuf::from(".ail"), &mut by_name);
-
-    // 3. `~/.config/ail/*.yaml` and `~/.config/ail/*.yml`.
-    if let Some(home) = dirs::home_dir() {
-        scan_dir(home.join(".config/ail"), &mut by_name);
-    }
-
-    by_name
-        .into_iter()
-        .map(|(name, path)| PipelineEntry { name, path })
-        .collect()
+/// Outcome of pipeline discovery — see [`discover`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscoveryResult {
+    /// A single pipeline path resolved unambiguously. Caller should `load()` it.
+    Resolved(PathBuf),
+    /// Multiple candidate pipelines exist and no preference is recorded
+    /// (no last-used pointer, no marker file). Callers in TTY contexts should
+    /// present these to the user; non-TTY callers should error with the list.
+    Ambiguous(Vec<PipelineEntry>),
+    /// No pipeline found anywhere on the search path. Caller falls through to
+    /// passthrough mode.
+    None,
 }
 
-/// Scan a directory for `.yaml` / `.yml` files, inserting entries that do not
-/// already exist in `map` (first-occurrence-wins deduplication).
-fn scan_dir(dir: PathBuf, map: &mut BTreeMap<String, PathBuf>) {
-    let entries = match std::fs::read_dir(&dir) {
-        Ok(e) => e,
-        Err(_) => return, // Directory missing or unreadable — silently skip.
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
+/// Locate a pipeline file using the project-aware discovery order.
+///
+/// Order:
+///   1. Explicit `--pipeline <path>` (whatever the caller passed).
+///   2. Per-project last-used pointer (`~/.ail/projects/<sha1>/last_pipeline`).
+///   3. Project default marker (`<cwd>/.ail/default`).
+///   4. Subdir enumeration of `<cwd>/.ail/<sub>/*.{yaml,yml}` (depth 2):
+///      - exactly one candidate → Resolved
+///      - multiple candidates    → Ambiguous (caller picks)
+///      - zero candidates        → fall through
+///   5. User-global default `~/.config/ail/default.yaml`.
+///   6. Otherwise → None (passthrough).
+///
+/// Files deeper than depth 2 (e.g. `.ail/<sub>/agents/foo.ail.yaml`) are
+/// invisible to the picker by design — they're sub-pipelines, not entry points.
+/// They remain reachable via `--pipeline` or by writing their relative path
+/// into the marker file.
+pub fn discover(explicit: Option<PathBuf>) -> DiscoveryResult {
+    if let Some(path) = explicit {
+        return DiscoveryResult::Resolved(path);
+    }
+
+    if let Some(p) = project_state::read_last_used() {
+        return DiscoveryResult::Resolved(p);
+    }
+
+    if let Ok(cwd) = std::env::current_dir() {
+        let ail_dir = cwd.join(AIL_DIRNAME);
+
+        if let Some(p) = project_state::read_marker(&ail_dir) {
+            return DiscoveryResult::Resolved(p);
         }
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        if ext != "yaml" && ext != "yml" {
-            continue;
-        }
-        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-            map.entry(stem.to_string()).or_insert(path);
+
+        let candidates = scan_subdirs(&ail_dir);
+        match candidates.len() {
+            0 => {} // fall through to user-global
+            1 => {
+                return DiscoveryResult::Resolved(
+                    candidates.into_iter().next().expect("len==1").path,
+                );
+            }
+            _ => return DiscoveryResult::Ambiguous(candidates),
         }
     }
+
+    if let Some(home) = dirs::home_dir() {
+        let user_default = home.join(".config/ail/default.yaml");
+        if user_default.exists() {
+            return DiscoveryResult::Resolved(user_default);
+        }
+    }
+
+    DiscoveryResult::None
+}
+
+/// List every pipeline candidate under `<cwd>/.ail/`. Includes the per-project
+/// user-global default as a `~/.config/ail/<stem>.yaml` entry only if the CWD
+/// has no candidates of its own. Used by callers that want to render their
+/// own picker UI.
+pub fn discover_all() -> Vec<PipelineEntry> {
+    let mut out = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        out.extend(scan_subdirs(&cwd.join(AIL_DIRNAME)));
+    }
+    if out.is_empty() {
+        if let Some(home) = dirs::home_dir() {
+            scan_user_global(&home.join(".config/ail"), &mut out);
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+/// Walk `<ail_dir>/<sub>/*.{yaml,yml}` to depth 2 and return one entry per file.
+fn scan_subdirs(ail_dir: &Path) -> Vec<PipelineEntry> {
+    let mut out = Vec::new();
+    let Ok(subdirs) = std::fs::read_dir(ail_dir) else {
+        return out;
+    };
+    for entry in subdirs.flatten() {
+        let sub_path = entry.path();
+        if !sub_path.is_dir() {
+            continue;
+        }
+        let Some(sub_name) = sub_path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Ok(files) = std::fs::read_dir(&sub_path) else {
+            continue;
+        };
+        for f in files.flatten() {
+            let p = f.path();
+            if !p.is_file() {
+                continue;
+            }
+            if !is_yaml(&p) {
+                continue;
+            }
+            let stem = display_stem(&p);
+            let display_name = if stem == "default" {
+                sub_name.to_string()
+            } else {
+                format!("{sub_name}/{stem}")
+            };
+            out.push(PipelineEntry {
+                name: display_name,
+                path: p,
+            });
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+fn scan_user_global(dir: &Path, out: &mut Vec<PipelineEntry>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if !p.is_file() || !is_yaml(&p) {
+            continue;
+        }
+        let stem = display_stem(&p);
+        out.push(PipelineEntry {
+            name: stem,
+            path: p,
+        });
+    }
+}
+
+fn is_yaml(p: &Path) -> bool {
+    matches!(
+        p.extension().and_then(|e| e.to_str()),
+        Some("yaml") | Some("yml")
+    )
+}
+
+/// Strip `.yaml`/`.yml`, then a trailing `.ail` if present, so
+/// `code-review.ail.yaml` → `code-review`.
+fn display_stem(p: &Path) -> String {
+    let stem = p
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+    stem.strip_suffix(".ail")
+        .map(str::to_string)
+        .unwrap_or(stem)
 }
 
 #[cfg(test)]
@@ -109,251 +191,189 @@ mod tests {
     /// Serialise all CWD-mutating tests through this mutex so they don't race.
     static TEST_CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    fn write_pipeline(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            path,
+            "version: \"0.0.1\"\npipeline:\n  - id: x\n    prompt: hi\n",
+        )
+        .unwrap();
+    }
+
     // ── discover() ───────────────────────────────────────────────────────────
 
     #[test]
-    fn explicit_path_existing_file_is_returned() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("custom.ail.yaml");
-        std::fs::write(&path, "").expect("write");
-
-        let result = discover(Some(path.clone()));
-        assert_eq!(result, Some(path));
+    fn explicit_path_is_returned_as_resolved() {
+        let path = PathBuf::from("/some/explicit/path.ail.yaml");
+        assert_eq!(
+            discover(Some(path.clone())),
+            DiscoveryResult::Resolved(path)
+        );
     }
 
     #[test]
-    fn explicit_path_missing_file_is_returned_as_is() {
-        // discover() returns the explicit path without checking existence
-        // (the load() function is responsible for producing the file-not-found error)
-        let path = PathBuf::from("/does/not/exist/pipeline.ail.yaml");
-        let result = discover(Some(path.clone()));
-        assert_eq!(result, Some(path));
-    }
-
-    #[test]
-    fn no_pipeline_files_returns_none() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
+    fn no_files_returns_none() {
+        let _g = TEST_CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
 
         let result = discover(None);
 
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-        assert!(result.is_none());
+        std::env::set_current_dir(&original).unwrap();
+        // No CWD candidates; ~/.config/ail/default.yaml may or may not exist on
+        // the host. We only assert that we did NOT pick anything from the tempdir.
+        if let DiscoveryResult::Resolved(p) = result {
+            assert!(!p.starts_with(dir.path()));
+        }
     }
 
     #[test]
-    fn ail_yaml_in_cwd_is_discovered() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
+    fn single_subdir_with_default_yaml_resolves() {
+        let _g = TEST_CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        write_pipeline(&canonical.join(".ail/starter/default.yaml"));
 
-        let yaml_path = dir.path().join(".ail.yaml");
-        std::fs::write(&yaml_path, "").expect("write");
-
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&canonical).unwrap();
         let result = discover(None);
+        std::env::set_current_dir(&original).unwrap();
 
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-        assert!(result.is_some());
-        assert!(result.unwrap().ends_with(".ail.yaml"));
+        match result {
+            DiscoveryResult::Resolved(p) => {
+                assert_eq!(p, canonical.join(".ail/starter/default.yaml"))
+            }
+            other => panic!("expected Resolved, got {other:?}"),
+        }
     }
 
     #[test]
-    fn ail_default_yaml_discovered_when_ail_yaml_absent() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
+    fn multiple_subdir_candidates_returns_ambiguous() {
+        let _g = TEST_CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        write_pipeline(&canonical.join(".ail/starter/default.yaml"));
+        write_pipeline(&canonical.join(".ail/oh-my-ail/.ohmy.ail.yaml"));
 
-        let ail_dir = dir.path().join(".ail");
-        std::fs::create_dir(&ail_dir).expect("mkdir");
-        let default_yaml = ail_dir.join("default.yaml");
-        std::fs::write(&default_yaml, "").expect("write");
-
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&canonical).unwrap();
         let result = discover(None);
+        std::env::set_current_dir(&original).unwrap();
 
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-        assert!(result.is_some());
-        assert!(result.unwrap().ends_with(".ail/default.yaml"));
+        match result {
+            DiscoveryResult::Ambiguous(entries) => {
+                let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+                // `.ohmy.ail.yaml` → stem `.ohmy.ail`, then strip `.ail` → `.ohmy`
+                assert!(
+                    names.contains(&"starter"),
+                    "expected `starter` in {names:?}"
+                );
+                assert!(
+                    names.iter().any(|n| n.starts_with("oh-my-ail/")),
+                    "expected an oh-my-ail/* entry in {names:?}"
+                );
+            }
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
     }
 
     #[test]
-    fn ail_yaml_takes_precedence_over_ail_default_yaml() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
+    fn marker_overrides_subdir_enumeration() {
+        let _g = TEST_CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        write_pipeline(&canonical.join(".ail/starter/default.yaml"));
+        write_pipeline(&canonical.join(".ail/oh-my-ail/.ohmy.ail.yaml"));
+        // Even though there are two candidates, the marker forces a choice.
+        std::fs::write(canonical.join(".ail/default"), "oh-my-ail/.ohmy.ail.yaml").unwrap();
 
-        // Create both .ail.yaml and .ail/default.yaml
-        let yaml_path = dir.path().join(".ail.yaml");
-        std::fs::write(&yaml_path, "").expect("write .ail.yaml");
-        let ail_dir = dir.path().join(".ail");
-        std::fs::create_dir(&ail_dir).expect("mkdir");
-        let default_yaml = ail_dir.join("default.yaml");
-        std::fs::write(&default_yaml, "").expect("write default.yaml");
-
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&canonical).unwrap();
         let result = discover(None);
+        std::env::set_current_dir(&original).unwrap();
 
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-        assert!(result.is_some());
-        assert!(result.unwrap().ends_with(".ail.yaml"));
+        match result {
+            DiscoveryResult::Resolved(p) => {
+                assert_eq!(p, canonical.join(".ail/oh-my-ail/.ohmy.ail.yaml"))
+            }
+            other => panic!("expected Resolved, got {other:?}"),
+        }
     }
 
     #[test]
-    fn explicit_path_takes_precedence_over_cwd_files() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
+    fn deep_subpipeline_files_are_invisible_to_picker() {
+        let _g = TEST_CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        // depth-2 entry: visible
+        write_pipeline(&canonical.join(".ail/oh-my-ail/.ohmy.ail.yaml"));
+        // depth-3 sub-pipeline: hidden
+        write_pipeline(&canonical.join(".ail/oh-my-ail/agents/atlas.ail.yaml"));
 
-        // .ail.yaml exists in cwd too
-        let yaml_path = dir.path().join(".ail.yaml");
-        std::fs::write(&yaml_path, "").expect("write");
-        let explicit_path = dir.path().join("explicit.ail.yaml");
-        std::fs::write(&explicit_path, "").expect("write explicit");
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&canonical).unwrap();
+        let result = discover(None);
+        std::env::set_current_dir(&original).unwrap();
 
-        let result = discover(Some(explicit_path.clone()));
-
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-        assert_eq!(result, Some(explicit_path));
+        // Only one candidate at depth 2, so it resolves directly.
+        match result {
+            DiscoveryResult::Resolved(p) => {
+                assert_eq!(p, canonical.join(".ail/oh-my-ail/.ohmy.ail.yaml"))
+            }
+            other => panic!("expected Resolved, got {other:?}"),
+        }
     }
 
     // ── discover_all() ───────────────────────────────────────────────────────
 
     #[test]
-    fn discover_all_returns_empty_when_no_files_present() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
+    fn discover_all_returns_subdir_pipelines_with_display_names() {
+        let _g = TEST_CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        write_pipeline(&canonical.join(".ail/starter/default.yaml"));
+        write_pipeline(&canonical.join(".ail/superpowers/code-review.ail.yaml"));
+        write_pipeline(&canonical.join(".ail/superpowers/brainstorming.ail.yaml"));
 
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&canonical).unwrap();
         let entries = discover_all();
+        std::env::set_current_dir(&original).unwrap();
 
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-        // Only system ~/.config/ail/ entries can appear; in a clean tempdir there are none
-        // from CWD. We can't assert empty if user has ~/.config/ail/ files, so only check
-        // that none of the returned entries point inside our tempdir.
-        for entry in entries {
-            assert!(
-                !entry.path.starts_with(dir.path()),
-                "unexpected entry from tempdir: {:?}",
-                entry.path
-            );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"starter"));
+        assert!(names.contains(&"superpowers/code-review"));
+        assert!(names.contains(&"superpowers/brainstorming"));
+        // Sorted alphabetically.
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn discover_all_returns_empty_in_clean_cwd() {
+        let _g = TEST_CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let entries = discover_all();
+        std::env::set_current_dir(&original).unwrap();
+        // Host's ~/.config/ail/ is the only possible source of entries.
+        for e in entries {
+            assert!(!e.path.starts_with(dir.path()));
         }
     }
 
-    #[test]
-    fn discover_all_includes_ail_yaml_as_default() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
-
-        std::fs::write(dir.path().join(".ail.yaml"), "").expect("write");
-
-        let entries = discover_all();
-
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
-        assert!(names.contains(&"default"), "expected 'default' entry");
-    }
+    // ── helpers ──────────────────────────────────────────────────────────────
 
     #[test]
-    fn discover_all_includes_ail_dir_yaml_files() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
-
-        let ail_dir = dir.path().join(".ail");
-        std::fs::create_dir(&ail_dir).expect("mkdir");
-        std::fs::write(ail_dir.join("code-review.yaml"), "").expect("write");
-        std::fs::write(ail_dir.join("test-gen.yml"), "").expect("write");
-
-        let entries = discover_all();
-
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
-        assert!(names.contains(&"code-review"), "expected 'code-review'");
-        assert!(names.contains(&"test-gen"), "expected 'test-gen'");
-    }
-
-    #[test]
-    fn discover_all_deduplicates_by_name_cwd_wins() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
-
-        // Create a CWD entry named "review" under .ail/
-        let ail_dir = dir.path().join(".ail");
-        std::fs::create_dir(&ail_dir).expect("mkdir");
-        let cwd_review = ail_dir.join("review.yaml");
-        std::fs::write(&cwd_review, "# cwd version").expect("write cwd");
-
-        let entries = discover_all();
-
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-
-        // There should be exactly one entry named "review"
-        let review_entries: Vec<_> = entries.iter().filter(|e| e.name == "review").collect();
+    fn display_stem_strips_double_extension() {
         assert_eq!(
-            review_entries.len(),
-            1,
-            "expected exactly one 'review' entry"
+            display_stem(Path::new("code-review.ail.yaml")),
+            "code-review"
         );
-    }
-
-    #[test]
-    fn discover_all_returns_sorted_names() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
-
-        let ail_dir = dir.path().join(".ail");
-        std::fs::create_dir(&ail_dir).expect("mkdir");
-        std::fs::write(ail_dir.join("zebra.yaml"), "").expect("write");
-        std::fs::write(ail_dir.join("alpha.yaml"), "").expect("write");
-        std::fs::write(ail_dir.join("mango.yaml"), "").expect("write");
-
-        let entries = discover_all();
-
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-
-        // discover_all() uses relative paths for .ail/ entries (".ail/alpha.yaml", etc.)
-        // Filter to only the entries whose names we created (alpha/mango/zebra).
-        let known = ["alpha", "mango", "zebra"];
-        let local_names: Vec<&str> = entries
-            .iter()
-            .filter(|e| known.contains(&e.name.as_str()))
-            .map(|e| e.name.as_str())
-            .collect();
-
-        assert_eq!(local_names, vec!["alpha", "mango", "zebra"]);
-    }
-
-    #[test]
-    fn discover_all_ignores_non_yaml_files() {
-        let _guard = TEST_CWD_LOCK.lock().expect("lock");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let original_cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("chdir");
-
-        let ail_dir = dir.path().join(".ail");
-        std::fs::create_dir(&ail_dir).expect("mkdir");
-        std::fs::write(ail_dir.join("valid.yaml"), "").expect("write yaml");
-        std::fs::write(ail_dir.join("ignored.txt"), "").expect("write txt");
-        std::fs::write(ail_dir.join("ignored.json"), "").expect("write json");
-
-        let entries = discover_all();
-
-        std::env::set_current_dir(&original_cwd).expect("restore cwd");
-
-        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
-        assert!(names.contains(&"valid"), "expected 'valid'");
-        assert!(!names.contains(&"ignored"), "unexpected 'ignored' entry");
+        assert_eq!(display_stem(Path::new("default.yaml")), "default");
+        assert_eq!(display_stem(Path::new(".ohmy.ail.yaml")), ".ohmy");
     }
 }

--- a/ail-core/src/config/mod.rs
+++ b/ail-core/src/config/mod.rs
@@ -2,9 +2,10 @@
 
 pub mod discovery;
 pub mod domain;
-pub use discovery::PipelineEntry;
+pub use discovery::{DiscoveryResult, PipelineEntry};
 pub mod dto;
 pub mod inheritance;
+pub mod project_state;
 pub mod validation;
 
 use std::path::Path;
@@ -29,7 +30,14 @@ pub fn load(path: &Path) -> Result<Pipeline, AilError> {
     let mut chain = Vec::new();
     let dto = inheritance::load_with_inheritance(&abs_source, &mut chain)?;
 
-    validate(dto, abs_source)
+    let pipeline = validate(dto, abs_source.clone())?;
+
+    // Successful load — record this path so the next invocation in this project
+    // auto-resumes the user's choice. Best-effort; failures are logged and
+    // swallowed by `project_state::write_last_used`.
+    project_state::write_last_used(&abs_source);
+
+    Ok(pipeline)
 }
 
 #[cfg(test)]

--- a/ail-core/src/config/project_state.rs
+++ b/ail-core/src/config/project_state.rs
@@ -1,0 +1,146 @@
+//! Per-project pipeline-selection state.
+//!
+//! Two artifacts live here:
+//!
+//! 1. **Marker file** (`<cwd>/.ail/default`): a single-line text file naming the
+//!    default pipeline for this project. Contents are a path relative to `.ail/`,
+//!    e.g. `starter/default.yaml` or `oh-my-ail/.ohmy.ail.yaml`. Hand-editable.
+//!
+//! 2. **Last-used pointer** (`~/.ail/projects/<sha1_of_cwd>/last_pipeline`): the
+//!    absolute path of the most recently successfully-loaded pipeline. Written
+//!    by `config::load()` after a clean parse; read by `discovery::discover()`
+//!    on subsequent invocations to auto-resume the user's last choice.
+//!
+//! Both reads are silent — a missing or stale pointer falls through to the next
+//! discovery rung. Both writes are best-effort; failures are logged via
+//! `tracing::warn!` but never propagated, since persistence is convenience, not
+//! correctness.
+
+use std::path::{Path, PathBuf};
+
+use crate::session::log_provider::project_dir;
+
+const MARKER_FILENAME: &str = "default";
+const LAST_USED_FILENAME: &str = "last_pipeline";
+
+/// Read the project default-pipeline marker, if present.
+///
+/// `ail_dir` is the project's `.ail/` directory. The marker file lives at
+/// `<ail_dir>/default` and contains a single relative path. The returned
+/// `PathBuf` is `<ail_dir>/<marker_contents>`, or `None` if the marker is
+/// absent, empty, or points at a file that no longer exists.
+pub fn read_marker(ail_dir: &Path) -> Option<PathBuf> {
+    let marker = ail_dir.join(MARKER_FILENAME);
+    let contents = std::fs::read_to_string(&marker).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let resolved = ail_dir.join(trimmed);
+    if !resolved.exists() {
+        tracing::warn!(
+            marker = %marker.display(),
+            target = %resolved.display(),
+            "ail/default marker points at a missing file — ignoring"
+        );
+        return None;
+    }
+    Some(resolved)
+}
+
+/// Read the per-project last-used pipeline pointer, if present.
+///
+/// Returns `None` if the pointer file is missing, empty, or points at a path
+/// that no longer exists on disk.
+pub fn read_last_used() -> Option<PathBuf> {
+    let pointer = project_dir().join(LAST_USED_FILENAME);
+    let contents = std::fs::read_to_string(&pointer).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(trimmed);
+    if !path.exists() {
+        tracing::debug!(
+            pointer = %pointer.display(),
+            target = %path.display(),
+            "last_pipeline pointer is stale — ignoring"
+        );
+        return None;
+    }
+    Some(path)
+}
+
+/// Persist the most recently successfully-loaded pipeline path so the next
+/// invocation in this project auto-resumes it. Best-effort: errors are logged
+/// and swallowed.
+pub fn write_last_used(path: &Path) {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+    let dir = project_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(dir = %dir.display(), error = %e, "failed to create project state dir");
+        return;
+    }
+    let pointer = dir.join(LAST_USED_FILENAME);
+    if let Err(e) = std::fs::write(&pointer, abs.to_string_lossy().as_bytes()) {
+        tracing::warn!(pointer = %pointer.display(), error = %e, "failed to write last_pipeline pointer");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_returns_none_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(read_marker(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn marker_returns_none_when_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(MARKER_FILENAME), "").unwrap();
+        assert!(read_marker(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn marker_returns_none_when_target_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(MARKER_FILENAME), "starter/default.yaml").unwrap();
+        // Target file doesn't exist — marker silently returns None.
+        assert!(read_marker(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn marker_resolves_relative_path_when_target_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("starter")).unwrap();
+        std::fs::write(tmp.path().join("starter/default.yaml"), "x").unwrap();
+        std::fs::write(tmp.path().join(MARKER_FILENAME), "starter/default.yaml").unwrap();
+
+        let resolved = read_marker(tmp.path()).unwrap();
+        assert_eq!(resolved, tmp.path().join("starter/default.yaml"));
+    }
+
+    #[test]
+    fn marker_trims_whitespace() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("starter")).unwrap();
+        std::fs::write(tmp.path().join("starter/default.yaml"), "x").unwrap();
+        std::fs::write(
+            tmp.path().join(MARKER_FILENAME),
+            "  starter/default.yaml  \n",
+        )
+        .unwrap();
+
+        let resolved = read_marker(tmp.path()).unwrap();
+        assert_eq!(resolved, tmp.path().join("starter/default.yaml"));
+    }
+}

--- a/ail-core/tests/spec/s03_file_format.rs
+++ b/ail-core/tests/spec/s03_file_format.rs
@@ -1,44 +1,69 @@
 mod s3_1_discovery {
-    use ail_core::config::discovery::discover;
+    use ail_core::config::discovery::{discover, DiscoveryResult};
     use std::path::PathBuf;
+
+    fn write_pipeline(path: &std::path::Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            path,
+            "version: \"0.0.1\"\npipeline:\n  - id: x\n    prompt: hi\n",
+        )
+        .unwrap();
+    }
 
     #[test]
     fn explicit_path_takes_precedence() {
         let explicit = PathBuf::from("/some/explicit/path.ail.yaml");
         let result = discover(Some(explicit.clone()));
-        assert_eq!(result, Some(explicit));
+        assert_eq!(result, DiscoveryResult::Resolved(explicit));
     }
 
     #[test]
-    fn returns_none_when_no_file_found() {
+    fn empty_cwd_does_not_resolve_inside_tempdir() {
         let _cwd_guard = crate::spec::CWD_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
         let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
         let result = discover(None);
         std::env::set_current_dir(original_dir).unwrap();
-        assert!(result.is_none());
+        // Host's ~/.config/ail/default.yaml could match — assert only that no
+        // result points back into our scratch tempdir.
+        if let DiscoveryResult::Resolved(p) = result {
+            assert!(!p.starts_with(tmp.path()));
+        }
     }
 
     #[test]
-    fn falls_back_to_ail_yaml_in_cwd() {
+    fn single_template_subdir_resolves_to_its_pipeline() {
         let _cwd_guard = crate::spec::CWD_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
-        // Canonicalize to resolve symlinks (macOS: /tmp -> /private/tmp) so the
-        // expected path matches what current_dir() returns inside discover().
-        let tmp_path = tmp.path().canonicalize().unwrap();
-        let ail_yaml = tmp_path.join(".ail.yaml");
-        std::fs::write(
-            &ail_yaml,
-            "version: \"0.0.1\"\npipeline:\n  - id: s\n    prompt: x\n",
-        )
-        .unwrap();
+        let canonical = tmp.path().canonicalize().unwrap();
+        let pipeline = canonical.join(".ail/starter/default.yaml");
+        write_pipeline(&pipeline);
         let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&tmp_path).unwrap();
+        std::env::set_current_dir(&canonical).unwrap();
         let result = discover(None);
         std::env::set_current_dir(original_dir).unwrap();
-        // Discovery now returns absolute paths so parent() is always usable (SPEC §9).
-        assert_eq!(result, Some(ail_yaml));
+        assert_eq!(result, DiscoveryResult::Resolved(pipeline));
+    }
+
+    #[test]
+    fn multiple_template_subdirs_returns_ambiguous() {
+        let _cwd_guard = crate::spec::CWD_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let canonical = tmp.path().canonicalize().unwrap();
+        write_pipeline(&canonical.join(".ail/starter/default.yaml"));
+        write_pipeline(&canonical.join(".ail/oh-my-ail/.ohmy.ail.yaml"));
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&canonical).unwrap();
+        let result = discover(None);
+        std::env::set_current_dir(original_dir).unwrap();
+        match result {
+            DiscoveryResult::Ambiguous(entries) => {
+                assert!(entries.len() >= 2, "expected ≥2 candidates");
+            }
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
     }
 }
 
@@ -46,44 +71,35 @@ mod s3_1_discover_all {
     use ail_core::config::discovery::discover_all;
 
     #[test]
-    fn returns_empty_when_no_yaml_files_present() {
+    fn returns_only_user_global_when_cwd_has_no_pipelines() {
         let _cwd_guard = crate::spec::CWD_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
         let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
         let result = discover_all();
         std::env::set_current_dir(original_dir).unwrap();
-        assert!(result.is_empty());
+        // Host may have ~/.config/ail entries — assert only that nothing came from our tempdir.
+        for e in result {
+            assert!(!e.path.starts_with(tmp.path()));
+        }
     }
 
     #[test]
-    fn finds_ail_yaml_in_cwd_as_default() {
-        let _cwd_guard = crate::spec::CWD_LOCK.lock().unwrap();
-        let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(tmp.path().join(".ail.yaml"), "x").unwrap();
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(tmp.path()).unwrap();
-        let result = discover_all();
-        std::env::set_current_dir(original_dir).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].name, "default");
-    }
-
-    #[test]
-    fn finds_yaml_files_in_ail_directory() {
+    fn finds_pipelines_under_template_subdirs() {
         let _cwd_guard = crate::spec::CWD_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
         let ail_dir = tmp.path().join(".ail");
-        std::fs::create_dir(&ail_dir).unwrap();
-        std::fs::write(ail_dir.join("code-review.yaml"), "x").unwrap();
-        std::fs::write(ail_dir.join("incident.yaml"), "x").unwrap();
+        std::fs::create_dir_all(ail_dir.join("ops")).unwrap();
+        std::fs::create_dir_all(ail_dir.join("review")).unwrap();
+        std::fs::write(ail_dir.join("ops/default.yaml"), "x").unwrap();
+        std::fs::write(ail_dir.join("review/code-review.ail.yaml"), "x").unwrap();
         let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
         let result = discover_all();
         std::env::set_current_dir(original_dir).unwrap();
         let names: Vec<&str> = result.iter().map(|e| e.name.as_str()).collect();
-        assert!(names.contains(&"code-review"));
-        assert!(names.contains(&"incident"));
+        assert!(names.contains(&"ops"));
+        assert!(names.contains(&"review/code-review"));
     }
 
     #[test]
@@ -91,34 +107,18 @@ mod s3_1_discover_all {
         let _cwd_guard = crate::spec::CWD_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
         let ail_dir = tmp.path().join(".ail");
-        std::fs::create_dir(&ail_dir).unwrap();
-        std::fs::write(ail_dir.join("zebra.yaml"), "x").unwrap();
-        std::fs::write(ail_dir.join("alpha.yaml"), "x").unwrap();
-        std::fs::write(ail_dir.join("middle.yaml"), "x").unwrap();
+        std::fs::create_dir_all(ail_dir.join("zebra")).unwrap();
+        std::fs::create_dir_all(ail_dir.join("alpha")).unwrap();
+        std::fs::create_dir_all(ail_dir.join("middle")).unwrap();
+        std::fs::write(ail_dir.join("zebra/default.yaml"), "x").unwrap();
+        std::fs::write(ail_dir.join("alpha/default.yaml"), "x").unwrap();
+        std::fs::write(ail_dir.join("middle/default.yaml"), "x").unwrap();
         let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
         let result = discover_all();
         std::env::set_current_dir(original_dir).unwrap();
         let names: Vec<&str> = result.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["alpha", "middle", "zebra"]);
-    }
-
-    #[test]
-    fn cwd_entry_wins_over_home_config_on_duplicate_name() {
-        let _cwd_guard = crate::spec::CWD_LOCK.lock().unwrap();
-        // We can't easily test ~/.config/ail/ in isolation, but we can verify
-        // that the .ail/ directory entry takes precedence by checking deduplication
-        // logic: if the same name appears twice, only one entry is returned.
-        let tmp = tempfile::tempdir().unwrap();
-        let ail_dir = tmp.path().join(".ail");
-        std::fs::create_dir(&ail_dir).unwrap();
-        std::fs::write(ail_dir.join("code-review.yaml"), "x").unwrap();
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(tmp.path()).unwrap();
-        let result = discover_all();
-        std::env::set_current_dir(original_dir).unwrap();
-        let code_review_count = result.iter().filter(|e| e.name == "code-review").count();
-        assert_eq!(code_review_count, 1);
     }
 }
 

--- a/ail-init/src/install.rs
+++ b/ail-init/src/install.rs
@@ -4,9 +4,10 @@ use crate::template::Template;
 use ail_core::error::AilError;
 use std::path::{Path, PathBuf};
 
-/// All templates install under `$CWD/.ail/` — matches the discovery rule for
-/// `.ail/default.yaml` and keeps the user's CWD root uncluttered regardless
-/// of how many files a template ships.
+/// All templates install under `$CWD/.ail/<template_name>/` so multiple
+/// templates can coexist without collision. The leading `.ail/` keeps the
+/// project root uncluttered; the per-template subdirectory means two templates
+/// that both ship `default.yaml` (every starter does) no longer fight.
 pub const INSTALL_SUBDIR: &str = ".ail";
 
 pub struct InstallPlan {
@@ -22,7 +23,7 @@ pub struct InstallFile {
 }
 
 pub fn plan(template: &Template, cwd: &Path) -> InstallPlan {
-    let install_root = cwd.join(INSTALL_SUBDIR);
+    let install_root = cwd.join(INSTALL_SUBDIR).join(&template.meta.name);
     let mut files = Vec::with_capacity(template.files.len());
     let mut conflicts = Vec::new();
 
@@ -109,10 +110,13 @@ mod tests {
     fn plan_computes_install_root_and_paths() {
         let tmp = tempfile::tempdir().unwrap();
         let p = plan(&sample_template(), tmp.path());
-        assert_eq!(p.install_root, tmp.path().join(".ail"));
+        assert_eq!(p.install_root, tmp.path().join(".ail/t"));
         assert_eq!(p.files.len(), 2);
-        assert_eq!(p.files[0].absolute_path, tmp.path().join(".ail/a.yaml"));
-        assert_eq!(p.files[1].absolute_path, tmp.path().join(".ail/sub/b.yaml"));
+        assert_eq!(p.files[0].absolute_path, tmp.path().join(".ail/t/a.yaml"));
+        assert_eq!(
+            p.files[1].absolute_path,
+            tmp.path().join(".ail/t/sub/b.yaml")
+        );
         assert!(p.conflicts.is_empty());
     }
 
@@ -122,11 +126,11 @@ mod tests {
         let p = plan(&sample_template(), tmp.path());
         apply(&p, false).unwrap();
         assert_eq!(
-            std::fs::read(tmp.path().join(".ail/a.yaml")).unwrap(),
+            std::fs::read(tmp.path().join(".ail/t/a.yaml")).unwrap(),
             b"a\n"
         );
         assert_eq!(
-            std::fs::read(tmp.path().join(".ail/sub/b.yaml")).unwrap(),
+            std::fs::read(tmp.path().join(".ail/t/sub/b.yaml")).unwrap(),
             b"b\n"
         );
     }
@@ -134,19 +138,19 @@ mod tests {
     #[test]
     fn conflicts_detected_when_target_exists() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".ail")).unwrap();
-        std::fs::write(tmp.path().join(".ail/a.yaml"), b"existing").unwrap();
+        std::fs::create_dir_all(tmp.path().join(".ail/t")).unwrap();
+        std::fs::write(tmp.path().join(".ail/t/a.yaml"), b"existing").unwrap();
 
         let p = plan(&sample_template(), tmp.path());
         assert_eq!(p.conflicts.len(), 1);
-        assert_eq!(p.conflicts[0], tmp.path().join(".ail/a.yaml"));
+        assert_eq!(p.conflicts[0], tmp.path().join(".ail/t/a.yaml"));
     }
 
     #[test]
     fn apply_refuses_without_force_and_preserves_existing_contents() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".ail")).unwrap();
-        std::fs::write(tmp.path().join(".ail/a.yaml"), b"existing").unwrap();
+        std::fs::create_dir_all(tmp.path().join(".ail/t")).unwrap();
+        std::fs::write(tmp.path().join(".ail/t/a.yaml"), b"existing").unwrap();
 
         let p = plan(&sample_template(), tmp.path());
         let err = apply(&p, false).unwrap_err();
@@ -154,7 +158,7 @@ mod tests {
         assert!(err.detail().contains("--force"));
 
         assert_eq!(
-            std::fs::read(tmp.path().join(".ail/a.yaml")).unwrap(),
+            std::fs::read(tmp.path().join(".ail/t/a.yaml")).unwrap(),
             b"existing"
         );
     }
@@ -162,15 +166,35 @@ mod tests {
     #[test]
     fn apply_overwrites_with_force() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".ail")).unwrap();
-        std::fs::write(tmp.path().join(".ail/a.yaml"), b"existing").unwrap();
+        std::fs::create_dir_all(tmp.path().join(".ail/t")).unwrap();
+        std::fs::write(tmp.path().join(".ail/t/a.yaml"), b"existing").unwrap();
 
         let p = plan(&sample_template(), tmp.path());
         apply(&p, true).unwrap();
 
         assert_eq!(
-            std::fs::read(tmp.path().join(".ail/a.yaml")).unwrap(),
+            std::fs::read(tmp.path().join(".ail/t/a.yaml")).unwrap(),
             b"a\n"
         );
+    }
+
+    #[test]
+    fn distinct_template_names_install_to_separate_subdirs() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let mut t1 = sample_template();
+        t1.meta.name = "alpha".to_string();
+        let mut t2 = sample_template();
+        t2.meta.name = "beta".to_string();
+
+        let p1 = plan(&t1, tmp.path());
+        apply(&p1, false).unwrap();
+        let p2 = plan(&t2, tmp.path());
+        // Even though both ship a.yaml, no conflicts — they live in separate subdirs.
+        assert!(p2.conflicts.is_empty());
+        apply(&p2, false).unwrap();
+
+        assert!(tmp.path().join(".ail/alpha/a.yaml").exists());
+        assert!(tmp.path().join(".ail/beta/a.yaml").exists());
     }
 }

--- a/ail-init/src/lib.rs
+++ b/ail-init/src/lib.rs
@@ -131,8 +131,9 @@ fn print_dry_run(template: &Template, plan: &install::InstallPlan) {
             ""
         };
         println!(
-            "  {}/{}{}",
+            "  {}/{}/{}{}",
             install::INSTALL_SUBDIR,
+            template.meta.name,
             f.relative_path.display(),
             marker
         );
@@ -155,8 +156,9 @@ fn print_success(template: &Template, plan: &install::InstallPlan) {
     );
     for f in &plan.files {
         println!(
-            "  {}/{}",
+            "  {}/{}/{}",
             install::INSTALL_SUBDIR,
+            template.meta.name,
             f.relative_path.display()
         );
     }

--- a/ail-init/tests/run.rs
+++ b/ail-init/tests/run.rs
@@ -31,18 +31,21 @@ fn run_with_unknown_template_errors() {
 fn starter_installs_expected_files() {
     let tmp = tempfile::tempdir().unwrap();
     ail_init::run_in_cwd(args(Some("starter"), false, false), tmp.path()).unwrap();
-    assert!(tmp.path().join(".ail/default.yaml").exists());
-    assert!(tmp.path().join(".ail/README.md").exists());
+    assert!(tmp.path().join(".ail/starter/default.yaml").exists());
+    assert!(tmp.path().join(".ail/starter/README.md").exists());
 }
 
 #[test]
 fn oma_alias_installs_oh_my_ail() {
     let tmp = tempfile::tempdir().unwrap();
     ail_init::run_in_cwd(args(Some("oma"), false, false), tmp.path()).unwrap();
-    // oh-my-ail's main entry point.
-    assert!(tmp.path().join(".ail/.ohmy.ail.yaml").exists());
+    // oh-my-ail's main entry point — note: namespaced under .ail/oh-my-ail/.
+    assert!(tmp.path().join(".ail/oh-my-ail/.ohmy.ail.yaml").exists());
     // One of the agent pipelines — proves subdir preservation.
-    assert!(tmp.path().join(".ail/agents/hephaestus.ail.yaml").exists());
+    assert!(tmp
+        .path()
+        .join(".ail/oh-my-ail/agents/hephaestus.ail.yaml")
+        .exists());
 }
 
 #[test]
@@ -50,7 +53,10 @@ fn superpowers_installs_all_pipelines_under_ail() {
     let tmp = tempfile::tempdir().unwrap();
     ail_init::run_in_cwd(args(Some("superpowers"), false, false), tmp.path()).unwrap();
     // A representative pipeline from the superpowers set.
-    assert!(tmp.path().join(".ail/brainstorming.ail.yaml").exists());
+    assert!(tmp
+        .path()
+        .join(".ail/superpowers/brainstorming.ail.yaml")
+        .exists());
     // Crucially: NOT at the CWD root.
     assert!(!tmp.path().join("brainstorming.ail.yaml").exists());
 }
@@ -68,14 +74,14 @@ fn refuses_overwrite_without_force() {
     // First install — succeeds.
     ail_init::run_in_cwd(args(Some("starter"), false, false), tmp.path()).unwrap();
 
-    // Seed conflicting content.
-    std::fs::write(tmp.path().join(".ail/default.yaml"), b"user-edited").unwrap();
+    // Seed conflicting content under the namespaced location.
+    std::fs::write(tmp.path().join(".ail/starter/default.yaml"), b"user-edited").unwrap();
 
     // Second install without --force fails and preserves the edit.
     let err = ail_init::run_in_cwd(args(Some("starter"), false, false), tmp.path()).unwrap_err();
     assert!(err.detail().contains("already exist"));
     assert_eq!(
-        std::fs::read(tmp.path().join(".ail/default.yaml")).unwrap(),
+        std::fs::read(tmp.path().join(".ail/starter/default.yaml")).unwrap(),
         b"user-edited"
     );
 }
@@ -84,11 +90,23 @@ fn refuses_overwrite_without_force() {
 fn overwrites_with_force() {
     let tmp = tempfile::tempdir().unwrap();
     ail_init::run_in_cwd(args(Some("starter"), false, false), tmp.path()).unwrap();
-    std::fs::write(tmp.path().join(".ail/default.yaml"), b"user-edited").unwrap();
+    std::fs::write(tmp.path().join(".ail/starter/default.yaml"), b"user-edited").unwrap();
 
     ail_init::run_in_cwd(args(Some("starter"), true, false), tmp.path()).unwrap();
-    let restored = std::fs::read_to_string(tmp.path().join(".ail/default.yaml")).unwrap();
+    let restored = std::fs::read_to_string(tmp.path().join(".ail/starter/default.yaml")).unwrap();
     assert!(restored.contains("Starter — Invocation-only pipeline"));
+}
+
+#[test]
+fn distinct_templates_install_side_by_side() {
+    // The whole point of namespacing — two templates that both ship `default.yaml`
+    // (or any other shared filename) install cleanly without --force.
+    let tmp = tempfile::tempdir().unwrap();
+    ail_init::run_in_cwd(args(Some("starter"), false, false), tmp.path()).unwrap();
+    ail_init::run_in_cwd(args(Some("oma"), false, false), tmp.path()).unwrap();
+
+    assert!(tmp.path().join(".ail/starter/default.yaml").exists());
+    assert!(tmp.path().join(".ail/oh-my-ail/.ohmy.ail.yaml").exists());
 }
 
 #[allow(dead_code)]
@@ -130,15 +148,15 @@ files:
     ail_init::run_in_cwd(args(Some(&manifest_url), false, false), tmp.path()).unwrap();
 
     assert_eq!(
-        std::fs::read(tmp.path().join(".ail/default.yaml")).unwrap(),
+        std::fs::read(tmp.path().join(".ail/remote-demo/default.yaml")).unwrap(),
         default_yaml
     );
     assert_eq!(
-        std::fs::read(tmp.path().join(".ail/agents/atlas.ail.yaml")).unwrap(),
+        std::fs::read(tmp.path().join(".ail/remote-demo/agents/atlas.ail.yaml")).unwrap(),
         atlas_yaml
     );
     // Manifest is metadata, never installed.
-    assert!(!tmp.path().join(".ail/template.yaml").exists());
+    assert!(!tmp.path().join(".ail/remote-demo/template.yaml").exists());
 }
 
 #[test]
@@ -192,14 +210,18 @@ files:
 
     let manifest_url = format!("{}/template.yaml", server.url());
     let tmp = tempfile::tempdir().unwrap();
-    std::fs::create_dir_all(tmp.path().join(".ail")).unwrap();
-    std::fs::write(tmp.path().join(".ail/default.yaml"), b"user-edited").unwrap();
+    std::fs::create_dir_all(tmp.path().join(".ail/remote-demo")).unwrap();
+    std::fs::write(
+        tmp.path().join(".ail/remote-demo/default.yaml"),
+        b"user-edited",
+    )
+    .unwrap();
 
     let err =
         ail_init::run_in_cwd(args(Some(&manifest_url), false, false), tmp.path()).unwrap_err();
     assert!(err.detail().contains("already exist"));
     assert_eq!(
-        std::fs::read(tmp.path().join(".ail/default.yaml")).unwrap(),
+        std::fs::read(tmp.path().join(".ail/remote-demo/default.yaml")).unwrap(),
         b"user-edited"
     );
 }

--- a/ail/Cargo.toml
+++ b/ail/Cargo.toml
@@ -13,6 +13,7 @@ ail-core = { path = "../ail-core" }
 ail-init = { path = "../ail-init" }
 ail-spec = { path = "../ail-spec" }
 clap = { version = "4", features = ["derive"] }
+dialoguer = "0.11"
 dirs = "5"
 serde_json = "1"
 tracing = "0.1"

--- a/ail/src/discover.rs
+++ b/ail/src/discover.rs
@@ -1,0 +1,65 @@
+//! UI-aware wrapper around `ail_core::config::discovery`.
+//!
+//! `ail-core` is intentionally headless: it returns `DiscoveryResult::Ambiguous`
+//! and lets the caller decide what to do with multiple candidates. This module
+//! adds the binary-only behaviours: an interactive picker (TTY) and a typed
+//! error listing (non-TTY).
+
+use std::io::IsTerminal;
+use std::path::PathBuf;
+
+use ail_core::config::discovery::{discover, DiscoveryResult, PipelineEntry};
+
+/// Resolve the discovery result to a single path, prompting the user if there
+/// are multiple candidates and we're attached to a TTY. Returns `None` for the
+/// passthrough case (no pipeline found anywhere). On non-TTY ambiguity, prints
+/// a candidate list to stderr and exits 1 — there is no safe default.
+pub fn resolve_or_passthrough(explicit: Option<PathBuf>) -> Option<PathBuf> {
+    match discover(explicit) {
+        DiscoveryResult::Resolved(p) => Some(p),
+        DiscoveryResult::None => None,
+        DiscoveryResult::Ambiguous(entries) => Some(resolve_ambiguous(entries)),
+    }
+}
+
+fn resolve_ambiguous(entries: Vec<PipelineEntry>) -> PathBuf {
+    if std::io::stdin().is_terminal() {
+        match pick(&entries) {
+            Some(idx) => {
+                entries
+                    .into_iter()
+                    .nth(idx)
+                    .expect("dialoguer index in range")
+                    .path
+            }
+            None => {
+                // User cancelled the picker.
+                eprintln!("Cancelled.");
+                std::process::exit(0);
+            }
+        }
+    } else {
+        eprintln!(
+            "Multiple pipelines found in .ail/. Pick one with --pipeline <path>, \
+             or set a default by writing the relative path to .ail/default. Candidates:"
+        );
+        for e in &entries {
+            eprintln!("  {}  ({})", e.name, e.path.display());
+        }
+        std::process::exit(1);
+    }
+}
+
+fn pick(entries: &[PipelineEntry]) -> Option<usize> {
+    let items: Vec<String> = entries
+        .iter()
+        .map(|e| format!("{}  ({})", e.name, e.path.display()))
+        .collect();
+    dialoguer::Select::new()
+        .with_prompt("Select a pipeline to run")
+        .items(&items)
+        .default(0)
+        .interact_opt()
+        .ok()
+        .flatten()
+}

--- a/ail/src/main.rs
+++ b/ail/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod command;
 mod control_bridge;
 mod delete;
+mod discover;
 mod dry_run;
 mod help;
 mod log;
@@ -24,7 +25,7 @@ use command::CommandOutcome;
 /// Discover and load a pipeline from an optional explicit path, falling back to
 /// automatic discovery and then passthrough mode. Exits with code 1 on load error.
 fn load_pipeline(explicit_path: Option<std::path::PathBuf>) -> ail_core::config::domain::Pipeline {
-    match ail_core::config::discovery::discover(explicit_path) {
+    match discover::resolve_or_passthrough(explicit_path) {
         Some(ref path) => match ail_core::config::load(path) {
             Ok(p) => p,
             Err(e) => {

--- a/ail/src/validate.rs
+++ b/ail/src/validate.rs
@@ -1,3 +1,5 @@
+use ail_core::config::discovery::{discover, DiscoveryResult};
+
 use crate::cli::OutputFormat;
 use crate::command::CommandOutcome;
 
@@ -15,9 +17,9 @@ impl ValidateCommand {
     }
 
     pub fn execute(&self) -> CommandOutcome {
-        let path = match ail_core::config::discovery::discover(self.pipeline_path.clone()) {
-            Some(p) => p,
-            None => {
+        let path = match discover(self.pipeline_path.clone()) {
+            DiscoveryResult::Resolved(p) => p,
+            DiscoveryResult::None => {
                 match self.output_format {
                     OutputFormat::Json => {
                         println!(
@@ -30,6 +32,31 @@ impl ValidateCommand {
                     }
                     OutputFormat::Text => {
                         eprintln!("No pipeline file found.");
+                    }
+                }
+                return CommandOutcome::ExitCode(1);
+            }
+            DiscoveryResult::Ambiguous(entries) => {
+                let names: Vec<String> = entries
+                    .iter()
+                    .map(|e| format!("{} ({})", e.name, e.path.display()))
+                    .collect();
+                let msg = format!(
+                    "Multiple pipelines found; pass --pipeline <path>. Candidates: {}",
+                    names.join(", ")
+                );
+                match self.output_format {
+                    OutputFormat::Json => {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "valid": false,
+                                "errors": [{"message": msg, "error_type": "ail:config/file-not-found"}]
+                            })
+                        );
+                    }
+                    OutputFormat::Text => {
+                        eprintln!("{msg}");
                     }
                 }
                 return CommandOutcome::ExitCode(1);

--- a/spec/core/s03-file-format.md
+++ b/spec/core/s03-file-format.md
@@ -32,11 +32,18 @@ If no prompt and no subcommand are given, `ail` prints a short usage hint and ex
 `ail` looks for a pipeline definition file using the following resolution order. The first match wins.
 
 1. Explicit path passed via `--pipeline <path>` CLI flag.
-2. `.ail.yaml` in the current working directory.
-3. `.ail/default.yaml` in the current working directory.
-4. `~/.config/ail/default.yaml` (user-level default).
+2. **Per-project last-used pointer** — `~/.ail/projects/<sha1_of_cwd>/last_pipeline`. Written by `config::load()` after every successful parse, so the next invocation in this project auto-resumes the user's choice. Stale pointers (target deleted) are silently ignored.
+3. **Project default marker** — `<cwd>/.ail/default`, a single-line text file naming the default pipeline as a path relative to `.ail/` (e.g. `starter/default.yaml`). Hand-editable, commits cleanly, replaces a heavier YAML config for the one-line "which pipeline is the default" question.
+4. **Subdir enumeration** — every `<cwd>/.ail/<sub>/*.{yaml,yml}` file (depth 2 only):
+   - Exactly one candidate → resolve and use it.
+   - Multiple candidates → present an interactive picker on a TTY; print the candidate list to stderr and exit 1 on a non-TTY.
+   - Zero candidates → fall through.
+   Files deeper than depth 2 (e.g. `.ail/<sub>/agents/foo.ail.yaml`) are sub-pipelines, not entry points; they remain reachable via `--pipeline` or by writing their relative path into the marker file.
+5. `~/.config/ail/default.yaml` (user-level default).
 
 If no file is found, `ail` runs in **passthrough mode**: the underlying agent behaves exactly as if `ail` were not present. This is the zero-configuration safe default.
+
+When a user picks a pipeline interactively, the resulting load writes rule 2's last-used pointer, so subsequent invocations skip the picker and resume the same pipeline.
 
 The discovery order is significant beyond file resolution — it is the **authority order** that governs hook precedence in inherited pipelines. See §8.
 

--- a/spec/core/s32-init-command.md
+++ b/spec/core/s32-init-command.md
@@ -28,19 +28,23 @@ explicitly in non-interactive contexts.
 
 ## §32.2 Install Target
 
-Every template installs under `$CWD/.ail/`, preserving the template's internal
-directory structure. The `.ail/` prefix is a hard rule — it is not configurable
-per template. Rationale:
+Every template installs under `$CWD/.ail/<template_name>/`, preserving the
+template's internal directory structure under the namespaced subdirectory.
+Both the `.ail/` prefix and the per-template subdirectory are hard rules —
+neither is configurable per template. Rationale:
 
-- Discovery rule 3 (§3.1) already picks up `.ail/default.yaml` automatically,
-  so the starter template is runnable the moment install completes.
+- The per-template subdirectory means **multiple templates coexist without
+  collision**. Two templates that both ship `default.yaml` install cleanly
+  side-by-side. Discovery (§3.1) enumerates every `.ail/<sub>/*.yaml` it finds
+  and presents a picker when more than one is present.
 - Templates that ship many files (e.g. superpowers with 10 pipelines +
-  prompts) do not pollute the user's project root.
+  prompts) do not pollute the user's project root or the shared `.ail/` root.
 - A single install rule keeps manifest authoring trivial — authors do not
-  declare install paths.
+  declare install paths; the subdirectory name is `manifest.name`.
 
-Files inside a template's source directory map 1:1 to `$CWD/.ail/<relative-path>`.
-The template's manifest file (`template.yaml`) is never installed.
+Files inside a template's source directory map 1:1 to
+`$CWD/.ail/<template_name>/<relative-path>`. The template's manifest file
+(`template.yaml`) is never installed.
 
 ## §32.3 Bundled Templates
 


### PR DESCRIPTION
## Summary

This PR fundamentally redesigns how `ail` discovers and manages pipeline files. It introduces per-project state tracking (last-used pipeline and project default markers), implements template namespacing under `.ail/<template_name>/`, and adds an interactive picker for ambiguous discovery scenarios.

## Key Changes

### Pipeline Discovery (§3.1 Redesign)
- **New discovery order** (5 steps instead of 4):
  1. Explicit `--pipeline <path>` flag
  2. Per-project last-used pointer (`~/.ail/projects/<sha1_of_cwd>/last_pipeline`)
  3. Project default marker (`.ail/default` file)
  4. Subdir enumeration of `.ail/<sub>/*.{yaml,yml}` (depth 2 only)
  5. User-global default (`~/.config/ail/default.yaml`)

- **New `DiscoveryResult` enum** replaces `Option<PathBuf>`:
  - `Resolved(PathBuf)` — single unambiguous pipeline
  - `Ambiguous(Vec<PipelineEntry>)` — multiple candidates (caller picks)
  - `None` — no pipeline found (passthrough mode)

- **Depth-2 visibility rule**: Only files at `.ail/<sub>/*.yaml` are discoverable by the picker. Deeper files (e.g., `.ail/<sub>/agents/foo.yaml`) remain reachable via `--pipeline` or marker files but are hidden from enumeration by design.

### Per-Project State (`project_state.rs`)
- **Marker file** (`.ail/default`): Hand-editable text file naming the default pipeline for a project (relative path like `starter/default.yaml`)
- **Last-used pointer** (`~/.ail/projects/<sha1_of_cwd>/last_pipeline`): Auto-written by `config::load()` after successful parse; auto-read on next invocation to resume user's last choice
- Both reads are silent (missing/stale pointers fall through); both writes are best-effort (failures logged, not propagated)

### Template Namespacing
- Templates now install under `.ail/<template_name>/` instead of directly under `.ail/`
- Enables multiple templates to coexist without collision (e.g., two templates shipping `default.yaml` no longer conflict)
- Updated `ail-init` install logic and all test fixtures to reflect new paths

### Interactive Picker (`ail/src/discover.rs`)
- New `resolve_or_passthrough()` wrapper around core discovery
- **TTY context**: Presents ambiguous candidates via `dialoguer::Select` interactive picker
- **Non-TTY context**: Prints candidate list to stderr and exits 1 (no safe default in automation)
- Integrated into `ail` binary and `validate` command

### Display Names
- Entries under `.ail/<sub>/default.yaml` display as just `<sub>`
- Entries under `.ail/<sub>/<other>.yaml` display as `<sub>/<other>` (with `.ail` suffix stripped from stem)
- Example: `.ail/superpowers/code-review.ail.yaml` → `superpowers/code-review`

## Implementation Details

- `discover()` now returns `DiscoveryResult` instead of `Option<PathBuf>`, making ambiguity explicit
- `discover_all()` simplified: returns only CWD candidates if present, falls back to user-global only if CWD is empty
- Marker file resolution is relative to `.ail/` directory, allowing portable project configurations
- Last-used pointer stores absolute paths for robustness
- All discovery operations are silent on missing/stale files (no error propagation)
- Comprehensive test coverage for all discovery paths, marker resolution, and display name generation

## Spec Updates

- SPEC §3.1 updated with new 5-step discovery order and depth-2 visibility rule
- SPEC §32.2 updated to document per-template subdirectory requirement
- CLAUDE.md updated with new discovery flow and module responsibilities

https://claude.ai/code/session_018yWqULVb67wus9DKiuM7fs