### PR TITLE
Remove deprecated session.invocation_prompt alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,8 +192,6 @@ or by writing their relative path into `.ail/default`.
 | `{{ step.<join_id>.<dep_id>.response }}` | Full structured output of a named dependency in a structured join (SPEC §29.5) |
 | `{{ step.<join_id>.<dep_id>.<field> }}` | Specific field within a namespaced structured dependency output (SPEC §29.5) |
 
-Note: `{{ session.invocation_prompt }}` and `{{ session.invocation.prompt }}` are supported aliases for `{{ step.invocation.prompt }}` in the implementation but are deprecated — prefer the canonical form.
-
 Unresolved variables **abort with a typed error** — never silently empty.
 
 ## Code Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ or by writing their relative path into `.ail/default`.
 | `{{ step.<join_id>.<dep_id>.response }}` | Full structured output of a named dependency in a structured join (SPEC §29.5) |
 | `{{ step.<join_id>.<dep_id>.<field> }}` | Specific field within a namespaced structured dependency output (SPEC §29.5) |
 
-Note: `{{ session.invocation_prompt }}` is a supported alias for `{{ step.invocation.prompt }}` in the implementation but is deprecated — prefer the canonical form.
+Note: `{{ session.invocation_prompt }}` and `{{ session.invocation.prompt }}` are supported aliases for `{{ step.invocation.prompt }}` in the implementation but are deprecated — prefer the canonical form.
 
 Unresolved variables **abort with a typed error** — never silently empty.
 

--- a/ail-core/src/template.rs
+++ b/ail-core/src/template.rs
@@ -40,12 +40,7 @@ fn unresolved(detail: impl Into<String>) -> AilError {
 
 fn resolve_variable(variable: &str, session: &Session) -> Result<String, AilError> {
     match variable {
-        // `step.invocation.prompt` is the canonical form (SPEC §11).
-        // `session.invocation_prompt` and `session.invocation.prompt` are
-        // deprecated aliases retained for backwards compatibility.
-        "step.invocation.prompt" | "session.invocation_prompt" | "session.invocation.prompt" => {
-            Ok(session.invocation_prompt.clone())
-        }
+        "step.invocation.prompt" => Ok(session.invocation_prompt.clone()),
 
         "step.invocation.response" => session
             .turn_log

--- a/ail-core/src/template.rs
+++ b/ail-core/src/template.rs
@@ -40,7 +40,10 @@ fn unresolved(detail: impl Into<String>) -> AilError {
 
 fn resolve_variable(variable: &str, session: &Session) -> Result<String, AilError> {
     match variable {
-        "session.invocation_prompt" | "step.invocation.prompt" => {
+        // `step.invocation.prompt` is the canonical form (SPEC §11).
+        // `session.invocation_prompt` and `session.invocation.prompt` are
+        // deprecated aliases retained for backwards compatibility.
+        "step.invocation.prompt" | "session.invocation_prompt" | "session.invocation.prompt" => {
             Ok(session.invocation_prompt.clone())
         }
 

--- a/ail-core/tests/fixtures/invalid_invocation_not_first.ail.yaml
+++ b/ail-core/tests/fixtures/invalid_invocation_not_first.ail.yaml
@@ -3,4 +3,4 @@ pipeline:
   - id: some_step
     prompt: "Do something"
   - id: invocation
-    prompt: "{{ session.invocation_prompt }}"
+    prompt: "{{ step.invocation.prompt }}"

--- a/ail-core/tests/fixtures/named_pipeline_with_prompt.ail.yaml
+++ b/ail-core/tests/fixtures/named_pipeline_with_prompt.ail.yaml
@@ -3,7 +3,7 @@ version: "0.0.1"
 pipelines:
   review:
     - id: do_review
-      prompt: "{{ session.invocation_prompt }}"
+      prompt: "{{ step.invocation.prompt }}"
 
 pipeline:
   - id: invoke_review

--- a/ail-core/tests/fixtures/tool_permissions.ail.yaml
+++ b/ail-core/tests/fixtures/tool_permissions.ail.yaml
@@ -1,7 +1,7 @@
 version: "0.0.1"
 pipeline:
   - id: invocation
-    prompt: "{{ session.invocation_prompt }}"
+    prompt: "{{ step.invocation.prompt }}"
     tools:
       allow:
         - Read

--- a/ail-core/tests/spec/s05_step_specification.rs
+++ b/ail-core/tests/spec/s05_step_specification.rs
@@ -99,7 +99,7 @@ mod s5_2_file_path_resolution {
         let sp_path = prompts_dir.join("system.md");
         std::fs::write(&sp_path, "You are a test agent.").unwrap();
 
-        let yaml = "version: \"0.0.1\"\npipeline:\n  - id: invocation\n    system_prompt: ./prompts/system.md\n    prompt: \"{{ session.invocation_prompt }}\"\n";
+        let yaml = "version: \"0.0.1\"\npipeline:\n  - id: invocation\n    system_prompt: ./prompts/system.md\n    prompt: \"{{ step.invocation.prompt }}\"\n";
         let pipeline_path = tmp.path().join("test.ail.yaml");
         std::fs::write(&pipeline_path, yaml).unwrap();
 

--- a/ail-core/tests/spec/s09_sub_pipeline.rs
+++ b/ail-core/tests/spec/s09_sub_pipeline.rs
@@ -440,7 +440,7 @@ fn sub_pipeline_step_prompt_override_is_passed_to_child() {
     let child_path = tmp.path().join("child_override.ail.yaml");
     std::fs::write(
         &child_path,
-        "version: \"0.0.1\"\npipeline:\n  - id: echo\n    prompt: \"{{ session.invocation_prompt }}\"\n",
+        "version: \"0.0.1\"\npipeline:\n  - id: echo\n    prompt: \"{{ step.invocation.prompt }}\"\n",
     )
     .unwrap();
 
@@ -502,7 +502,7 @@ fn sub_pipeline_step_prompt_override_resolves_template_variables() {
     let child_path = tmp.path().join("child_tmpl.ail.yaml");
     std::fs::write(
         &child_path,
-        "version: \"0.0.1\"\npipeline:\n  - id: echo\n    prompt: \"{{ session.invocation_prompt }}\"\n",
+        "version: \"0.0.1\"\npipeline:\n  - id: echo\n    prompt: \"{{ step.invocation.prompt }}\"\n",
     )
     .unwrap();
 
@@ -510,7 +510,7 @@ fn sub_pipeline_step_prompt_override_resolves_template_variables() {
         id: StepId("parent".to_string()),
         body: StepBody::SubPipeline {
             path: child_path.to_str().unwrap().to_string(),
-            prompt: Some("{{ session.invocation_prompt }}".to_string()),
+            prompt: Some("{{ step.invocation.prompt }}".to_string()),
         },
         message: None,
         tools: None,
@@ -557,7 +557,7 @@ fn on_result_pipeline_prompt_override_is_passed_to_child() {
     let child_path = tmp.path().join("child_on_result.ail.yaml");
     std::fs::write(
         &child_path,
-        "version: \"0.0.1\"\npipeline:\n  - id: echo\n    prompt: \"{{ session.invocation_prompt }}\"\n",
+        "version: \"0.0.1\"\npipeline:\n  - id: echo\n    prompt: \"{{ step.invocation.prompt }}\"\n",
     )
     .unwrap();
 

--- a/ail-core/tests/spec/s11_template_variables.rs
+++ b/ail-core/tests/spec/s11_template_variables.rs
@@ -290,7 +290,7 @@ fn step_result_missing_step_returns_error() {
     assert_eq!(err.error_type(), error_types::TEMPLATE_UNRESOLVED);
 }
 
-// ── 11. session.invocation_prompt alias ───────────────────────────────────
+// ── 11. Deprecated invocation prompt aliases ──────────────────────────────
 
 #[test]
 fn session_invocation_prompt_alias_resolves() {
@@ -304,6 +304,21 @@ fn session_invocation_prompt_alias_matches_canonical() {
     let session = make_session();
     let canonical = resolve("{{ step.invocation.prompt }}", &session).unwrap();
     let alias = resolve("{{ session.invocation_prompt }}", &session).unwrap();
+    assert_eq!(canonical, alias);
+}
+
+#[test]
+fn session_invocation_dotted_alias_resolves() {
+    let session = make_session();
+    let result = resolve("{{ session.invocation.prompt }}", &session).unwrap();
+    assert_eq!(result, "original prompt");
+}
+
+#[test]
+fn session_invocation_dotted_alias_matches_canonical() {
+    let session = make_session();
+    let canonical = resolve("{{ step.invocation.prompt }}", &session).unwrap();
+    let alias = resolve("{{ session.invocation.prompt }}", &session).unwrap();
     assert_eq!(canonical, alias);
 }
 

--- a/ail-core/tests/spec/s11_template_variables.rs
+++ b/ail-core/tests/spec/s11_template_variables.rs
@@ -290,39 +290,7 @@ fn step_result_missing_step_returns_error() {
     assert_eq!(err.error_type(), error_types::TEMPLATE_UNRESOLVED);
 }
 
-// ── 11. Deprecated invocation prompt aliases ──────────────────────────────
-
-#[test]
-fn session_invocation_prompt_alias_resolves() {
-    let session = make_session();
-    let result = resolve("{{ session.invocation_prompt }}", &session).unwrap();
-    assert_eq!(result, "original prompt");
-}
-
-#[test]
-fn session_invocation_prompt_alias_matches_canonical() {
-    let session = make_session();
-    let canonical = resolve("{{ step.invocation.prompt }}", &session).unwrap();
-    let alias = resolve("{{ session.invocation_prompt }}", &session).unwrap();
-    assert_eq!(canonical, alias);
-}
-
-#[test]
-fn session_invocation_dotted_alias_resolves() {
-    let session = make_session();
-    let result = resolve("{{ session.invocation.prompt }}", &session).unwrap();
-    assert_eq!(result, "original prompt");
-}
-
-#[test]
-fn session_invocation_dotted_alias_matches_canonical() {
-    let session = make_session();
-    let canonical = resolve("{{ step.invocation.prompt }}", &session).unwrap();
-    let alias = resolve("{{ session.invocation.prompt }}", &session).unwrap();
-    assert_eq!(canonical, alias);
-}
-
-// ── 12. Unknown variables return errors ───────────────────────────────────
+// ── 11. Unknown variables return errors ───────────────────────────────────
 
 #[test]
 fn unknown_top_level_namespace_returns_error() {
@@ -342,6 +310,20 @@ fn unknown_variable_error_contains_variable_name() {
 fn bare_word_returns_error() {
     let session = make_session();
     let err = resolve("{{ notavariable }}", &session).unwrap_err();
+    assert_eq!(err.error_type(), error_types::TEMPLATE_UNRESOLVED);
+}
+
+#[test]
+fn legacy_session_invocation_prompt_alias_rejected() {
+    let session = make_session();
+    let err = resolve("{{ session.invocation_prompt }}", &session).unwrap_err();
+    assert_eq!(err.error_type(), error_types::TEMPLATE_UNRESOLVED);
+}
+
+#[test]
+fn legacy_session_invocation_dotted_alias_rejected() {
+    let session = make_session();
+    let err = resolve("{{ session.invocation.prompt }}", &session).unwrap_err();
     assert_eq!(err.error_type(), error_types::TEMPLATE_UNRESOLVED);
 }
 

--- a/demo/.ail.invocation.2.yaml
+++ b/demo/.ail.invocation.2.yaml
@@ -10,4 +10,4 @@ defaults:
     auth_token: ollama
 pipeline:
   - id: invocation
-    prompt: "{{ session.invocation_prompt }}"
+    prompt: "{{ step.invocation.prompt }}"

--- a/demo/.ail.invocation.yaml
+++ b/demo/.ail.invocation.yaml
@@ -1,7 +1,7 @@
 version: "0.0.1"
 pipeline:
   - id: invocation
-    prompt: "{{ session.invocation_prompt }}"
+    prompt: "{{ step.invocation.prompt }}"
     tools:
       allow:
         - Write

--- a/demo/.include-review.yaml
+++ b/demo/.include-review.yaml
@@ -10,7 +10,7 @@ defaults:
     auth_token: ollama
 pipeline:
   - id: invocation
-    prompt: "{{ session.invocation_prompt }}"
+    prompt: "{{ step.invocation.prompt }}"
   - id: review
     prompt: |
       this is a demo - repeat the last sentence of the following:

--- a/demo/oh-my-ail/.ohmy.ail.yaml
+++ b/demo/oh-my-ail/.ohmy.ail.yaml
@@ -35,7 +35,7 @@ pipeline:
       Classify this request. Explain your reasoning.
 
       ## User Request
-      {{ session.invocation_prompt }}
+      {{ step.invocation.prompt }}
     output_schema:
       type: object
       properties:

--- a/spec/core/s04-execution-model.md
+++ b/spec/core/s04-execution-model.md
@@ -32,7 +32,7 @@ step_2
 version: "0.0.1"
 pipeline:
   - id: invocation
-    prompt: "{{ session.invocation_prompt }}"
+    prompt: "{{ step.invocation.prompt }}"
   - id: review
     prompt: "Review the above output."
 ```

--- a/spec/core/s11-template-variables.md
+++ b/spec/core/s11-template-variables.md
@@ -30,8 +30,6 @@ Prompt strings, file-based prompts, and `pipeline:` paths may reference runtime 
 | `{{ for_each.index }}` | Inside a `for_each:` step body (§28): the current 0-based item index. |
 | `{{ for_each.total }}` | Inside a `for_each:` step body (§28): the total number of items in the collection. |
 
-> **Note:** All variable references use the dot-path structure above. `{{ session.invocation_prompt }}` and `{{ session.invocation.prompt }}` are supported but **deprecated** aliases for `{{ step.invocation.prompt }}`; prefer the canonical form. No other aliases exist.
-
 **Skipped step variables:** If a template variable references a step that was skipped by its `condition`, `ail` raises a **parse-time error** if the reference is unconditional, or returns an empty string if the referencing step itself has a matching condition guard. Silently empty references are never permitted.
 
 **Future step variables:** Template variables may only reference steps that have already run. A reference to a step that has not yet executed at the point of resolution raises a fatal parse error.

--- a/spec/core/s11-template-variables.md
+++ b/spec/core/s11-template-variables.md
@@ -30,7 +30,7 @@ Prompt strings, file-based prompts, and `pipeline:` paths may reference runtime 
 | `{{ for_each.index }}` | Inside a `for_each:` step body (§28): the current 0-based item index. |
 | `{{ for_each.total }}` | Inside a `for_each:` step body (§28): the total number of items in the collection. |
 
-> **Note:** All variable references use the dot-path structure above. `{{ session.invocation_prompt }}` is a supported but **deprecated** alias for `{{ step.invocation.prompt }}`; prefer the canonical form. No other aliases exist.
+> **Note:** All variable references use the dot-path structure above. `{{ session.invocation_prompt }}` and `{{ session.invocation.prompt }}` are supported but **deprecated** aliases for `{{ step.invocation.prompt }}`; prefer the canonical form. No other aliases exist.
 
 **Skipped step variables:** If a template variable references a step that was skipped by its `condition`, `ail` raises a **parse-time error** if the reference is unconditional, or returns an empty string if the referencing step itself has a matching condition guard. Silently empty references are never permitted.
 


### PR DESCRIPTION
## Summary
This PR removes support for the deprecated `{{ session.invocation_prompt }}` template variable alias and its dotted variant `{{ session.invocation.prompt }}`. Users must now use the canonical `{{ step.invocation.prompt }}` form.

## Changes Made

- **Template Resolution**: Removed the `session.invocation_prompt` and `session.invocation.prompt` aliases from the variable resolution logic in `src/template.rs`, keeping only the canonical `step.invocation.prompt` form
- **Test Updates**: 
  - Converted tests that verified alias functionality into tests that verify the aliases are now rejected with `TEMPLATE_UNRESOLVED` errors
  - Reorganized test section 11 to focus on "Unknown variables return errors" rather than alias support
- **Documentation**: Removed deprecation notes about the alias from `CLAUDE.md` and `spec/core/s11-template-variables.md`
- **Fixture Updates**: Updated all test fixtures and demo files to use the canonical `{{ step.invocation.prompt }}` form instead of the deprecated alias

## Implementation Details

The change is straightforward: the template resolver now only recognizes `"step.invocation.prompt"` as a valid variable reference. Any attempt to use `session.invocation_prompt` or `session.invocation.prompt` will result in a `TEMPLATE_UNRESOLVED` error, consistent with other unknown variables.

All references across the codebase (tests, fixtures, demos, and specification documents) have been updated to use the canonical form.

https://claude.ai/code/session_01RF2y3f8UW4F6npGPG4xmGe